### PR TITLE
Break up kernels, use do-concurrent

### DIFF
--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -504,93 +504,63 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     if (CS%no_slip) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         rel_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
-      enddo; enddo
-      !$omp end target
+      enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+          do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
-          enddo; enddo
-          !$omp end target
+          enddo
         endif
       endif
     else
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         rel_vort(I,J) = G%mask2dBu(I,J) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
-      enddo; enddo
-      !$omp end target
+      enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+          do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
-          enddo; enddo
-          !$omp end target
+          enddo
         endif
       endif
     endif
 
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+    do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
       abs_vort(I,J) = G%CoriolisBu(I,J) + rel_vort(I,J)
-    enddo ; enddo
-    !$omp end target
+    enddo
 
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+    do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
       hArea_q = (hArea_u(I,j) + hArea_u(I,j+1)) + (hArea_v(i,J) + hArea_v(i+1,J))
       Ih_q(I,J) = Area_q(I,J) / (hArea_q + vol_neglect)
       q(I,J) = abs_vort(I,J) * Ih_q(I,J)
-    enddo; enddo
-    !$omp end target
+    enddo
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
           qS(I,J) = stk_vort(I,J) * Ih_q(I,J)
-        enddo; enddo
-        !$omp end target
+        enddo
       endif
     endif
 
     if (CS%id_rv > 0) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         RV(I,J,k) = rel_vort(I,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (CS%id_PV > 0) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         PV(I,J,k) = q(I,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (associated(AD%rv_x_v) .or. associated(AD%rv_x_u)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         q2(I,J) = rel_vort(I,J) * Ih_q(I,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     !   a, b, c, and d are combinations of neighboring potential
@@ -598,33 +568,24 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! scheme.  All are defined at u grid points.
 
     if (CS%Coriolis_Scheme == ARAKAWA_HSU90) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, j=Jsq:Jeq+1)
         a(I,j) = (q(I,J) + (q(I+1,J) + q(I,J-1))) * C1_12
         d(I,j) = ((q(I,J) + q(I+1,J-1)) + q(I,J-1)) * C1_12
-      enddo ; enddo
-      !$omp end target
+      enddo
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=Jsq:Jeq+1)
         b(I,j) = (q(I,J) + (q(I-1,J) + q(I,J-1))) * C1_12
         c(I,j) = ((q(I,J) + q(I-1,J-1)) + q(I,J-1)) * C1_12
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == ARAKAWA_LAMB81) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
+      do concurrent (I=Isq:Ieq+1, j=Jsq:Jeq+1)
         a(I-1,j) = (2.0*(q(I,J) + q(I-1,J-1)) + (q(I-1,J) + q(I,J-1))) * C1_24
         d(I-1,j) = ((q(I,j) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
         b(I,j) =   ((q(I,J) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
         c(I,j) =   (2.0*(q(I,J) + q(I-1,J-1)) + (q(I-1,J) + q(I,J-1))) * C1_24
         ep_u(i,j) = ((q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
         ep_v(i,j) = (-(q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == AL_BLEND) then
       Fe_m2 = CS%F_eff_max_blend - 2.0
       rat_lin = 1.5 * Fe_m2 / max(CS%wt_lin_blend, 1.0e-16)
@@ -632,9 +593,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! This allows the code to always give Sadourny Energy
       if (CS%F_eff_max_blend <= 2.0) then ; Fe_m2 = -1. ; rat_lin = -1.0 ; endif
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
+      do concurrent (I=Isq:Ieq+1, j=Jsq:Jeq+1)
         min_Ihq = MIN(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
         max_Ihq = MAX(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
         rat_m1 = 1.0e15
@@ -671,8 +630,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                       2.0 * (q(I,J) + q(I-1,J-1)) ) * C1_24
         ep_u(i,j) = AL_wt  * ((q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
         ep_v(i,j) = AL_wt * (-(q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! .and. SADOURNEY75_ENERGY ??
@@ -680,9 +638,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     !  c1 = 1.0-1.5*RANGE ; c2 = 1.0-RANGE ; c3 = 2.0 ; slope = 0.5
       c1 = 1.0-1.5*0.5 ; c2 = 1.0-0.5 ; c3 = 2.0 ; slope = 0.5
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=is-1,ie
+      do concurrent (I=is-1:ie, j=Jsq:Jeq+1)
         uhc = uh_center(I,j)
         uhm = uh(I,j,k)
         ! This sometimes matters with some types of open boundary conditions.
@@ -702,12 +658,9 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         else
           uh_max(I,j) = uhm ; uh_min(I,j) = uhc
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,je ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, J=js-1:je)
         vhc = vh_center(i,J)
         vhm = vh(i,J,k)
         ! This sometimes matters with some types of open boundary conditions.
@@ -727,24 +680,20 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         else
           vh_max(i,J) = vhm ; vh_min(i,J) = vhc
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Calculate KE and the gradient of KE
     call gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
     ! TODO: Can KE be removed from this function?
 
-    !!!$omp target
     ! Calculate the tendencies of zonal velocity due to the Coriolis
     ! force and momentum advection.  On a Cartesian grid, this is
     !     CAu =  q * vh - d(KE)/dx.
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do j=js,je ; do I=Isq,Ieq
+        do concurrent (I=Isq:Ieq, j=js:je)
           if (q(I,J)*u(I,j,k) == 0.0) then
             temp1 = q(I,J) * ( (vh_max(i,j)+vh_max(i+1,j)) &
                              + (vh_min(i,j)+vh_min(i+1,j)) )*0.5
@@ -762,45 +711,33 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             temp2 = q(I,J-1) * (vh_min(i,j-1)+vh_min(i+1,j-1))
           endif
           CAu(I,j,k) = 0.25 * G%IdxCu(I,j) * (temp1 + temp2)
-        enddo ; enddo
-        !$omp end target
+        enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do j=js,je ; do I=Isq,Ieq
+        do concurrent (I=Isq:Ieq, j=js:je)
           CAu(I,j,k) = 0.25 * &
             ((q(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
              (q(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         CAu(I,j,k) = 0.125 * (G%IdxCu(I,j) * (q(I,J) + q(I,J-1))) * &
                      ((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         CAu(I,j,k) = (((a(I,j) * vh(i+1,J,k)) +  (c(I,j) * vh(i,J-1,k)))  + &
                       ((b(I,j) * vh(i,J,k)) +  (d(I,j) * vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_v that should be returned by the
       !       continuity solver. AJA
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         Heff1 = abs(vh(i,J,k) * G%IdxCv(i,J)) / (eps_vel+abs(v(i,J,k)))
         Heff1 = max(Heff1, min(h(i,j,k),h(i,j+1,k)))
         Heff1 = min(Heff1, max(h(i,j,k),h(i,j+1,k)))
@@ -823,40 +760,31 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                        - ((abs_vort(I,J)-abs_vort(I,J-1))*abs(VHeff)) )
           CAu(I,j,k) = (QVHeff / ( h_tiny + ((Heff1+Heff4) + (Heff2+Heff3)) ) ) * G%IdxCu(I,j)
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         CAu(I,j,k) = CAu(I,j,k) + &
               ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAu
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do j=js,je ; do I=Isq,Ieq
+        do concurrent (I=Isq:Ieq, j=js:je)
           CAuS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
                  (qS(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
     endif
 
     if (CS%bound_Coriolis) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         fv1 = abs_vort(I,J) * v(i+1,J,k)
         fv2 = abs_vort(I,J) * v(i,J,k)
         fv3 = abs_vort(I,J-1) * v(i+1,J-1,k)
@@ -867,25 +795,18 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         CAu(I,j,k) = min(CAu(I,j,k), max_fv)
         CAu(I,j,k) = max(CAu(I,j,k), min_fv)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Term - d(KE)/dx.
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do j=js,je ; do I=Isq,Ieq
+    do concurrent (I=Isq:Ieq, j=js:je)
       CAu(I,j,k) = CAu(I,j,k) - KEx(I,j)
-    enddo ; enddo
-    !$omp end target
+    enddo
 
     if (associated(AD%gradKEu)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         AD%gradKEu(I,j,k) = -KEx(I,j)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Calculate the tendencies of meridional velocity due to the Coriolis
@@ -894,9 +815,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq,Jeq ; do i=is,ie
+        do concurrent (i=is:ie, J=Jsq:Jeq)
           if (q(I-1,J)*v(i,J,k) == 0.0) then
             temp1 = q(I-1,J) * ( (uh_max(i-1,j)+uh_max(i-1,j+1)) &
                                + (uh_min(i-1,j)+uh_min(i-1,j+1)) )*0.5
@@ -914,47 +833,35 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             temp2 = q(I,J) * (uh_min(i,j)+uh_min(i,j+1))
           endif
           CAv(i,J,k) = -0.25 * G%IdyCv(i,J) * (temp1 + temp2)
-        enddo ; enddo
-        !$omp end target
+        enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq,Jeq ; do i=is,ie
+        do concurrent (i=is:ie, J=Jsq:Jeq)
           CAv(i,J,k) = - 0.25* &
               ((q(I-1,J)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q(I,J)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J) + q(I,J))) * &
                      ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         CAv(i,J,k) = - (((a(I-1,j)   * uh(I-1,j,k)) + &
                          (c(I,j+1)   * uh(I,j+1,k)))  &
                       + ((b(I,j)     * uh(I,j,k)) +   &
                          (d(I-1,j+1) * uh(I-1,j+1,k)))) * G%IdyCv(i,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_u that should be returned by the
       !       continuity solver. AJA
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         Heff1 = abs(uh(I,j,k) * G%IdyCu(I,j)) / (eps_vel+abs(u(I,j,k)))
         Heff1 = max(Heff1, min(h(i,j,k),h(i+1,j,k)))
         Heff1 = min(Heff1, max(h(i,j,k),h(i+1,j,k)))
@@ -980,39 +887,30 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAv(i,J,k) = - QUHeff / &
                        (h_tiny + ((Heff1+Heff4) +(Heff2+Heff3)) ) * G%IdyCv(i,J)
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
     ! Add in the additonal terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         CAv(i,J,k) = CAv(i,J,k) + &
               ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAv
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq,Jeq ; do i=is,ie
+        do concurrent (i=is:ie, J=Jsq:Jeq)
           CAvS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (uh(I,j+1,k) + uh(I,j,k))) + &
                  (qS(I,J-1) * (uh(I-1,j,k) + uh(I-1,j+1,k)))) * G%IdyCv(i,J)
-        enddo; enddo
-        !$omp end target
+        enddo
       endif
     endif
 
     if (CS%bound_Coriolis) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         fu1 = -abs_vort(I,J) * u(I,j+1,k)
         fu2 = -abs_vort(I,J) * u(I,j,k)
         fu3 = -abs_vort(I-1,J) * u(I-1,j+1,k)
@@ -1023,75 +921,56 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         CAv(I,j,k) = min(CAv(I,j,k), max_fu)
         CAv(I,j,k) = max(CAv(I,j,k), min_fu)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Term - d(KE)/dy.
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do J=Jsq,Jeq ; do i=is,ie
+    do concurrent (i=is:ie, J=Jsq:Jeq)
       CAv(i,J,k) = CAv(i,J,k) - KEy(i,J)
-    enddo ; enddo
-    !$omp end target
+    enddo
     if (associated(AD%gradKEv)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         AD%gradKEv(i,J,k) = -KEy(i,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (associated(AD%rv_x_u) .or. associated(AD%rv_x_v)) then
       ! Calculate the Coriolis-like acceleration due to relative vorticity.
       if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
         if (associated(AD%rv_x_u)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq,Jeq ; do i=is,ie
+          do concurrent (i=is:ie, J=Jsq:Jeq)
             AD%rv_x_u(i,J,k) = - 0.25* &
               ((q2(I-1,j)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q2(I,j)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
 
         if (associated(AD%rv_x_v)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do j=js,je ; do I=Isq,Ieq
+          do concurrent (I=Isq:Ieq, j=js:je)
             AD%rv_x_v(I,j,k) = 0.25 * &
               ((q2(I,j) * (vh(i+1,J,k) + vh(i,J,k))) + &
                (q2(I,j-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
       else
         if (associated(AD%rv_x_u)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq,Jeq ; do i=is,ie
+          do concurrent (i=is:ie, J=Jsq:Jeq)
             AD%rv_x_u(i,J,k) = -G%IdyCv(i,J) * C1_12 * &
               (((((q2(I,J) + q2(I-1,J-1)) + q2(I-1,J)) * uh(I-1,j,k)) + &
                 (((q2(I-1,J) + q2(I,J+1)) + q2(I,J)) * uh(I,j+1,k))) + &
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * uh(I,j,k))+ &
                 (((q2(I,J) + q2(I-1,J+1)) + q2(I-1,J)) * uh(I-1,j+1,k))))
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
 
         if (associated(AD%rv_x_v)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do j=js,je ; do I=Isq,Ieq
+          do concurrent (I=Isq:Ieq, j=js:je)
             AD%rv_x_v(I,j,k) = G%IdxCu(I,j) * C1_12 * &
               (((((q2(I+1,J) + q2(I,J-1)) + q2(I,J)) * vh(i+1,J,k)) + &
                 (((q2(I-1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i,J-1,k))) + &
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * vh(i,J,k)) + &
                 (((q2(I+1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i+1,J-1,k))))
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
       endif
     endif

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -719,13 +719,14 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     call gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
     ! TODO: Can KE be removed from this function?
 
-    !$omp target
+    !!!$omp target
     ! Calculate the tendencies of zonal velocity due to the Coriolis
     ! force and momentum advection.  On a Cartesian grid, this is
     !     CAu =  q * vh - d(KE)/dx.
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
+        !$omp target
         !$omp parallel loop collapse(2)
         do j=js,je ; do I=Isq,Ieq
           if (q(I,J)*u(I,j,k) == 0.0) then
@@ -746,34 +747,42 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           endif
           CAu(I,j,k) = 0.25 * G%IdxCu(I,j) * (temp1 + temp2)
         enddo ; enddo
+        !$omp end target
       else
         ! Energy conserving scheme, Sadourny 1975
+        !$omp target
         !$omp parallel loop collapse(2)
         do j=js,je ; do I=Isq,Ieq
           CAu(I,j,k) = 0.25 * &
             ((q(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
              (q(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
         enddo ; enddo
+        !$omp end target
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         CAu(I,j,k) = 0.125 * (G%IdxCu(I,j) * (q(I,J) + q(I,J-1))) * &
                      ((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
       enddo ; enddo
+      !$omp end target
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         CAu(I,j,k) = (((a(I,j) * vh(i+1,J,k)) +  (c(I,j) * vh(i,J-1,k)))  + &
                       ((b(I,j) * vh(i,J,k)) +  (d(I,j) * vh(i+1,J-1,k)))) * G%IdxCu(I,j)
       enddo ; enddo
+      !$omp end target
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_v that should be returned by the
       !       continuity solver. AJA
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         Heff1 = abs(vh(i,J,k) * G%IdxCv(i,J)) / (eps_vel+abs(v(i,J,k)))
@@ -799,31 +808,37 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAu(I,j,k) = (QVHeff / ( h_tiny + ((Heff1+Heff4) + (Heff2+Heff3)) ) ) * G%IdxCu(I,j)
         endif
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         CAu(I,j,k) = CAu(I,j,k) + &
               ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
       enddo ; enddo
+      !$omp end target
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAu
+        !$omp target
         !$omp parallel loop collapse(2)
         do j=js,je ; do I=Isq,Ieq
           CAuS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
                  (qS(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
         enddo ; enddo
+        !$omp end target
       endif
     endif
 
     if (CS%bound_Coriolis) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         fv1 = abs_vort(I,J) * v(i+1,J,k)
@@ -837,19 +852,24 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         CAu(I,j,k) = min(CAu(I,j,k), max_fv)
         CAu(I,j,k) = max(CAu(I,j,k), min_fv)
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Term - d(KE)/dx.
+    !$omp target
     !$omp parallel loop collapse(2)
     do j=js,je ; do I=Isq,Ieq
       CAu(I,j,k) = CAu(I,j,k) - KEx(I,j)
     enddo ; enddo
+    !$omp end target
 
     if (associated(AD%gradKEu)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         AD%gradKEu(I,j,k) = -KEx(I,j)
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Calculate the tendencies of meridional velocity due to the Coriolis
@@ -858,6 +878,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
+        !$omp target
         !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           if (q(I-1,J)*v(i,J,k) == 0.0) then
@@ -878,25 +899,31 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           endif
           CAv(i,J,k) = -0.25 * G%IdyCv(i,J) * (temp1 + temp2)
         enddo ; enddo
+        !$omp end target
       else
         ! Energy conserving scheme, Sadourny 1975
+        !$omp target
         !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           CAv(i,J,k) = - 0.25* &
               ((q(I-1,J)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q(I,J)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
         enddo ; enddo
+        !$omp end target
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J) + q(I,J))) * &
                      ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
       enddo ; enddo
+      !$omp end target
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = - (((a(I-1,j)   * uh(I-1,j,k)) + &
@@ -904,10 +931,12 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                       + ((b(I,j)     * uh(I,j,k)) +   &
                          (d(I-1,j+1) * uh(I-1,j+1,k)))) * G%IdyCv(i,J)
       enddo ; enddo
+      !$omp end target
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_u that should be returned by the
       !       continuity solver. AJA
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         Heff1 = abs(uh(I,j,k) * G%IdyCu(I,j)) / (eps_vel+abs(u(I,j,k)))
@@ -936,30 +965,36 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                        (h_tiny + ((Heff1+Heff4) +(Heff2+Heff3)) ) * G%IdyCv(i,J)
         endif
       enddo ; enddo
+      !$omp end target
     endif
     ! Add in the additonal terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = CAv(i,J,k) + &
               ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
       enddo ; enddo
+      !$omp end target
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAv
+        !$omp target
         !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           CAvS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (uh(I,j+1,k) + uh(I,j,k))) + &
                  (qS(I,J-1) * (uh(I-1,j,k) + uh(I-1,j+1,k)))) * G%IdyCv(i,J)
         enddo; enddo
+        !$omp end target
       endif
     endif
 
     if (CS%bound_Coriolis) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         fu1 = -abs_vort(I,J) * u(I,j+1,k)
@@ -973,42 +1008,52 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         CAv(I,j,k) = min(CAv(I,j,k), max_fu)
         CAv(I,j,k) = max(CAv(I,j,k), min_fu)
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Term - d(KE)/dy.
+    !$omp target
     !$omp parallel loop collapse(2)
     do J=Jsq,Jeq ; do i=is,ie
       CAv(i,J,k) = CAv(i,J,k) - KEy(i,J)
     enddo ; enddo
+    !$omp end target
     if (associated(AD%gradKEv)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         AD%gradKEv(i,J,k) = -KEy(i,J)
       enddo ; enddo
+      !$omp end target
     endif
 
     if (associated(AD%rv_x_u) .or. associated(AD%rv_x_v)) then
       ! Calculate the Coriolis-like acceleration due to relative vorticity.
       if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
         if (associated(AD%rv_x_u)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do J=Jsq,Jeq ; do i=is,ie
             AD%rv_x_u(i,J,k) = - 0.25* &
               ((q2(I-1,j)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q2(I,j)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
           enddo ; enddo
+          !$omp end target
         endif
 
         if (associated(AD%rv_x_v)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do j=js,je ; do I=Isq,Ieq
             AD%rv_x_v(I,j,k) = 0.25 * &
               ((q2(I,j) * (vh(i+1,J,k) + vh(i,J,k))) + &
                (q2(I,j-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
           enddo ; enddo
+          !$omp end target
         endif
       else
         if (associated(AD%rv_x_u)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do J=Jsq,Jeq ; do i=is,ie
             AD%rv_x_u(i,J,k) = -G%IdyCv(i,J) * C1_12 * &
@@ -1017,9 +1062,11 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * uh(I,j,k))+ &
                 (((q2(I,J) + q2(I-1,J+1)) + q2(I-1,J)) * uh(I-1,j+1,k))))
           enddo ; enddo
+          !$omp end target
         endif
 
         if (associated(AD%rv_x_v)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do j=js,je ; do I=Isq,Ieq
             AD%rv_x_v(I,j,k) = G%IdxCu(I,j) * C1_12 * &
@@ -1028,11 +1075,10 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * vh(i,J,k)) + &
                 (((q2(I+1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i+1,J-1,k))))
           enddo ; enddo
+          !$omp end target
         endif
       endif
     endif
-    !$omp end target
-
   enddo ! k-loop.
 
   !$omp target exit data map(delete: Area_h, Area_q)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -874,7 +874,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
   ! TODO: Am I doing this twice for no reason?
-  !!$omp target update to(u_av, v_av, h_av, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
+  !$omp target update to(u_av, v_av, h_av, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
   call horizontal_viscosity(u_av, v_av, h_av, uh, vh, CS%diffu, CS%diffv, &
                             MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt, &
                             OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -961,20 +961,16 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
   !   Possibly because Nvidia cannot associate `this` with `EOS%type`.
 
-  !$omp target
   if (present(rho_ref)) then
-    !$omp parallel loop
-    do j = js, je ; do i = is, ie
+    do concurrent (i=is:ie, j=js:je)
       rho(i,j) = density_anomaly_elem_buggy_Wright(this, T(i,j), S(i,j), &
           pressure(i,j), rho_ref)
-    enddo ; enddo
+    enddo
   else
-    !$omp parallel loop
-    do j = js, je ; do i = is, ie
+    do concurrent (i=is:ie, j=js:je)
       rho(i,j) = density_elem_buggy_Wright(this, T(i,j), S(i,j), pressure(i,j))
-    enddo ; enddo
+    enddo
   endif
-  !$omp end target
 end subroutine calculate_density_array_2d_buggy_Wright
 
 !> Calculate the in-situ specific volume for 1D array inputs and outputs.
@@ -1030,13 +1026,10 @@ subroutine calculate_density_derivs_2d_buggy_Wright(this, T, S, pressure, &
 
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
 
-  !$omp target
-  !$omp parallel loop collapse(2)
-  do j = js, je ; do i = is, ie
+  do concurrent (i=is:ie, j=js:je)
     call calculate_density_derivs_elem_buggy_Wright(this, T(i,j), S(i,j), &
         pressure(i,j), drho_dT(i,j), drho_dS(i,j))
-  enddo ; enddo
-  !$omp end target
+  enddo
 end subroutine calculate_density_derivs_2d_buggy_Wright
 
 !> Set coefficients that can correct bugs un the buggy Wright equation of state.

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -698,48 +698,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
 
   do k=1,nz
-
     ! The following are the forms of the horizontal tension and horizontal
     ! shearing strain advocated by Smagorinsky (1993) and discussed in
     ! Griffies and Hallberg (2000).
 
-    ! NOTE: There is a ~1% speedup when the tension and shearing loops below
-    !   are fused (presumably due to shared access of Id[xy]C[uv]).  However,
-    !   this breaks the center/vertex index case convention, and also evaluates
-    !   the dudx and dvdy terms beyond their valid bounds.
-    ! TODO: Explore methods for retaining both the syntax and speedup.
-
     ! XXX: **I don't understand why I need this**
     !$omp target update to(u(:,:,k), v(:,:,k), h(:,:,k))
 
-    !$omp target
-
     ! Calculate horizontal tension
-    !$omp parallel loop collapse(2)
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
       dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                   (G%IdyCu(I-1,j) * u(I-1,j,k)))
-    enddo ; enddo
+    enddo
 
-    !$omp parallel loop collapse(2)
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
       dvdy(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
                                   (G%IdxCv(i,J-1) * v(i,J-1,k)))
-    enddo ; enddo
+    enddo
 
-    !$omp parallel loop collapse(2)
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
       sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
-    enddo ; enddo
+    enddo
 
     ! Components for the shearing strain
-    !$omp parallel loop collapse(2)
-    do J=js_vort,je_vort ; do I=is_vort,ie_vort
+    do concurrent (I=is_vort:ie_vort, J=js_vort:je_vort)
       dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
-    enddo ; enddo
-
-    !$omp end target
+    enddo
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity


### PR DESCRIPTION
Multiple commits which split up some of the very large kernels (with lots of if-blocks and other logic) into many smaller kernels associated with single nested-loop blocks.  Speedup was significant (~20%).  Data transfer was also reduced (maybe half?).

I have also replaced many of these loops with do-concurrent blocks. There was no change in answers or runtime, but the amount of data transfer was reduced.

The total data reduced is very high, perhaps a third of the previous amount.

Switching to do concurrent only appears to work effectively if we use `-gpu=nomanaged`.  I am still manually handling all of `enter data` and `exit data`.  I don't think we are at the point where we can rely on managed data.

Also fixes an error in `set_pbce_Bouss`.  Directives around a k-j-i loop had accidentally collapsed and parallelized the outer k-j loops rather than the inner j-i loops.  The resulting speedup was significant (~25%).