### PR TITLE
Btstep gpu

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2852,6 +2852,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   !$omp target enter data map(to: G)
   !$omp target enter data map(to: G%dxCu, G%dyCv)
+  !$omp target enter data map(to: G%dx_Cv, G%dy_Cu)
   !$omp target enter data map(to: G%IdxCu, G%IdyCv)
   !$omp target enter data map(to: G%mask2dBu, G%mask2dT)
   !$omp target enter data map(to: G%IareaBu)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2851,9 +2851,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)
 
   !$omp target enter data map(to: G)
-  !$omp target enter data map(to: G%dxCu, G%dyCv)
+  !$omp target enter data map(to: G%dxT, G%dxCu, G%dxCv, G%dxBu)
+  !$omp target enter data map(to: G%dyT, G%dyCu, G%dyCv, G%dyBu)
   !$omp target enter data map(to: G%dx_Cv, G%dy_Cu)
-  !$omp target enter data map(to: G%IdxCu, G%IdxCv, G%IdyCu, G%IdyCv)
+  !$omp target enter data map(to: G%IdxT, G%IdxCu, G%IdxCv, G%IdxBu)
+  !$omp target enter data map(to: G%IdyT, G%IdyCu, G%IdyCv, G%IdyBu)
   !$omp target enter data map(to: G%mask2dBu, G%mask2dT)
   !$omp target enter data map(to: G%areaT, G%areaCu, G%areaCv)
   !$omp target enter data map(to: G%IareaT, G%IareaCu, G%IareaCv, G%IareaBu)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2850,8 +2850,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ! Copy the grid metrics and bathymetry to the ocean_grid_type
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)
 
-  !$acc enter data copyin(G)
-  !$acc enter data copyin(G%IdxCu, G%IdyCv)
   !$omp target enter data map(to: G)
   !$omp target enter data map(to: G%IdxCu, G%IdyCv)
 
@@ -3416,9 +3414,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ! XXX: Where to put this??
   ! XXX: G transfer should possibly also be here.
 
-  !$acc enter data copyin(GV)
-  !$acc enter data copyin(GV%Rlay)
-  !$acc enter data copyin(GV%g_prime)
   !$omp target enter data map(to: GV, GV%Rlay, GV%g_prime)
 
   diag => CS%diag

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2851,6 +2851,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)
 
   !$omp target enter data map(to: G)
+  !$omp target enter data map(to: G%dxCu, G%dyCv)
   !$omp target enter data map(to: G%IdxCu, G%IdyCv)
   !$omp target enter data map(to: G%mask2dT)
   !$omp target enter data map(to: G%areaT)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2858,9 +2858,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call verticalGridInit( param_file, CS%GV, US )
   GV => CS%GV
 
-  !$acc enter data copyin(GV)
-  !$acc enter data copyin(GV%Rlay)
-
   ! Now that the vertical grid has been initialized, rescale parameters that depend on factors
   ! that are set with the vertical grid to their desired units.  This added rescaling step would
   ! be unnecessary if the vertical grid were initialized earlier in this routine.
@@ -3411,6 +3408,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     call calc_derived_thermo(CS%tv, CS%h, G, GV, US, halo=dynamics_stencil, debug=CS%debug)
   endif
 
+  ! XXX: Where to put this??
+  !$acc enter data copyin(GV)
+  !$acc enter data copyin(GV%Rlay)
 
   diag => CS%diag
   ! Initialize the diag mediator.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2850,10 +2850,16 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ! Copy the grid metrics and bathymetry to the ocean_grid_type
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)
 
+  !$acc enter data copyin(G)
+  !$acc enter data copyin(G%IdxCu, G%IdyCv)
+
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")
 
   call verticalGridInit( param_file, CS%GV, US )
   GV => CS%GV
+
+  !$acc enter data copyin(GV)
+  !$acc enter data copyin(GV%Rlay)
 
   ! Now that the vertical grid has been initialized, rescale parameters that depend on factors
   ! that are set with the vertical grid to their desired units.  This added rescaling step would

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2852,6 +2852,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   !$omp target enter data map(to: G)
   !$omp target enter data map(to: G%IdxCu, G%IdyCv)
+  !$omp target enter data map(to: G%mask2dT)
+  !$omp target enter data map(to: G%areaT)
   !$omp target enter data map(to: G%bathyT)
 
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2336,10 +2336,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                                                                 ! (To be used for writing out ocean geometry)
   character(len=240) :: geom_file ! Name of the ocean geometry file
 
-  ! XXX: This may need to happen even soon, at the driver level
-  ! NOTE: This must precede copy of G to GPU!
-  !$omp target enter data map(to: CS)
-
   CS%Time => Time
 
   id_clock_init = cpu_clock_id('Ocean Initialization', grain=CLOCK_SUBCOMPONENT)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2852,11 +2852,15 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   !$acc enter data copyin(G)
   !$acc enter data copyin(G%IdxCu, G%IdyCv)
+  !$omp target enter data map(to: G)
+  !$omp target enter data map(to: G%IdxCu, G%IdyCv)
 
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")
 
   call verticalGridInit( param_file, CS%GV, US )
   GV => CS%GV
+
+  !$omp target enter data map(to: GV, GV%Rlay, GV%g_prime)
 
   ! Now that the vertical grid has been initialized, rescale parameters that depend on factors
   ! that are set with the vertical grid to their desired units.  This added rescaling step would

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -661,6 +661,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       call set_derived_forcing_fields(forces, fluxes, G, US, GV%Rho0)
     endif
   endif
+  !$omp target enter data map(to: forces, forces%taux, forces%tauy)
 
   ! This will be replaced later with the pressures from forces or fluxes if they are available.
   if (associated(CS%tv%p_surf)) CS%tv%p_surf(:,:) = 0.0

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2860,7 +2860,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call verticalGridInit( param_file, CS%GV, US )
   GV => CS%GV
 
-  !$omp target enter data map(to: GV, GV%Rlay, GV%g_prime)
+  ! This does not work.  GV%RLay changes sometime later.
+  !!!$omp target enter data map(to: GV, GV%Rlay, GV%g_prime)
 
   ! Now that the vertical grid has been initialized, rescale parameters that depend on factors
   ! that are set with the vertical grid to their desired units.  This added rescaling step would
@@ -3413,9 +3414,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
 
   ! XXX: Where to put this??
+  ! XXX: G transfer should possibly also be here.
+
   !$acc enter data copyin(GV)
   !$acc enter data copyin(GV%Rlay)
   !$acc enter data copyin(GV%g_prime)
+  !$omp target enter data map(to: GV, GV%Rlay, GV%g_prime)
 
   diag => CS%diag
   ! Initialize the diag mediator.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2856,7 +2856,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(to: G%IdxCu, G%IdxCv, G%IdyCu, G%IdyCv)
   !$omp target enter data map(to: G%mask2dBu, G%mask2dT)
   !$omp target enter data map(to: G%areaT, G%areaCu, G%areaCv)
-  !$omp target enter data map(to: G%IareaT, G%IareaBu)
+  !$omp target enter data map(to: G%IareaT, G%IareaCu, G%IareaCv, G%IareaBu)
   !$omp target enter data map(to: G%bathyT)
   !$omp target enter data map(to: G%CoriolisBu)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2852,6 +2852,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   !$omp target enter data map(to: G)
   !$omp target enter data map(to: G%IdxCu, G%IdyCv)
+  !$omp target enter data map(to: G%bathyT)
 
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2853,7 +2853,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(to: G)
   !$omp target enter data map(to: G%dxCu, G%dyCv)
   !$omp target enter data map(to: G%dx_Cv, G%dy_Cu)
-  !$omp target enter data map(to: G%IdxCu, G%IdyCv)
+  !$omp target enter data map(to: G%IdxCu, G%IdxCv, G%IdyCu, G%IdyCv)
   !$omp target enter data map(to: G%mask2dBu, G%mask2dT)
   !$omp target enter data map(to: G%areaT, G%areaCu, G%areaCv)
   !$omp target enter data map(to: G%IareaT, G%IareaBu)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2853,9 +2853,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(to: G)
   !$omp target enter data map(to: G%dxCu, G%dyCv)
   !$omp target enter data map(to: G%IdxCu, G%IdyCv)
-  !$omp target enter data map(to: G%mask2dT)
+  !$omp target enter data map(to: G%mask2dBu, G%mask2dT)
+  !$omp target enter data map(to: G%IareaBu)
   !$omp target enter data map(to: G%areaT)
   !$omp target enter data map(to: G%bathyT)
+  !$omp target enter data map(to: G%CoriolisBu)
 
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2861,6 +2861,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(to: G%IareaT, G%IareaCu, G%IareaCv, G%IareaBu)
   !$omp target enter data map(to: G%bathyT)
   !$omp target enter data map(to: G%CoriolisBu)
+  !$omp target enter data map(to: G%mask2dCu, G%mask2dCv)
 
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2855,8 +2855,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(to: G%dx_Cv, G%dy_Cu)
   !$omp target enter data map(to: G%IdxCu, G%IdyCv)
   !$omp target enter data map(to: G%mask2dBu, G%mask2dT)
-  !$omp target enter data map(to: G%IareaBu)
-  !$omp target enter data map(to: G%areaT)
+  !$omp target enter data map(to: G%areaT, G%areaCu, G%areaCv)
+  !$omp target enter data map(to: G%IareaT, G%IareaBu)
   !$omp target enter data map(to: G%bathyT)
   !$omp target enter data map(to: G%CoriolisBu)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3030,6 +3030,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ALLOC_(CS%ssh_rint(isd:ied,jsd:jed)) ; CS%ssh_rint(:,:) = 0.0
   ALLOC_(CS%ave_ssh_ibc(isd:ied,jsd:jed)) ; CS%ave_ssh_ibc(:,:) = 0.0
   ALLOC_(CS%eta_av_bc(isd:ied,jsd:jed)) ; CS%eta_av_bc(:,:) = 0.0 ! -G%Z_ref
+  !$omp target enter data map(alloc: CS%eta_av_bc)
   CS%time_in_cycle = 0.0 ; CS%time_in_thermo_cycle = 0.0
 
   !allocate porous topography variables

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2336,6 +2336,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                                                                 ! (To be used for writing out ocean geometry)
   character(len=240) :: geom_file ! Name of the ocean geometry file
 
+  ! XXX: This may need to happen even soon, at the driver level
+  ! NOTE: This must precede copy of G to GPU!
+  !$omp target enter data map(to: CS)
+
   CS%Time => Time
 
   id_clock_init = cpu_clock_id('Ocean Initialization', grain=CLOCK_SUBCOMPONENT)
@@ -2930,6 +2934,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ALLOC_(CS%h(isd:ied,jsd:jed,nz))     ; CS%h(:,:,:) = GV%Angstrom_H
   ALLOC_(CS%uh(IsdB:IedB,jsd:jed,nz))  ; CS%uh(:,:,:) = 0.0
   ALLOC_(CS%vh(isd:ied,JsdB:JedB,nz))  ; CS%vh(:,:,:) = 0.0
+  !$omp target enter data map(to: CS%u, CS%v, CS%h, CS%uh, CS%vh)
   if (use_temperature) then
     ALLOC_(CS%T(isd:ied,jsd:jed,nz))   ; CS%T(:,:,:) = 0.0
     ALLOC_(CS%S(isd:ied,jsd:jed,nz))   ; CS%S(:,:,:) = 0.0
@@ -4509,6 +4514,7 @@ subroutine MOM_end(CS)
 
   DEALLOC_(CS%u) ; DEALLOC_(CS%v) ; DEALLOC_(CS%h)
   DEALLOC_(CS%uh) ; DEALLOC_(CS%vh)
+  !$omp target exit data map(delete: CS%u, CS%v, CS%h, CS%uh, CS%vh)
 
   if (associated(CS%update_OBC_CSp)) call OBC_register_end(CS%update_OBC_CSp)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2969,6 +2969,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                            diag_form=2, underflow_conc=salin_underflow, Tr_out=CS%tv%tr_S)
     endif
   endif
+  !$omp target enter data map(alloc: CS%h)
 
   if (use_p_surf_in_EOS) allocate(CS%tv%p_surf(isd:ied,jsd:jed), source=0.0)
   if (use_frazil) allocate(CS%tv%frazil(isd:ied,jsd:jed), source=0.0)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3411,6 +3411,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ! XXX: Where to put this??
   !$acc enter data copyin(GV)
   !$acc enter data copyin(GV%Rlay)
+  !$acc enter data copyin(GV%g_prime)
 
   diag => CS%diag
   ! Initialize the diag mediator.

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -504,93 +504,63 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     if (CS%no_slip) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         rel_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
-      enddo; enddo
-      !$omp end target
+      enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+          do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
-          enddo; enddo
-          !$omp end target
+          enddo
         endif
       endif
     else
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         rel_vort(I,J) = G%mask2dBu(I,J) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
-      enddo; enddo
-      !$omp end target
+      enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+          do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
-          enddo; enddo
-          !$omp end target
+          enddo
         endif
       endif
     endif
 
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+    do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
       abs_vort(I,J) = G%CoriolisBu(I,J) + rel_vort(I,J)
-    enddo ; enddo
-    !$omp end target
+    enddo
 
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+    do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
       hArea_q = (hArea_u(I,j) + hArea_u(I,j+1)) + (hArea_v(i,J) + hArea_v(i+1,J))
       Ih_q(I,J) = Area_q(I,J) / (hArea_q + vol_neglect)
       q(I,J) = abs_vort(I,J) * Ih_q(I,J)
-    enddo; enddo
-    !$omp end target
+    enddo
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
           qS(I,J) = stk_vort(I,J) * Ih_q(I,J)
-        enddo; enddo
-        !$omp end target
+        enddo
       endif
     endif
 
     if (CS%id_rv > 0) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         RV(I,J,k) = rel_vort(I,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (CS%id_PV > 0) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         PV(I,J,k) = q(I,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (associated(AD%rv_x_v) .or. associated(AD%rv_x_u)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
         q2(I,J) = rel_vort(I,J) * Ih_q(I,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     !   a, b, c, and d are combinations of neighboring potential
@@ -598,33 +568,24 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! scheme.  All are defined at u grid points.
 
     if (CS%Coriolis_Scheme == ARAKAWA_HSU90) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, j=Jsq:Jeq+1)
         a(I,j) = (q(I,J) + (q(I+1,J) + q(I,J-1))) * C1_12
         d(I,j) = ((q(I,J) + q(I+1,J-1)) + q(I,J-1)) * C1_12
-      enddo ; enddo
-      !$omp end target
+      enddo
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=Jsq:Jeq+1)
         b(I,j) = (q(I,J) + (q(I-1,J) + q(I,J-1))) * C1_12
         c(I,j) = ((q(I,J) + q(I-1,J-1)) + q(I,J-1)) * C1_12
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == ARAKAWA_LAMB81) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
+      do concurrent (I=Isq:Ieq+1, j=Jsq:Jeq+1)
         a(I-1,j) = (2.0*(q(I,J) + q(I-1,J-1)) + (q(I-1,J) + q(I,J-1))) * C1_24
         d(I-1,j) = ((q(I,j) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
         b(I,j) =   ((q(I,J) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
         c(I,j) =   (2.0*(q(I,J) + q(I-1,J-1)) + (q(I-1,J) + q(I,J-1))) * C1_24
         ep_u(i,j) = ((q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
         ep_v(i,j) = (-(q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == AL_BLEND) then
       Fe_m2 = CS%F_eff_max_blend - 2.0
       rat_lin = 1.5 * Fe_m2 / max(CS%wt_lin_blend, 1.0e-16)
@@ -632,9 +593,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! This allows the code to always give Sadourny Energy
       if (CS%F_eff_max_blend <= 2.0) then ; Fe_m2 = -1. ; rat_lin = -1.0 ; endif
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
+      do concurrent (I=Isq:Ieq+1, j=Jsq:Jeq+1)
         min_Ihq = MIN(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
         max_Ihq = MAX(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
         rat_m1 = 1.0e15
@@ -671,8 +630,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                       2.0 * (q(I,J) + q(I-1,J-1)) ) * C1_24
         ep_u(i,j) = AL_wt  * ((q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
         ep_v(i,j) = AL_wt * (-(q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! .and. SADOURNEY75_ENERGY ??
@@ -680,9 +638,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     !  c1 = 1.0-1.5*RANGE ; c2 = 1.0-RANGE ; c3 = 2.0 ; slope = 0.5
       c1 = 1.0-1.5*0.5 ; c2 = 1.0-0.5 ; c3 = 2.0 ; slope = 0.5
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do I=is-1,ie
+      do concurrent (I=is-1:ie, j=Jsq:Jeq+1)
         uhc = uh_center(I,j)
         uhm = uh(I,j,k)
         ! This sometimes matters with some types of open boundary conditions.
@@ -702,12 +658,9 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         else
           uh_max(I,j) = uhm ; uh_min(I,j) = uhc
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,je ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, J=js-1:je)
         vhc = vh_center(i,J)
         vhm = vh(i,J,k)
         ! This sometimes matters with some types of open boundary conditions.
@@ -727,24 +680,20 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         else
           vh_max(i,J) = vhm ; vh_min(i,J) = vhc
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Calculate KE and the gradient of KE
     call gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
     ! TODO: Can KE be removed from this function?
 
-    !!!$omp target
     ! Calculate the tendencies of zonal velocity due to the Coriolis
     ! force and momentum advection.  On a Cartesian grid, this is
     !     CAu =  q * vh - d(KE)/dx.
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do j=js,je ; do I=Isq,Ieq
+        do concurrent (I=Isq:Ieq, j=js:je)
           if (q(I,J)*u(I,j,k) == 0.0) then
             temp1 = q(I,J) * ( (vh_max(i,j)+vh_max(i+1,j)) &
                              + (vh_min(i,j)+vh_min(i+1,j)) )*0.5
@@ -762,45 +711,33 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             temp2 = q(I,J-1) * (vh_min(i,j-1)+vh_min(i+1,j-1))
           endif
           CAu(I,j,k) = 0.25 * G%IdxCu(I,j) * (temp1 + temp2)
-        enddo ; enddo
-        !$omp end target
+        enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do j=js,je ; do I=Isq,Ieq
+        do concurrent (I=Isq:Ieq, j=js:je)
           CAu(I,j,k) = 0.25 * &
             ((q(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
              (q(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         CAu(I,j,k) = 0.125 * (G%IdxCu(I,j) * (q(I,J) + q(I,J-1))) * &
                      ((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         CAu(I,j,k) = (((a(I,j) * vh(i+1,J,k)) +  (c(I,j) * vh(i,J-1,k)))  + &
                       ((b(I,j) * vh(i,J,k)) +  (d(I,j) * vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_v that should be returned by the
       !       continuity solver. AJA
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         Heff1 = abs(vh(i,J,k) * G%IdxCv(i,J)) / (eps_vel+abs(v(i,J,k)))
         Heff1 = max(Heff1, min(h(i,j,k),h(i,j+1,k)))
         Heff1 = min(Heff1, max(h(i,j,k),h(i,j+1,k)))
@@ -823,40 +760,31 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                        - ((abs_vort(I,J)-abs_vort(I,J-1))*abs(VHeff)) )
           CAu(I,j,k) = (QVHeff / ( h_tiny + ((Heff1+Heff4) + (Heff2+Heff3)) ) ) * G%IdxCu(I,j)
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         CAu(I,j,k) = CAu(I,j,k) + &
               ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAu
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do j=js,je ; do I=Isq,Ieq
+        do concurrent (I=Isq:Ieq, j=js:je)
           CAuS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
                  (qS(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
     endif
 
     if (CS%bound_Coriolis) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         fv1 = abs_vort(I,J) * v(i+1,J,k)
         fv2 = abs_vort(I,J) * v(i,J,k)
         fv3 = abs_vort(I,J-1) * v(i+1,J-1,k)
@@ -867,25 +795,18 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         CAu(I,j,k) = min(CAu(I,j,k), max_fv)
         CAu(I,j,k) = max(CAu(I,j,k), min_fv)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Term - d(KE)/dx.
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do j=js,je ; do I=Isq,Ieq
+    do concurrent (I=Isq:Ieq, j=js:je)
       CAu(I,j,k) = CAu(I,j,k) - KEx(I,j)
-    enddo ; enddo
-    !$omp end target
+    enddo
 
     if (associated(AD%gradKEu)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         AD%gradKEu(I,j,k) = -KEx(I,j)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Calculate the tendencies of meridional velocity due to the Coriolis
@@ -894,9 +815,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq,Jeq ; do i=is,ie
+        do concurrent (i=is:ie, J=Jsq:Jeq)
           if (q(I-1,J)*v(i,J,k) == 0.0) then
             temp1 = q(I-1,J) * ( (uh_max(i-1,j)+uh_max(i-1,j+1)) &
                                + (uh_min(i-1,j)+uh_min(i-1,j+1)) )*0.5
@@ -914,47 +833,35 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             temp2 = q(I,J) * (uh_min(i,j)+uh_min(i,j+1))
           endif
           CAv(i,J,k) = -0.25 * G%IdyCv(i,J) * (temp1 + temp2)
-        enddo ; enddo
-        !$omp end target
+        enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq,Jeq ; do i=is,ie
+        do concurrent (i=is:ie, J=Jsq:Jeq)
           CAv(i,J,k) = - 0.25* &
               ((q(I-1,J)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q(I,J)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J) + q(I,J))) * &
                      ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         CAv(i,J,k) = - (((a(I-1,j)   * uh(I-1,j,k)) + &
                          (c(I,j+1)   * uh(I,j+1,k)))  &
                       + ((b(I,j)     * uh(I,j,k)) +   &
                          (d(I-1,j+1) * uh(I-1,j+1,k)))) * G%IdyCv(i,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_u that should be returned by the
       !       continuity solver. AJA
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         Heff1 = abs(uh(I,j,k) * G%IdyCu(I,j)) / (eps_vel+abs(u(I,j,k)))
         Heff1 = max(Heff1, min(h(i,j,k),h(i+1,j,k)))
         Heff1 = min(Heff1, max(h(i,j,k),h(i+1,j,k)))
@@ -980,39 +887,30 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAv(i,J,k) = - QUHeff / &
                        (h_tiny + ((Heff1+Heff4) +(Heff2+Heff3)) ) * G%IdyCv(i,J)
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
     ! Add in the additonal terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         CAv(i,J,k) = CAv(i,J,k) + &
               ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAv
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=Jsq,Jeq ; do i=is,ie
+        do concurrent (i=is:ie, J=Jsq:Jeq)
           CAvS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (uh(I,j+1,k) + uh(I,j,k))) + &
                  (qS(I,J-1) * (uh(I-1,j,k) + uh(I-1,j+1,k)))) * G%IdyCv(i,J)
-        enddo; enddo
-        !$omp end target
+        enddo
       endif
     endif
 
     if (CS%bound_Coriolis) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         fu1 = -abs_vort(I,J) * u(I,j+1,k)
         fu2 = -abs_vort(I,J) * u(I,j,k)
         fu3 = -abs_vort(I-1,J) * u(I-1,j+1,k)
@@ -1023,75 +921,56 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         CAv(I,j,k) = min(CAv(I,j,k), max_fu)
         CAv(I,j,k) = max(CAv(I,j,k), min_fu)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     ! Term - d(KE)/dy.
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do J=Jsq,Jeq ; do i=is,ie
+    do concurrent (i=is:ie, J=Jsq:Jeq)
       CAv(i,J,k) = CAv(i,J,k) - KEy(i,J)
-    enddo ; enddo
-    !$omp end target
+    enddo
     if (associated(AD%gradKEv)) then
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         AD%gradKEv(i,J,k) = -KEy(i,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
     if (associated(AD%rv_x_u) .or. associated(AD%rv_x_v)) then
       ! Calculate the Coriolis-like acceleration due to relative vorticity.
       if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
         if (associated(AD%rv_x_u)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq,Jeq ; do i=is,ie
+          do concurrent (i=is:ie, J=Jsq:Jeq)
             AD%rv_x_u(i,J,k) = - 0.25* &
               ((q2(I-1,j)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q2(I,j)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
 
         if (associated(AD%rv_x_v)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do j=js,je ; do I=Isq,Ieq
+          do concurrent (I=Isq:Ieq, j=js:je)
             AD%rv_x_v(I,j,k) = 0.25 * &
               ((q2(I,j) * (vh(i+1,J,k) + vh(i,J,k))) + &
                (q2(I,j-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
       else
         if (associated(AD%rv_x_u)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do J=Jsq,Jeq ; do i=is,ie
+          do concurrent (i=is:ie, J=Jsq:Jeq)
             AD%rv_x_u(i,J,k) = -G%IdyCv(i,J) * C1_12 * &
               (((((q2(I,J) + q2(I-1,J-1)) + q2(I-1,J)) * uh(I-1,j,k)) + &
                 (((q2(I-1,J) + q2(I,J+1)) + q2(I,J)) * uh(I,j+1,k))) + &
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * uh(I,j,k))+ &
                 (((q2(I,J) + q2(I-1,J+1)) + q2(I-1,J)) * uh(I-1,j+1,k))))
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
 
         if (associated(AD%rv_x_v)) then
-          !$omp target
-          !$omp parallel loop collapse(2)
-          do j=js,je ; do I=Isq,Ieq
+          do concurrent (I=Isq:Ieq, j=js:je)
             AD%rv_x_v(I,j,k) = G%IdxCu(I,j) * C1_12 * &
               (((((q2(I+1,J) + q2(I,J-1)) + q2(I,J)) * vh(i+1,J,k)) + &
                 (((q2(I-1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i,J-1,k))) + &
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * vh(i,J,k)) + &
                 (((q2(I+1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i+1,J-1,k))))
-          enddo ; enddo
-          !$omp end target
+          enddo
         endif
       endif
     endif

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -719,13 +719,14 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     call gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
     ! TODO: Can KE be removed from this function?
 
-    !$omp target
+    !!!$omp target
     ! Calculate the tendencies of zonal velocity due to the Coriolis
     ! force and momentum advection.  On a Cartesian grid, this is
     !     CAu =  q * vh - d(KE)/dx.
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
+        !$omp target
         !$omp parallel loop collapse(2)
         do j=js,je ; do I=Isq,Ieq
           if (q(I,J)*u(I,j,k) == 0.0) then
@@ -746,34 +747,42 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           endif
           CAu(I,j,k) = 0.25 * G%IdxCu(I,j) * (temp1 + temp2)
         enddo ; enddo
+        !$omp end target
       else
         ! Energy conserving scheme, Sadourny 1975
+        !$omp target
         !$omp parallel loop collapse(2)
         do j=js,je ; do I=Isq,Ieq
           CAu(I,j,k) = 0.25 * &
             ((q(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
              (q(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
         enddo ; enddo
+        !$omp end target
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         CAu(I,j,k) = 0.125 * (G%IdxCu(I,j) * (q(I,J) + q(I,J-1))) * &
                      ((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
       enddo ; enddo
+      !$omp end target
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         CAu(I,j,k) = (((a(I,j) * vh(i+1,J,k)) +  (c(I,j) * vh(i,J-1,k)))  + &
                       ((b(I,j) * vh(i,J,k)) +  (d(I,j) * vh(i+1,J-1,k)))) * G%IdxCu(I,j)
       enddo ; enddo
+      !$omp end target
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_v that should be returned by the
       !       continuity solver. AJA
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         Heff1 = abs(vh(i,J,k) * G%IdxCv(i,J)) / (eps_vel+abs(v(i,J,k)))
@@ -799,31 +808,37 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAu(I,j,k) = (QVHeff / ( h_tiny + ((Heff1+Heff4) + (Heff2+Heff3)) ) ) * G%IdxCu(I,j)
         endif
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         CAu(I,j,k) = CAu(I,j,k) + &
               ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
       enddo ; enddo
+      !$omp end target
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAu
+        !$omp target
         !$omp parallel loop collapse(2)
         do j=js,je ; do I=Isq,Ieq
           CAuS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
                  (qS(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
         enddo ; enddo
+        !$omp end target
       endif
     endif
 
     if (CS%bound_Coriolis) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         fv1 = abs_vort(I,J) * v(i+1,J,k)
@@ -837,19 +852,24 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         CAu(I,j,k) = min(CAu(I,j,k), max_fv)
         CAu(I,j,k) = max(CAu(I,j,k), min_fv)
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Term - d(KE)/dx.
+    !$omp target
     !$omp parallel loop collapse(2)
     do j=js,je ; do I=Isq,Ieq
       CAu(I,j,k) = CAu(I,j,k) - KEx(I,j)
     enddo ; enddo
+    !$omp end target
 
     if (associated(AD%gradKEu)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         AD%gradKEu(I,j,k) = -KEx(I,j)
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Calculate the tendencies of meridional velocity due to the Coriolis
@@ -858,6 +878,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
+        !$omp target
         !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           if (q(I-1,J)*v(i,J,k) == 0.0) then
@@ -878,25 +899,31 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           endif
           CAv(i,J,k) = -0.25 * G%IdyCv(i,J) * (temp1 + temp2)
         enddo ; enddo
+        !$omp end target
       else
         ! Energy conserving scheme, Sadourny 1975
+        !$omp target
         !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           CAv(i,J,k) = - 0.25* &
               ((q(I-1,J)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q(I,J)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
         enddo ; enddo
+        !$omp end target
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J) + q(I,J))) * &
                      ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
       enddo ; enddo
+      !$omp end target
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = - (((a(I-1,j)   * uh(I-1,j,k)) + &
@@ -904,10 +931,12 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                       + ((b(I,j)     * uh(I,j,k)) +   &
                          (d(I-1,j+1) * uh(I-1,j+1,k)))) * G%IdyCv(i,J)
       enddo ; enddo
+      !$omp end target
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_u that should be returned by the
       !       continuity solver. AJA
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         Heff1 = abs(uh(I,j,k) * G%IdyCu(I,j)) / (eps_vel+abs(u(I,j,k)))
@@ -936,30 +965,36 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                        (h_tiny + ((Heff1+Heff4) +(Heff2+Heff3)) ) * G%IdyCv(i,J)
         endif
       enddo ; enddo
+      !$omp end target
     endif
     ! Add in the additonal terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = CAv(i,J,k) + &
               ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
       enddo ; enddo
+      !$omp end target
     endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAv
+        !$omp target
         !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           CAvS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (uh(I,j+1,k) + uh(I,j,k))) + &
                  (qS(I,J-1) * (uh(I-1,j,k) + uh(I-1,j+1,k)))) * G%IdyCv(i,J)
         enddo; enddo
+        !$omp end target
       endif
     endif
 
     if (CS%bound_Coriolis) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         fu1 = -abs_vort(I,J) * u(I,j+1,k)
@@ -973,42 +1008,52 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         CAv(I,j,k) = min(CAv(I,j,k), max_fu)
         CAv(I,j,k) = max(CAv(I,j,k), min_fu)
       enddo ; enddo
+      !$omp end target
     endif
 
     ! Term - d(KE)/dy.
+    !$omp target
     !$omp parallel loop collapse(2)
     do J=Jsq,Jeq ; do i=is,ie
       CAv(i,J,k) = CAv(i,J,k) - KEy(i,J)
     enddo ; enddo
+    !$omp end target
     if (associated(AD%gradKEv)) then
+      !$omp target
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         AD%gradKEv(i,J,k) = -KEy(i,J)
       enddo ; enddo
+      !$omp end target
     endif
 
     if (associated(AD%rv_x_u) .or. associated(AD%rv_x_v)) then
       ! Calculate the Coriolis-like acceleration due to relative vorticity.
       if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
         if (associated(AD%rv_x_u)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do J=Jsq,Jeq ; do i=is,ie
             AD%rv_x_u(i,J,k) = - 0.25* &
               ((q2(I-1,j)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q2(I,j)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
           enddo ; enddo
+          !$omp end target
         endif
 
         if (associated(AD%rv_x_v)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do j=js,je ; do I=Isq,Ieq
             AD%rv_x_v(I,j,k) = 0.25 * &
               ((q2(I,j) * (vh(i+1,J,k) + vh(i,J,k))) + &
                (q2(I,j-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
           enddo ; enddo
+          !$omp end target
         endif
       else
         if (associated(AD%rv_x_u)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do J=Jsq,Jeq ; do i=is,ie
             AD%rv_x_u(i,J,k) = -G%IdyCv(i,J) * C1_12 * &
@@ -1017,9 +1062,11 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * uh(I,j,k))+ &
                 (((q2(I,J) + q2(I-1,J+1)) + q2(I-1,J)) * uh(I-1,j+1,k))))
           enddo ; enddo
+          !$omp end target
         endif
 
         if (associated(AD%rv_x_v)) then
+          !$omp target
           !$omp parallel loop collapse(2)
           do j=js,je ; do I=Isq,Ieq
             AD%rv_x_v(I,j,k) = G%IdxCu(I,j) * C1_12 * &
@@ -1028,11 +1075,10 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * vh(i,J,k)) + &
                 (((q2(I+1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i+1,J-1,k))))
           enddo ; enddo
+          !$omp end target
         endif
       endif
     endif
-    !$omp end target
-
   enddo ! k-loop.
 
   !$omp target exit data map(delete: Area_h, Area_q)

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -316,10 +316,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   !$omp target enter data map(alloc: AD%rv_x_v) if (associated(AD%rv_x_v))
 
   ! TODO: Do this outside of the function
-  !$omp target enter data map(to: u, v, h, uh, vh)
   !$omp target enter data map(to: pbv, pbv%por_face_areaU, pbv%por_face_areaV) &
   !$omp   if (CS%Coriolis_En_Dis)
-  !$omp target enter data map(alloc: CAu, CAv)
 
   do k=1,nz
 
@@ -1051,10 +1049,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   !$omp     if(associated(AD%rv_x_u) .or. associated(AD%rv_x_v))
 
   ! TODO: Move outside function
-  !$omp target exit data map(delete: u, v, h, uh, vh)
   !$omp target exit data map(delete: pbv, pbv%por_face_areaU, pbv%por_face_areaV) &
   !$omp   if (CS%Coriolis_En_Dis)
-  !$omp target exit data map(from: CAu, CAv)
 
   ! Diagnostics
   !$omp target exit data map(from: RV) if (CS%id_RV > 0)
@@ -1103,7 +1099,6 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%id_intz_rvxv_2d > 0) call post_product_sum_u(CS%id_intz_rvxv_2d, AD%rv_x_v, AD%diag_hu, G, nz, CS%diag)
     if (CS%id_intz_rvxu_2d > 0) call post_product_sum_v(CS%id_intz_rvxu_2d, AD%rv_x_u, AD%diag_hv, G, nz, CS%diag)
   endif
-
 end subroutine CorAdCalc
 
 
@@ -1206,6 +1201,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
     !$omp target update to(KEx, KEy)
   endif
 end subroutine gradKE
+
 
 !> Initializes the control structure for MOM_CoriolisAdv
 subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -296,20 +296,22 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   !$omp target enter data map(alloc: hArea_u, hArea_v)
   !$omp target enter data map(alloc: rel_vort, abs_vort, q, Ih_q)
   !$omp target enter data map(alloc: a, b, c, d, ep_u, ep_v)
+  !$omp target enter data map(alloc: KE, KEx, KEy)
   ! TODO: These Stokes_VF fields seem associated with diagnostics
   !$omp target enter data map(alloc: dvSdx, duSdy, stk_vort, qS) if (Stokes_VF)
+  !$omp target enter data map(alloc: CAuS, CAvS) if (Stokes_VF)
   !$omp target enter data map(alloc: uh_center, vh_center) if (CS%Coriolis_En_Dis)
   ! TODO: May also need SADOURNEY75_ENERGY
   !$omp target enter data map(alloc: uh_min, vh_min) if (CS%Coriolis_En_Dis)
   !$omp target enter data map(alloc: uh_max, vh_max) if (CS%Coriolis_En_Dis)
-
-  !$omp target enter data map(alloc: KE, KEx, KEy)
 
   ! Diagnostics
   !$omp target enter data map(alloc: RV) if (CS%id_RV > 0)
   !$omp target enter data map(alloc: PV) if (CS%id_PV > 0)
   !$omp target enter data map(alloc: q2) &
   !$omp   if(associated(AD%rv_x_u) .or. associated(AD%rv_x_v))
+  !$omp target enter data map(alloc: AD%gradKEu) if (associated(AD%gradKEu))
+  !$omp target enter data map(alloc: AD%gradKEv) if (associated(AD%gradKEv))
 
   ! TODO: Do this outside of the function
   !$omp target enter data map(to: u, v, h, uh, vh)
@@ -715,8 +717,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
     ! Calculate KE and the gradient of KE
     call gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
-
-    !$omp target update from(KE, KEx, KEy)
+    ! TODO: Can KE be removed from this function?
 
     !$omp target
     ! Calculate the tendencies of zonal velocity due to the Coriolis
@@ -799,30 +800,21 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         endif
       enddo ; enddo
     endif
-    !$omp end target
-    !$omp target update from(CAu(:,:,k))
-
-    !$omp target update from(abs_vort, q)
-    !$omp target update from(a, b, c, d, ep_u, ep_v)
-    !$omp target update from(uh_min, vh_min) if (CS%Coriolis_En_Dis)
-    !$omp target update from(uh_max, vh_max) if (CS%Coriolis_En_Dis)
-
-    ! Diagnostics
-    !$omp target update from(RV) if (CS%id_RV > 0)
-    !$omp target update from(PV) if (CS%id_PV > 0)
-    !$omp target update from(q2) &
-    !$omp     if(associated(AD%rv_x_u) .or. associated(AD%rv_x_v))
 
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
-        (CS%Coriolis_Scheme == AL_BLEND)) then ; do j=js,je ; do I=Isq,Ieq
-      CAu(I,j,k) = CAu(I,j,k) + &
-            ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
-    enddo ; enddo ; endif
+        (CS%Coriolis_Scheme == AL_BLEND)) then
+      !$omp parallel loop collapse(2)
+      do j=js,je ; do I=Isq,Ieq
+        CAu(I,j,k) = CAu(I,j,k) + &
+              ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
+      enddo ; enddo
+    endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAu
+        !$omp parallel loop collapse(2)
         do j=js,je ; do I=Isq,Ieq
           CAuS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
@@ -832,6 +824,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     if (CS%bound_Coriolis) then
+      !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         fv1 = abs_vort(I,J) * v(i+1,J,k)
         fv2 = abs_vort(I,J) * v(i,J,k)
@@ -847,11 +840,13 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     ! Term - d(KE)/dx.
+    !$omp parallel loop collapse(2)
     do j=js,je ; do I=Isq,Ieq
       CAu(I,j,k) = CAu(I,j,k) - KEx(I,j)
     enddo ; enddo
 
     if (associated(AD%gradKEu)) then
+      !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
         AD%gradKEu(I,j,k) = -KEx(I,j)
       enddo ; enddo
@@ -863,6 +858,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
+        !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           if (q(I-1,J)*v(i,J,k) == 0.0) then
             temp1 = q(I-1,J) * ( (uh_max(i-1,j)+uh_max(i-1,j+1)) &
@@ -884,6 +880,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo ; enddo
       else
         ! Energy conserving scheme, Sadourny 1975
+        !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           CAv(i,J,k) = - 0.25* &
               ((q(I-1,J)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
@@ -891,6 +888,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo ; enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
+      !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J) + q(I,J))) * &
                      ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
@@ -899,6 +897,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
+      !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         CAv(i,J,k) = - (((a(I-1,j)   * uh(I-1,j,k)) + &
                          (c(I,j+1)   * uh(I,j+1,k)))  &
@@ -909,6 +908,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_u that should be returned by the
       !       continuity solver. AJA
+      !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         Heff1 = abs(uh(I,j,k) * G%IdyCu(I,j)) / (eps_vel+abs(u(I,j,k)))
         Heff1 = max(Heff1, min(h(i,j,k),h(i+1,j,k)))
@@ -939,14 +939,18 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
     ! Add in the additonal terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
-        (CS%Coriolis_Scheme == AL_BLEND)) then ; do J=Jsq,Jeq ; do i=is,ie
-      CAv(i,J,k) = CAv(i,J,k) + &
-            ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
-    enddo ; enddo ; endif
+        (CS%Coriolis_Scheme == AL_BLEND)) then
+      !$omp parallel loop collapse(2)
+      do J=Jsq,Jeq ; do i=is,ie
+        CAv(i,J,k) = CAv(i,J,k) + &
+              ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
+      enddo ; enddo
+    endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAv
+        !$omp parallel loop collapse(2)
         do J=Jsq,Jeq ; do i=is,ie
           CAvS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (uh(I,j+1,k) + uh(I,j,k))) + &
@@ -956,6 +960,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     if (CS%bound_Coriolis) then
+      !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         fu1 = -abs_vort(I,J) * u(I,j+1,k)
         fu2 = -abs_vort(I,J) * u(I,j,k)
@@ -971,14 +976,24 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     ! Term - d(KE)/dy.
+    !$omp parallel loop collapse(2)
     do J=Jsq,Jeq ; do i=is,ie
       CAv(i,J,k) = CAv(i,J,k) - KEy(i,J)
     enddo ; enddo
     if (associated(AD%gradKEv)) then
+      !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
         AD%gradKEv(i,J,k) = -KEy(i,J)
       enddo ; enddo
     endif
+    !$omp end target
+    !$omp target update from(CAu(:,:,k), CAv(:,:,k))
+
+    ! Diagnostics
+    !$omp target update from(RV(:,:,k)) if (CS%id_RV > 0)
+    !$omp target update from(PV(:,:,k)) if (CS%id_PV > 0)
+    !$omp target update from(q2) &
+    !$omp     if(associated(AD%rv_x_u) .or. associated(AD%rv_x_v))
 
     if (associated(AD%rv_x_u) .or. associated(AD%rv_x_v)) then
       ! Calculate the Coriolis-like acceleration due to relative vorticity.
@@ -1028,12 +1043,15 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   !$omp target exit data map(delete: hArea_u, hArea_v)
   !$omp target exit data map(delete: rel_vort, abs_vort, q, Ih_q)
   !$omp target exit data map(delete: a, b, c, d, ep_u, ep_v)
+  !$omp target exit data map(delete: KE, KEx, KEy)
   !$omp target exit data map(delete: dvSdx, duSdy, stk_vort, qS) if (Stokes_VF)
+  !$omp target exit data map(delete: CAuS, CAvS) if (Stokes_VF)
   !$omp target exit data map(delete: uh_center, vh_center) if (CS%Coriolis_En_Dis)
   !$omp target exit data map(delete: uh_min, vh_min) if (CS%Coriolis_En_Dis)
   !$omp target exit data map(delete: uh_max, vh_max) if (CS%Coriolis_En_Dis)
+  !$omp target exit data map(delete: AD%gradKEu) if (associated(AD%gradKEu))
+  !$omp target exit data map(delete: AD%gradKEv) if (associated(AD%gradKEv))
 
-  !$omp target exit data map(delete: KE, KEx, KEy)
 
   ! TODO: Move outside function
   !$omp target exit data map(delete: u, v, h, uh, vh)

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1279,24 +1279,19 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
 
   if (use_EOS) then
     !$omp target enter data map(alloc: Z_0p) if (use_EOS)
-    !$omp target
     if (CS%use_SSH_in_Z0p .and. use_p_atm) then
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         Z_0p(i,j) = e(i,j,1) + p_atm(i,j) * I_g_rho
-      enddo ; enddo
+      enddo
     elseif (CS%use_SSH_in_Z0p) then
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         Z_0p(i,j) = e(i,j,1)
-      enddo ; enddo
+      enddo
     else
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         Z_0p(i,j) = G%Z_ref
-      enddo ; enddo
+      enddo
     endif
-    !$omp end target
     !$omp target update from(Z_0p) if (use_EOS)
   endif
 

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1211,14 +1211,11 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     !$omp target update to(e(:,:,nz+1))
   endif
 
-  !$omp target
   do k=nz,1,-1
-    !$omp parallel loop collapse(2)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
       e(i,j,K) = e(i,j,K+1) + h(i,j,k)*GV%H_to_Z
-    enddo ; enddo
+    enddo
   enddo
-  !$omp end target
 
   if (use_EOS) then
     if (nkmb>0) then
@@ -1265,7 +1262,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     enddo ; enddo ; enddo
   endif
 
-  !$omp target enter data map(to: e)
   !$omp target enter data map(to: p_atm) if (use_p_atm)
   !$omp target enter data map(alloc: pa)
 

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -982,9 +982,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   real, dimension(SZI_(G)) :: &
     Rho_cv_BL   ! The coordinate potential density in the deepest variable
                 ! density near-surface layer [R ~> kg m-3].
-  !real, dimension(SZI_(G),SZJ_(G)) :: &
-  !!!real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
-  !  dz_geo      ! The change in geopotential thickness through a layer [L2 T-2 ~> m2 s-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: &
     pa          ! The pressure anomaly (i.e. pressure + g*RHO_0*e) at the
                 ! the interface atop a layer [R L2 T-2 ~> Pa].
@@ -1074,7 +1071,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
                              ! consistent with what is used in the density integral routines [R L2 T-2 ~> Pa]
   real :: p0(SZI_(G), SZJ_(G)) ! An array of zeros to use for pressure [R L2 T-2 ~> Pa].
   real :: dz_geo_sfc         ! The change in surface geopotential height between adjacent cells [L2 T-2 ~> m2 s-2]
-  real :: dz_geo2, dz_geo3   ! Some dumb constants
+  real :: dz_geo, dz_geo_next ! Change in geopotential thickness across layer [L2 T-2 ~> m2 s-2]
   real :: GxRho0             ! The gravitational acceleration times mean ocean density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: GxRho_ref          ! The gravitational acceleration times reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: rho0_int_density   ! Rho0 used in int_density_dz_* subroutines [R ~> kg m-3]
@@ -1292,8 +1289,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   !$omp   map(to: h) &
   !$omp   map(alloc: dpa, intx_dpa, inty_dpa, intz_dpa)
 
-  !!$omp target enter data map(alloc: dz_geo)
-
   ! Calculate 4 integrals through the layer that are required in the
   ! subsequent calculation.
   if (use_EOS) then
@@ -1338,94 +1333,33 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
                                     G%HI, MassWt_u(:,:,k), MassWt_v(:,:,k), &
                                     MassWghtInterpVanOnly=CS%MassWghtInterpVanOnly, h_nv=CS%h_nonvanished)
     enddo
+    !$omp target update to(dpa, intx_dpa, inty_dpa, intz_dpa)
   else
     !$omp target
     do k=1,nz
-      !!print *, "pre"
-      !!print *, k, "h", sum(h(Isq:Ieq+1,Jsq:Jeq+1,k))
-      !!print *, k, "GV%g_Earth", GV%g_Earth
-      !!print *, k, "GV%H_to_Z", GV%H_to_Z
-      !!!print *, k, "GV%Rlay(k)", GV%Rlay(k)
-      !!print *, k, "rho_ref", rho_ref
-
-      !call hchksum(h(:,:,k), "pre h", G%HI, haloshift=1)
-
-      !!$omp target
-
-      !!$OMP parallel do default(shared)
       !$omp parallel loop collapse(2)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        !!* Does not work *!
-        !dz_geo(i,j) = GV%g_Earth * GV%H_to_Z*h(i,j,k)
-        !dpa(i,j,k) = (GV%Rlay(k) - rho_ref) * dz_geo(i,j)
-        !intz_dpa(i,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * dz_geo(i,j)*h(i,j,k)
-
-        !* Works but needs a new 3d array *!
-        !!dz_geo(i,j,k) = GV%g_Earth * GV%H_to_Z*h(i,j,k)
-        !!dpa(i,j,k) = (GV%Rlay(k) - rho_ref) * dz_geo(i,j,k)
-        !!intz_dpa(i,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * dz_geo(i,j,k)*h(i,j,k)
-
-        !* Works but requires re-computing dz_geo in next two loops *!
-        dz_geo2 = GV%g_Earth * GV%H_to_Z * h(i,j,k)
-        dpa(i,j,k) = (GV%Rlay(k) - rho_ref) * dz_geo2
-        intz_dpa(i,j,k) = 0.5 * (GV%Rlay(k) - rho_ref) * dz_geo2 * h(i,j,k)
-
-        !!* Does not work *!
-        !dz_geo(i,j) = GV%g_Earth * GV%H_to_Z*h(i,j,k)
-        !dpa(i,j,k) = (GV%Rlay(k) - rho_ref) * dz_geo(i,j)
-        !intz_dpa(i,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * dz_geo(i,j)*h(i,j,k)
-        !intx_dpa(I-1,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i-1,j) + dz_geo(i,j))
-        !inty_dpa(i,J-1,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j-1) + dz_geo(i,j))
+        dz_geo = GV%g_Earth * GV%H_to_Z * h(i,j,k)
+        dpa(i,j,k) = (GV%Rlay(k) - rho_ref) * dz_geo
+        intz_dpa(i,j,k) = 0.5 * (GV%Rlay(k) - rho_ref) * dz_geo * h(i,j,k)
       enddo ; enddo
-      !!$OMP parallel do default(shared)
+
       !$omp parallel loop collapse(2)
       do j=js,je ; do I=Isq,Ieq
-        !intx_dpa(I,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j) + dz_geo(i+1,j))
-        !!intx_dpa(I,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j,k) + dz_geo(i+1,j,k))
-
-        dz_geo2 = GV%g_Earth * GV%H_to_Z * h(i,j,k)
-        dz_geo3 = GV%g_Earth * GV%H_to_Z * h(i+1,j,k)
-        intx_dpa(I,j,k) = 0.5 * (GV%Rlay(k) - rho_ref) * (dz_geo2 + dz_geo3)
+        dz_geo = GV%g_Earth * GV%H_to_Z * h(i,j,k)
+        dz_geo_next = GV%g_Earth * GV%H_to_Z * h(i+1,j,k)
+        intx_dpa(I,j,k) = 0.5 * (GV%Rlay(k) - rho_ref) * (dz_geo + dz_geo_next)
       enddo ; enddo
-      !!$OMP parallel do default(shared)
+
       !$omp parallel loop collapse(2)
       do J=Jsq,Jeq ; do i=is,ie
-        !inty_dpa(i,J,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j) + dz_geo(i,j+1))
-        !!inty_dpa(i,J,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j,k) + dz_geo(i,j+1,k))
-
-        dz_geo2 = GV%g_Earth * GV%H_to_Z * h(i,j+1,k)
-        dz_geo3 = GV%g_Earth * GV%H_to_Z * h(i,j,k)
-        inty_dpa(i,J,k) = 0.5 * (GV%Rlay(k) - rho_ref) * (dz_geo2 + dz_geo3)
+        dz_geo = GV%g_Earth * GV%H_to_Z * h(i,j,k)
+        dz_geo_next = GV%g_Earth * GV%H_to_Z * h(i,j+1,k)
+        inty_dpa(i,J,k) = 0.5 * (GV%Rlay(k) - rho_ref) * (dz_geo + dz_geo_next)
       enddo ; enddo
-      !!$omp end target
-
-      !!$omp target update from(dz_geo, dpa, intx_dpa, inty_dpa, intz_dpa)
-      !print *, "post"
-      !print *, k, "dz_geo", sum(dz_geo(Isq:Ieq+1,Jsq:Jeq+1))
-      !print *, k, "dpa", sum(dpa(Isq:Ieq+1,Jsq:Jeq+1,k))
-      !print *, k, "intx_dpa", sum(intx_dpa(Isq:Ieq,js:je,k))
-      !print *, k, "inty_dpa", sum(inty_dpa(is:ie,Jsq:Jeq,k))
-      !print *, k, "intz_dpa", sum(intz_dpa(Isq:Ieq+1,Jsq:Jeq+1,k))
-      !print *, "-----"
-      !print *, k, "dz_geo(:,:)", dz_geo(Isq:Ieq+1,Jsq:Jeq+1)
-      !print *, "-----"
-      !print *, k, "intx_dpa(:,:)", intx_dpa(Isq:Ieq+1,Jsq:Jeq+1)
-      !print *, "-----"
-      !print *, k, "inty_dpa(:,:)", inty_dpa(Isq:Ieq+1,Jsq:Jeq+1)
-      !print *, "====="
-
-      !call hchksum(dz_geo(:,:), "post dz_geo", G%HI, haloshift=1)
-      !!call hchksum(dz_geo(:,:,k), "post dz_geo", G%HI, haloshift=1)
-      !call hchksum(dpa(:,:,k), "post dpa", G%HI, haloshift=1)
-      !call hchksum(intz_dpa(:,:,k), "post intz_dpa", G%HI, haloshift=1)
-      !call uvchksum("post intxy_dpa", intx_dpa(:,:,k), inty_dpa(:,:,k), G%HI)
     enddo
     !$omp end target
   endif
-
-  ! TODO: Get rid of this!  Run the block above on GPU...
-  !!$omp target update to(dpa, intx_dpa, inty_dpa, intz_dpa)
-  !!$omp target exit data map(delete: dz_geo)
 
   !$omp target enter data map(to: pa)
 

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1874,19 +1874,13 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     ! Adjust the Montgomery potential to make this a reduced gravity model.
 
     if (use_EOS) then
-      !$acc data present(tv_tmp, tv_tmp%T, tv_tmp%S, tv, tv%eqn_of_state, EOSdom2d)
       if (use_p_atm) then
-        !$acc data present(p_atm)
         call calculate_density(tv_tmp%T(:,:,1), tv_tmp%S(:,:,1), p_atm, rho_in_situ, &
                                tv%eqn_of_state, EOSdom2d)
-        !$acc end data
       else
-        !$acc data present(p0)
         call calculate_density(tv_tmp%T(:,:,1), tv_tmp%S(:,:,1), p0, rho_in_situ, &
                                tv%eqn_of_state, EOSdom2d)
-        !$acc end data
       endif
-      !$acc end data
 
       !$OMP parallel do default(shared)
       !$acc kernels

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1967,33 +1967,27 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   if (present(eta)) then
     ! eta is the sea surface height relative to a time-invariant geoid, for comparison with
     ! what is used for eta in btstep.  See how e was calculated about 200 lines above.
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
       eta(i,j) = e(i,j,1)*GV%Z_to_H
-    enddo ; enddo
+    enddo
 
     if (CS%tides .and. (.not.CS%bq_sal_tides)) then
       if (CS%tides_answer_date>20230630) then
-        !$omp parallel loop collapse(2)
-        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
           eta(i,j) = eta(i,j) + (e_tidal_eq(i,j)+e_tidal_sal(i,j))*GV%Z_to_H
-        enddo ; enddo
+        enddo
       else
-        !$omp parallel loop collapse(2)
-        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
           eta(i,j) = eta(i,j) + e_sal_and_tide(i,j)*GV%Z_to_H
-        enddo ; enddo
+        enddo
       endif
     endif
 
     if (CS%calculate_SAL .and. (CS%tides_answer_date>20230630) .and. (.not.CS%bq_sal_tides)) then
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         eta(i,j) = eta(i,j) + e_sal(i,j)*GV%Z_to_H
-      enddo ; enddo
+      enddo
     endif
-    !$omp end target
   endif
 
   !$omp target exit data map(delete: e)

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1153,12 +1153,9 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
 
   !$omp target enter data map(alloc: e)
 
-  !$omp target
-  !$omp parallel loop collapse(2)
-  do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+  do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
     e(i,j,nz+1) = -G%bathyT(i,j)
-  enddo ; enddo
-  !$omp end target
+  enddo
 
   ! The following two if-blocks are used to recover old answers for self-attraction and loading
   ! (SAL) and tides only. The old algorithm moves interface heights before density calculations,

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1265,22 +1265,18 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   !$omp target enter data map(to: p_atm) if (use_p_atm)
   !$omp target enter data map(alloc: pa)
 
-  !$omp target
   ! Set the surface boundary conditions on pressure anomaly and its horizontal
   ! integrals, assuming that the surface pressure anomaly varies linearly
   ! in x and y.
   if (use_p_atm) then
-    !$omp parallel loop collapse(2)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
       pa(i,j,1) = GxRho_ref * (e(i,j,1) - G%Z_ref) + p_atm(i,j)
-    enddo ; enddo
+    enddo
   else
-    !$omp parallel loop collapse(2)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
       pa(i,j,1) = GxRho_ref * (e(i,j,1) - G%Z_ref)
-    enddo ; enddo
+    enddo
   endif
-  !$omp end target
 
   if (use_EOS) then
     !$omp target enter data map(alloc: Z_0p) if (use_EOS)
@@ -1372,15 +1368,12 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     !$omp end target data
   endif
 
-  !$omp target
   ! Set the pressure anomalies at the interfaces.
   do k=1,nz
-    !$omp parallel loop collapse(2)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
       pa(i,j,K+1) = pa(i,j,K) + dpa(i,j,k)
-    enddo ; enddo
+    enddo
   enddo
-  !$omp end target
 
   ! Calculate and add SAL geopotential anomaly to interface height (new answers)
   if (CS%calculate_SAL .and. CS%tides_answer_date>20250131) then

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1262,7 +1262,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     enddo ; enddo ; enddo
   endif
 
-  !$omp target enter data map(to: p_atm) if (use_p_atm)
   !$omp target enter data map(alloc: pa)
 
   ! Set the surface boundary conditions on pressure anomaly and its horizontal
@@ -1956,9 +1955,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   !$omp   map(delete:tv_tmp, tv_tmp%T, tv_tmp%S, tv, tv%eqn_of_state, EOSdom2d)
 
   !$omp target exit data map(delete: Z_0p) if (use_EOS)
-
-  !$omp target exit data if (use_p_atm) &
-  !$omp   map(delete: p_atm)
 
   !$omp target exit data &
   !$omp   map(delete: pa, dpa) &

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1355,6 +1355,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     enddo
     !$omp target update to(dpa, intx_dpa, inty_dpa, intz_dpa)
   else
+    !$omp target data map(alloc: dz_geo)
     do k=1,nz
       do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         dz_geo(i,j) = GV%g_Earth * GV%H_to_Z*h(i,j,k)
@@ -1368,6 +1369,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
         inty_dpa(i,J,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j) + dz_geo(i,j+1))
       enddo
     enddo
+    !$omp end target data
   endif
 
   !$omp target

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1852,9 +1852,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   !$omp target enter data if(.not. use_p_atm) &
   !$omp   map(to: p0)
 
-  !$omp target enter data if(present(pbce)) &
-  !$omp   map(to: pbce)
-
   ! NOTE: e_sal condition could be sharpened, but this is close enough.
   !$omp target enter data map(to: e_tidal_eq, e_tidal_sal, e_sal_and_tide) if (CS%tides)
   !$omp target enter data map(to: e_sal) if (CS%calculate_SAL)
@@ -1975,9 +1972,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   !$omp target exit data if (.not. use_p_atm) &
   !$omp   map(delete: p0)
 
-  !$omp target exit data if (present(pbce)) &
-  !$omp   map(from: pbce)
-
   !$omp target exit data &
   !$omp   map(delete: pa, dpa) &
   !$omp   map(delete: intx_pa, inty_pa, intx_dpa, inty_dpa, intz_dpa)
@@ -1985,8 +1979,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   ! NOTE: As above, these are here until data is set up outside of the function.
 
   if (present(eta)) then
-    !$omp target enter data map(alloc: eta)
-
     ! eta is the sea surface height relative to a time-invariant geoid, for comparison with
     ! what is used for eta in btstep.  See how e was calculated about 200 lines above.
     !$omp target
@@ -2016,8 +2008,6 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
       enddo ; enddo
     endif
     !$omp end target
-
-    !$omp target exit data map(from: eta)
   endif
 
   !$omp target exit data map(delete: e)

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1296,12 +1296,10 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     !$omp target update from(Z_0p) if (use_EOS)
   endif
 
-  !$omp target enter data &
-  !$omp   map(to: h) &
-  !$omp   map(alloc: dpa, intx_dpa, inty_dpa, intz_dpa)
-
   ! Calculate 4 integrals through the layer that are required in the
   ! subsequent calculation.
+  !$omp target enter data map(alloc: dpa, intx_dpa, inty_dpa, intz_dpa)
+
   if (use_EOS) then
     ! The following routine computes the integrals that are needed to
     ! calculate the pressure gradient force. Linear profiles for T and S are
@@ -1977,7 +1975,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   !$omp   map(from: pbce)
 
   !$omp target exit data &
-  !$omp   map(delete: pa, dpa, h) &
+  !$omp   map(delete: pa, dpa) &
   !$omp   map(delete: intx_pa, inty_pa, intx_dpa, inty_dpa, intz_dpa)
 
   ! NOTE: As above, these are here until data is set up outside of the function.

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1931,26 +1931,19 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
 
       !$omp end target data
     else
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         dM(i,j) = (CS%GFS_scale - 1.0) * (G_Rho0 * GV%Rlay(1)) * (e(i,j,1) - G%Z_ref)
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif
 
-    !$omp target
     do k=1,nz
-      !$omp parallel loop collapse(2)
-      do j=js,je ; do I=Isq,Ieq
+      do concurrent (I=Isq:Ieq, j=js:je)
         PFu(I,j,k) = PFu(I,j,k) - (dM(i+1,j) - dM(i,j)) * G%IdxCu(I,j)
-      enddo ; enddo
-      !$omp parallel loop collapse(2)
-      do J=Jsq,Jeq ; do i=is,ie
+      enddo
+      do concurrent (i=is:ie, J=Jsq:Jeq)
         PFv(i,J,k) = PFv(i,J,k) - (dM(i,j+1) - dM(i,j)) * G%IdyCv(i,J)
-      enddo ; enddo
+      enddo
     enddo
-    !$omp end target
 
     !$omp end target data
   endif

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -764,11 +764,13 @@ subroutine Set_pbce_Bouss(e, tv, G, GV, US, Rho0, GFS_scale, pbce, rho_star)
       Ihtot(i,j) = 1.0 / ((e(i,j,1) - e(i,j,nz+1)) + dz_neglect)
       pbce(i,j,1) = GV%g_prime(1) * GV%H_to_Z
     enddo ; enddo
-    !$omp parallel loop collapse(2)
-    do k=2,nz ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      pbce(i,j,k) = pbce(i,j,k-1) + (GV%g_prime(K) * GV%H_to_Z) &
-          * ((e(i,j,K) - e(i,j,nz+1)) * Ihtot(i,j))
-    enddo ; enddo ; enddo
+    do k=2,nz
+      !$omp parallel loop collapse(2)
+      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        pbce(i,j,k) = pbce(i,j,k-1) + (GV%g_prime(K) * GV%H_to_Z) &
+            * ((e(i,j,K) - e(i,j,nz+1)) * Ihtot(i,j))
+      enddo ; enddo
+    enddo
     !$omp end target
   endif
   !$omp end target data

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -697,11 +697,13 @@ subroutine Set_pbce_Bouss(e, tv, G, GV, US, Rho0, GFS_scale, pbce, rho_star)
         pbce(i,j,1) = GFS_scale * rho_star(i,j,1) * GV%H_to_Z
       enddo ; enddo
 
-      !$omp parallel loop collapse(3)
-      do k=2,nz ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        pbce(i,j,k) = pbce(i,j,k-1) + (rho_star(i,j,k) - rho_star(i,j,k-1)) &
-            * ((e(i,j,K) - e(i,j,nz+1)) * Ihtot(i,j))
-      enddo ; enddo ; enddo
+      do k=2,nz
+        !$omp parallel loop collapse(2)
+        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+          pbce(i,j,k) = pbce(i,j,k-1) + (rho_star(i,j,k) - rho_star(i,j,k-1)) &
+              * ((e(i,j,K) - e(i,j,nz+1)) * Ihtot(i,j))
+        enddo ; enddo
+      enddo
       !$omp end target
     else
       !$omp target data &

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -760,20 +760,16 @@ subroutine Set_pbce_Bouss(e, tv, G, GV, US, Rho0, GFS_scale, pbce, rho_star)
       !$omp end target data
     endif
   else
-    !$omp target
-    !$omp parallel loop collapse(2)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
       Ihtot(i,j) = 1.0 / ((e(i,j,1) - e(i,j,nz+1)) + dz_neglect)
       pbce(i,j,1) = GV%g_prime(1) * GV%H_to_Z
-    enddo ; enddo
+    enddo
     do k=2,nz
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         pbce(i,j,k) = pbce(i,j,k-1) + (GV%g_prime(K) * GV%H_to_Z) &
             * ((e(i,j,K) - e(i,j,nz+1)) * Ihtot(i,j))
-      enddo ; enddo
+      enddo
     enddo
-    !$omp end target
   endif
   !$omp end target data
 end subroutine Set_pbce_Bouss

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1733,7 +1733,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   allocate(wt_vel(nstep+nfilter)) ; allocate(wt_eta(nstep+nfilter))
   allocate(wt_trans(nstep+nfilter+1)) ; allocate(wt_accel(nstep+nfilter+1))
   allocate(wt_accel2(nstep+nfilter+1))
-  ! leaving above arrays to be managed by compiler
+  !$omp target enter data map(alloc: wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
   do concurrent (n=1:nstep+nfilter)
     ! Modify this to use a different filter...
 
@@ -1752,6 +1752,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     ! The rest should not be changed.
   enddo
   ! do sum reduction on CPU to preserve fp summation order (nstep+filter is small)
+  !$omp target update from(wt_vel, wt_eta)
   do n=1,nstep+nfilter
     sum_wt_vel = sum_wt_vel + wt_vel(n) ; sum_wt_eta = sum_wt_eta + wt_eta(n)
   enddo
@@ -1762,6 +1763,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     wt_accel(n) = wt_accel(n+1) + wt_vel(n)
     sum_wt_accel = sum_wt_accel + wt_accel(n) ; sum_wt_trans = sum_wt_trans + wt_trans(n)
   enddo
+  !$omp target update to(wt_trans, wt_accel)
   ! Normalize the weights.
   I_sum_wt_vel = 1.0 / sum_wt_vel ; I_sum_wt_accel = 1.0 / sum_wt_accel
   I_sum_wt_eta = 1.0 / sum_wt_eta ; I_sum_wt_trans = 1.0 / sum_wt_trans
@@ -1791,6 +1793,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   else
     I_sum_wt_vel = 1.0 ; I_sum_wt_eta = 1.0 ; I_sum_wt_accel = 1.0 ; I_sum_wt_trans = 1.0
   endif
+
+  !$omp target update from(wt_accel, wt_accel2) ! needed inside btstep_timeloop
 
   ! March the barotropic solver through all of its time steps.
   call btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL_v, eta_IC, &
@@ -2171,7 +2175,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
   !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, Datu, Datv, &
   !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF, &
-  !$omp       gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v)
+  !$omp       gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, wt_vel, wt_eta, &
+  !$omp       wt_trans, wt_accel, wt_accel2)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -854,6 +854,13 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 !--- end setup for group halo update
 
   !$omp target enter data &
+  !$omp   map(to: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, bc_accel_v, visc_rem_u, visc_rem_v, &
+  !$omp       forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, &
+  !$omp       CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, &
+  !$omp       CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, uh0, vh0) &
+  !$omp   map(alloc: eta_out, etaav)
+
+  !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, uhbt0, vhbt0, ubt_prev, vbt_prev, &
@@ -1525,7 +1532,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! Set the mass source, after first initializing the halos to 0.
   do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1) ; eta_src(i,j) = 0.0 ; enddo
   if (CS%bound_BT_corr) then ; if ((use_BT_Cont.or.integral_BT_cont) .and. CS%BT_cont_bounds) then
-    do concurrent (j=js:je, i=is:ie) ; if (G%mask2dT(i,j) > 0.0) then
+    do concurrent (j=js:je, i=is:ie) local(uint_cor, vint_cor, u_max_cor, v_max_cor, eta_cor_max); if (G%mask2dT(i,j) > 0.0) then
       if (CS%eta_cor(i,j) > 0.0) then
         !   Limit the source (outward) correction to be a fraction the mass that
         ! can be transported out of the cell by velocities with a CFL number of CFL_cor.
@@ -2175,6 +2182,13 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       Datu, Datv, f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, &
   !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, &
   !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2, PFu_avg, PFv_avg)
+
+  !$omp target exit data &
+  !$omp   map(release: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, bc_accel_v,visc_rem_u, &
+  !$omp       visc_rem_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, &
+  !$omp       CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, CS%ua_polarity, &
+  !$omp       CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, uh0, vh0) &
+  !$omp   map(from: eta_out, etaav)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -852,15 +852,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
 !--- end setup for group halo update
-
-  ! transfers of derived types and members being kept to minimize .attach. and .detach. data
-  !$omp target enter data &
-  !$omp   map(to: G, G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, forces, forces%taux, &
-  !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
-  !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
-  !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v)
-
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
@@ -2183,13 +2174,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       Datu, Datv, f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, &
   !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, &
   !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2, PFu_avg, PFv_avg)
-
-  !$omp target exit data &
-  !$omp   map(release: G, G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, forces, forces%taux, &
-  !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
-  !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
-  !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4360,11 +4360,15 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   if (present(h_u)) then
     do k=1,nz ; do j=js,je ; do I=is-1,ie
       CS%frhatu(I,j,k) = h_u(I,j,k)
+    enddo ; enddo ; enddo
+    do j=js,je ; do I=is-1,ie ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
     do k=1,nz ; do j=js,je ; do I=is-1,ie
       CS%frhatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
+    enddo ; enddo ; enddo
+    do j=js,je ; do I=is-1,ie ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
@@ -4387,6 +4391,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           CS%frhatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
+    enddo ; enddo ; enddo
+    do j=js,je ; do I=is-1,ie ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then
@@ -4438,11 +4444,15 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   if (present(h_v)) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
       CS%frhatv(i,J,k) = h_v(i,J,k)
+    enddo ; enddo ; enddo
+    do J=js-1,je ; do i=is,ie ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
       CS%frhatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
+    enddo ; enddo ; enddo
+    do J=js-1,je ; do i=is,ie ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
@@ -4465,6 +4475,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           CS%frhatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
+    enddo ; enddo ; enddo
+    do J=js-1,je ; do i=is,ie ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -856,10 +856,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
-  !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
-  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, Datu, Datv, &
-  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF, &
-  !$omp       gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v)
+  !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, uhbt0, vhbt0, ubt_prev, vbt_prev, &
+  !$omp       ubt_trans, vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, &
+  !$omp       Datu, Datv, f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, &
+  !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -1461,6 +1461,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
     ! The following halo update is not needed without wide halos.  RWH
     !$omp target update from(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
+    !$omp target update if(add_uh0) from(uhbt0, vhbt0)
     call start_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
   endif
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
@@ -1637,8 +1638,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       !$omp target update to(Datu, Datv)
     endif
     !$omp target update from(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
+    !$omp target update if(add_uh0) from(uhbt0, vhbt0)
     call do_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
     !$omp target update to(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
+    !$omp target update if(add_uh0) to(uhbt0, vhbt0)
   endif
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
   if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -1659,6 +1662,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     !$omp target update if(.not.interp_eta_PF) to(eta_PF)
     !$omp target update if(interp_eta_PF) to(eta_PF_1, d_eta_PF)
     !$omp target update if(CS%dynamic_psurf) to(dyn_coef_eta)
+    !$omp target update if(add_uh0) to(uhbt0, vhbt0)
 
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -2170,11 +2174,11 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp target exit data &
   !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
-  !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
-  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, Datu, Datv, &
-  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF, &
-  !$omp       gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, wt_vel, wt_eta, &
-  !$omp       wt_trans, wt_accel, wt_accel2)
+  !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, uhbt0, vhbt0, ubt_prev, vbt_prev, &
+  !$omp       ubt_trans, vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, &
+  !$omp       Datu, Datv, f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, &
+  !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, &
+  !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4826,32 +4826,26 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
   dt = 1.0 ; if (present(dt_baroclinic)) dt = dt_baroclinic
 
   ! Copy the BT_cont arrays into symmetric, potentially wide haloed arrays.
-  !$OMP parallel default(shared)
-  !$OMP do
-  do j=js-hs,je+hs ; do i=is-hs-1,ie+hs
+  do concurrent (j=js-hs:je+hs, i=is-hs-1:ie+hs)
     u_polarity(i,j) = 1.0
     uBT_EE(i,j) = 0.0 ; uBT_WW(i,j) = 0.0
     FA_u_EE(i,j) = 0.0 ; FA_u_E0(i,j) = 0.0 ; FA_u_W0(i,j) = 0.0 ; FA_u_WW(i,j) = 0.0
-  enddo ; enddo
-  !$OMP do
-  do j=js-hs-1,je+hs ; do i=is-hs,ie+hs
+  enddo
+  do concurrent (j=js-hs-1:je+hs, i=is-hs:ie+hs)
     v_polarity(i,j) = 1.0
     vBT_NN(i,j) = 0.0 ; vBT_SS(i,j) = 0.0
     FA_v_NN(i,j) = 0.0 ; FA_v_N0(i,j) = 0.0 ; FA_v_S0(i,j) = 0.0 ; FA_v_SS(i,j) = 0.0
-  enddo ; enddo
-  !$OMP do
-  do j=js,je ; do I=is-1,ie
+  enddo
+  do concurrent (j=js:je, I=is-1:ie)
     uBT_EE(I,j) = BT_cont%uBT_EE(I,j) ; uBT_WW(I,j) = BT_cont%uBT_WW(I,j)
     FA_u_EE(I,j) = BT_cont%FA_u_EE(I,j) ; FA_u_E0(I,j) = BT_cont%FA_u_E0(I,j)
     FA_u_W0(I,j) = BT_cont%FA_u_W0(I,j) ; FA_u_WW(I,j) = BT_cont%FA_u_WW(I,j)
-  enddo ; enddo
-  !$OMP do
-  do J=js-1,je ; do i=is,ie
+  enddo
+  do concurrent (J=js-1:je, i=is:ie)
     vBT_NN(i,J) = BT_cont%vBT_NN(i,J) ; vBT_SS(i,J) = BT_cont%vBT_SS(i,J)
     FA_v_NN(i,J) = BT_cont%FA_v_NN(i,J) ; FA_v_N0(i,J) = BT_cont%FA_v_N0(i,J)
     FA_v_S0(i,J) = BT_cont%FA_v_S0(i,J) ; FA_v_SS(i,J) = BT_cont%FA_v_SS(i,J)
-  enddo ; enddo
-  !$OMP end parallel
+  enddo
 
   if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
   if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
@@ -4871,9 +4865,7 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
   if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
 
-  !$OMP parallel default(shared)
-  !$OMP do
-  do j=js-hs,je+hs ; do I=is-hs-1,ie+hs
+  do concurrent (j=js-hs:je+hs, I=is-hs-1:ie+hs)
     BTCL_u(I,j)%FA_u_EE = FA_u_EE(I,j) ; BTCL_u(I,j)%FA_u_E0 = FA_u_E0(I,j)
     BTCL_u(I,j)%FA_u_W0 = FA_u_W0(I,j) ; BTCL_u(I,j)%FA_u_WW = FA_u_WW(I,j)
     BTCL_u(I,j)%uBT_EE = dt*uBT_EE(I,j)   ; BTCL_u(I,j)%uBT_WW = dt*uBT_WW(I,j)
@@ -4894,9 +4886,8 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
       (C1_3 * (BTCL_u(I,j)%FA_u_WW - BTCL_u(I,j)%FA_u_W0)) / BTCL_u(I,j)%uBT_WW**2
     if (abs(BTCL_u(I,j)%uBT_EE) > 0.0) BTCL_u(I,j)%uh_crvE = &
       (C1_3 * (BTCL_u(I,j)%FA_u_EE - BTCL_u(I,j)%FA_u_E0)) / BTCL_u(I,j)%uBT_EE**2
-  enddo ; enddo
-  !$OMP do
-  do J=js-hs-1,je+hs ; do i=is-hs,ie+hs
+  enddo
+  do concurrent (J=js-hs-1:je+hs, i=is-hs:ie+hs)
     BTCL_v(i,J)%FA_v_NN = FA_v_NN(i,J) ; BTCL_v(i,J)%FA_v_N0 = FA_v_N0(i,J)
     BTCL_v(i,J)%FA_v_S0 = FA_v_S0(i,J) ; BTCL_v(i,J)%FA_v_SS = FA_v_SS(i,J)
     BTCL_v(i,J)%vBT_NN = dt*vBT_NN(i,J)   ; BTCL_v(i,J)%vBT_SS = dt*vBT_SS(i,J)
@@ -4917,8 +4908,7 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
       (C1_3 * (BTCL_v(i,J)%FA_v_SS - BTCL_v(i,J)%FA_v_S0)) / BTCL_v(i,J)%vBT_SS**2
     if (abs(BTCL_v(i,J)%vBT_NN) > 0.0) BTCL_v(i,J)%vh_crvN = &
       (C1_3 * (BTCL_v(i,J)%FA_v_NN - BTCL_v(i,J)%FA_v_N0)) / BTCL_v(i,J)%vBT_NN**2
-  enddo ; enddo
-  !$OMP end parallel
+  enddo
 end subroutine set_local_BT_cont_types
 
 
@@ -5053,7 +5043,7 @@ subroutine BT_cont_to_face_areas(BT_cont, Datu, Datv, G, US, MS, halo)
 end subroutine BT_cont_to_face_areas
 
 !> Swap the values of two real variables
-subroutine swap(a,b)
+pure subroutine swap(a,b)
   real, intent(inout) :: a !< The first variable to be swapped [arbitrary units]
   real, intent(inout) :: b !< The second variable to be swapped [arbitrary units]
   real :: tmp ! A temporary variable [arbitrary units]

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3183,42 +3183,34 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
 
   ! The bracket bug only applies if v is second, use ioff to check.
   if (use_bracket_bug) then
-   !$OMP do schedule(static)
-   do J=Js_v,Je_v ; do i=is_v,ie_v
+   do concurrent (J=Js_v:Je_v, i=is_v:ie_v)
      Cor_v(i,J) = -1.0*(((f_4_v(1,i,J) * ubt(I-1,j)) + (f_4_v(2,i,J) * ubt(I,j))) + &
              ((f_4_v(4,i,J) * ubt(I,j+1)) + (f_4_v(3,i,J) * ubt(I-1,j+1)))) - Cor_ref_v(i,J)
-   enddo ; enddo
-   !$OMP end do nowait
+   enddo
   else
-   !$OMP do schedule(static)
-   do J=Js_v,Je_v ; do i=is_v,ie_v
+   do concurrent (J=Js_v:Je_v, i=is_v:ie_v)
      Cor_v(i,J) = -1.0*(((f_4_v(1,i,J) * ubt(I-1,j)) + (f_4_v(4,i,J) * ubt(I,j+1))) + &
              ((f_4_v(2,i,J) * ubt(I,j)) + (f_4_v(3,i,J) * ubt(I-1,j+1)))) - Cor_ref_v(i,J)
-   enddo ; enddo
-   !$OMP end do nowait
+   enddo
   endif
 
-  !$OMP do schedule(static)
   ! This updates the v-velocity, except at OBC points.
-  do J=Js_v,Je_v ; do i=is_v,ie_v
+  do concurrent (J=Js_v:Je_v, i=is_v:ie_v)
     vbt_prev(i,J) = vbt(i,J)
     vbt(i,J) = bt_rem_v(i,J) * (vbt(i,J) + &
          dtbt * ((BT_force_v(i,J) + Cor_v(i,J)) + PFv(i,J)))
     if (abs(vbt(i,J)) < CS%vel_underflow) vbt(i,J) = 0.0
-  enddo ; enddo
-  !$OMP end do nowait
+  enddo
 
   if (CS%linear_wave_drag) then
-    !$OMP do schedule(static)
-    do J=Js_v,Je_v ; do i=is_v,ie_v
+    do concurrent (J=Js_v:Je_v, i=is_v:ie_v)
       v_accel_bt(i,J) = v_accel_bt(i,J) + wt_accel_n * &
           ((Cor_v(i,J) + PFv(i,J)) - vbt(i,J)*Rayleigh_v(i,J))
-    enddo ; enddo
+    enddo
   else
-    !$OMP do schedule(static)
-    do J=Js_v,Je_v ; do i=is_v,ie_v
+    do concurrent (J=Js_v:Je_v, i=is_v:ie_v)
       v_accel_bt(i,J) = v_accel_bt(i,J) + wt_accel_n * (Cor_v(i,J) + PFv(i,J))
-    enddo ; enddo
+    enddo
   endif
 
 end subroutine btloop_update_v

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1218,10 +1218,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 ! Calculate the initial barotropic velocities from the layer's velocities.
   call btstep_ubt_from_layer(U_in, V_in, wt_u, wt_v, ubt, vbt, G, GV, CS)
 
-  do concurrent (j=SZJW_(CS), i=SZIBW_(CS))
+  do concurrent (j=CS%jsdw:CS%jedw, i=CS%isdw-1:CS%iedw)
     uhbt(i,j) = 0.0 ; u_accel_bt(i,j) = 0.0
   enddo
-  do concurrent (j=SZJBW_(CS), i=SZIW_(CS))
+  do concurrent (j=CS%jsdw-1:CS%jedw, i=CS%isdw:CS%iedw)
     vhbt(i,j) = 0.0 ; v_accel_bt(i,j) = 0.0
   enddo
 
@@ -2493,7 +2493,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     vbt_int(:,:) = 0.0 ; vhbt_int(:,:) = 0.0
   endif
 
-  do concurrent (j=SZJW_(CS), i=SZIW_(CS)) ; p_surf_dyn(i,j) = 0.0 ; enddo
+  do concurrent (j=CS%jsdw:CS%jedw, i=CS%isdw:CS%iedw) ; p_surf_dyn(i,j) = 0.0 ; enddo
 
   ! Set up the group pass used for halo updates within the barotropic time stepping loops.
   call create_group_pass(CS%pass_eta_ubt, eta, CS%BT_Domain)
@@ -3346,8 +3346,8 @@ subroutine btstep_ubt_from_layer(U_in, V_in, wt_u, wt_v, ubt, vbt,  G, GV, CS)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  do concurrent (j=SZJW_(CS), i=SZIBW_(CS)) ; ubt(i,j) = 0.0 ; enddo
-  do concurrent (j=SZJBW_(CS), i=SZIW_(CS)) ; vbt(i,j) = 0.0 ; enddo
+  do concurrent (j=CS%jsdw:CS%jedw, i=CS%isdw-1:CS%iedw) ; ubt(i,j) = 0.0 ; enddo
+  do concurrent (j=CS%jsdw-1:CS%jedw, i=CS%isdw:CS%iedw) ; vbt(i,j) = 0.0 ; enddo
 
   do k=1,nz ; do concurrent (j=js:je, I=is-1:ie)
     ubt(I,j) = ubt(I,j) + wt_u(I,j,k) * U_in(I,j,k)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -845,7 +845,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! share with the main part of the MOM6 code.
   if (find_etaav) then
     call create_group_pass(CS%pass_etaav, etaav, G%Domain)
-  endif                                                              
+  endif
   call create_group_pass(CS%pass_e_anom, e_anom, G%Domain)
   call create_group_pass(CS%pass_ubta_uhbta, CS%ubtav, CS%vbtav, G%Domain)
   call create_group_pass(CS%pass_ubta_uhbta, uhbtav, vhbtav, G%Domain)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4310,7 +4310,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   type(ocean_OBC_type), optional, pointer :: OBC !< Open boundary control structure.
 
   ! Local variables
-  real :: hatu(SZIB_(G),SZK_(GV)) ! The layer thicknesses interpolated to u points [H ~> m or kg m-2]
+  real :: hatu(SZIB_(G),SZJ_(G),SZK_(GV)) ! The layer thicknesses interpolated to u points [H ~> m or kg m-2]
   real :: hatv(SZI_(G),SZK_(GV))  ! The layer thicknesses interpolated to v points [H ~> m or kg m-2]
   real :: hatutot(SZIB_(G))    ! The sum of the layer thicknesses interpolated to u points [H ~> m or kg m-2].
   real :: hatvtot(SZI_(G))     ! The sum of the layer thicknesses interpolated to v points [H ~> m or kg m-2].
@@ -4365,13 +4365,13 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
 
     if (present(h_u)) then
       do k=1,nz ; do I=is-1,ie
-        hatu(I,k) = h_u(I,j,k)
-        hatutot(I) = hatutot(I) + hatu(I,k)
+        hatu(I,j,k) = h_u(I,j,k)
+        hatutot(I) = hatutot(I) + hatu(I,j,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == ARITHMETIC) then
       do k=1,nz ; do I=is-1,ie
-        hatu(I,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
-        hatutot(I) = hatutot(I) + hatu(I,k)
+        hatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
+        hatutot(I) = hatutot(I) + hatu(I,j,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HYBRID .or. use_default) then
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
@@ -4383,25 +4383,25 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
         e_u(I,K) = e_u(I,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
         h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
         if (e_u(I,K+1) >= D_shallow_u(I)) then
-          hatu(I,k) = h_arith
+          hatu(I,j,k) = h_arith
         else
           h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
           if (e_u(I,K) <= D_shallow_u(I)) then
-            hatu(I,k) = h_harm
+            hatu(I,j,k) = h_harm
           else
             wt_arith = (e_u(I,K) - D_shallow_u(I)) / (h_arith + h_neglect)
-            hatu(I,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+            hatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
-        hatutot(I) = hatutot(I) + hatu(I,k)
+        hatutot(I) = hatutot(I) + hatu(I,j,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HARMONIC) then
       !   Interpolates thicknesses onto u grid points with the
       ! second order accurate estimate h = 2*(h+ * h-)/(h+ + h-).
       do k=1,nz ; do I=is-1,ie
-        hatu(I,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
+        hatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
                         ((h(i+1,j,k) + h(i,j,k)) + h_neglect)
-        hatutot(I) = hatutot(I) + hatu(I,k)
+        hatutot(I) = hatutot(I) + hatu(I,j,k)
       enddo ; enddo
     endif
 
@@ -4412,8 +4412,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%u_OBC_type(I,j) > 0) then ! Eastern boundary condition
             hatutot(I) = 0.0
             do k=1,nz
-              hatu(I,k) = h(i,j,k)
-              hatutot(I) = hatutot(I) + hatu(I,k)
+              hatu(I,j,k) = h(i,j,k)
+              hatutot(I) = hatutot(I) + hatu(I,j,k)
             enddo
           endif
         enddo
@@ -4423,8 +4423,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%u_OBC_type(I,j) < 0) then ! Western boundary condition
             hatutot(I) = 0.0
             do k=1,nz
-              hatu(I,k) = h(i+1,j,k)
-              hatutot(I) = hatutot(I) + hatu(I,k)
+              hatu(I,j,k) = h(i+1,j,k)
+              hatutot(I) = hatutot(I) + hatu(I,j,k)
             enddo
           endif
         enddo
@@ -4434,7 +4434,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     ! Determine the fractional thickness of each layer at the velocity points.
     do I=is-1,ie ; Ihatutot(I) = G%mask2dCu(I,j) / (hatutot(I) + h_neglect) ; enddo
     do k=1,nz ; do I=is-1,ie
-      CS%frhatu(I,j,k) = hatu(I,k) * Ihatutot(I)
+      CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I)
     enddo ; enddo
   enddo
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3357,25 +3357,22 @@ subroutine btstep_ubt_from_layer(U_in, V_in, wt_u, wt_v, ubt, vbt,  G, GV, CS)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  ubt(:,:) = 0.0 ; vbt(:,:) = 0.0
+  do concurrent (j=SZJW_(CS), i=SZIBW_(CS)) ; ubt(i,j) = 0.0 ; enddo
+  do concurrent (j=SZJBW_(CS), i=SZIW_(CS)) ; vbt(i,j) = 0.0 ; enddo
 
-  !$OMP parallel do default(shared)
-  do j=js,je ; do k=1,nz ; do I=is-1,ie
+  do k=1,nz ; do concurrent (j=js:je, I=is-1:ie)
     ubt(I,j) = ubt(I,j) + wt_u(I,j,k) * U_in(I,j,k)
-  enddo ; enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=js-1,je ; do k=1,nz ; do i=is,ie
+  enddo ; enddo
+  do k=1,nz ; do concurrent (J=js-1:je, i=is:ie)
     vbt(i,J) = vbt(i,J) + wt_v(i,J,k) * V_in(i,J,k)
-  enddo ; enddo ;  enddo
+  enddo ; enddo
 
-  !$OMP parallel do default(shared)
-  do j=js,je ; do I=is-1,ie
+  do concurrent (j=js:je, I=is-1:ie)
     if (abs(ubt(I,j)) < CS%vel_underflow) ubt(I,j) = 0.0
-  enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=js-1,je ; do i=is,ie
+  enddo
+  do concurrent (J=js-1:je, i=is:ie)
     if (abs(vbt(i,J)) < CS%vel_underflow) vbt(i,J) = 0.0
-  enddo ; enddo
+  enddo
 
 end subroutine btstep_ubt_from_layer
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -855,7 +855,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
-  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt)
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -1605,10 +1605,13 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
   if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
   if (nonblock_setup) then
+    !$omp target update from(bt_rem_u, bt_rem_v)
     call start_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
     ! The following halo update is not needed without wide halos.  RWH
   else
+    !$omp target update from(bt_rem_u, bt_rem_v)
     call do_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
+    !$omp target update to(bt_rem_u, bt_rem_v)
     if (.not.use_BT_cont) &
       call do_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
     call do_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
@@ -1624,6 +1627,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (.not.use_BT_cont) call complete_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
     call complete_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
     call complete_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
+    !$omp target update to(bt_rem_u, bt_rem_v)
 
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -2131,7 +2135,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !$omp target exit data &
   !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
-  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt)
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4435,51 +4435,50 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I,j)
   enddo ; enddo ; enddo
 
-  !$OMP parallel do default(none) shared(is,ie,js,je,nz,CS,G,GV,h_v,h_neglect,h,use_default) &
-  !$OMP                          private(hatv,hatvtot,Ihatvtot,e_v,D_shallow_v,h_arith,h_harm,wt_arith,Z_to_H)
-  do J=js-1,je
-    do i=is,ie ; hatvtot(i,J) = 0.0 ; enddo
-    if (present(h_v)) then
-      do k=1,nz ; do i=is,ie
-        hatv(i,J,k) = h_v(i,J,k)
-        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
-      enddo ; enddo
-    elseif (CS%hvel_scheme == ARITHMETIC) then
-      do k=1,nz ; do i=is,ie
-        hatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
-        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
-      enddo ; enddo
-    elseif (CS%hvel_scheme == HYBRID .or. use_default) then
-      Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
-      do i=is,ie
-        e_v(i,J,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
-        D_shallow_v(i,J) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
-      enddo
-      do k=nz,1,-1 ; do i=is,ie
-        e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
-        h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
-        if (e_v(i,J,K+1) >= D_shallow_v(i,J)) then
-          hatv(i,J,k) = h_arith
-        else
-          h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
-          if (e_v(i,J,K) <= D_shallow_v(i,J)) then
-            hatv(i,J,k) = h_harm
-          else
-            wt_arith = (e_v(i,J,K) - D_shallow_v(i,J)) / (h_arith + h_neglect)
-            hatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
-          endif
-        endif
-        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
-      enddo ; enddo
-    elseif (CS%hvel_scheme == HARMONIC) then
-      do k=1,nz ; do i=is,ie
-        hatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
-                        ((h(i,j+1,k) + h(i,j,k)) + h_neglect)
-        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
-      enddo ; enddo
-    endif
+  do J=js-1,je ; do i=is,ie ; hatvtot(i,J) = 0.0 ; enddo ; enddo
 
-    if (CS%BT_OBC%v_OBCs_on_PE) then
+  if (present(h_v)) then
+    do k=1,nz ; do J=js-1,je ; do i=is,ie
+      hatv(i,J,k) = h_v(i,J,k)
+      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+    enddo ; enddo ; enddo
+  elseif (CS%hvel_scheme == ARITHMETIC) then
+    do k=1,nz ; do J=js-1,je ; do i=is,ie
+      hatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
+      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+    enddo ; enddo ; enddo
+  elseif (CS%hvel_scheme == HYBRID .or. use_default) then
+    Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
+    do J=js-1,je ; do i=is,ie
+      e_v(i,J,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
+      D_shallow_v(i,J) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
+    enddo ; enddo
+    do k=nz,1,-1 ; do J=js-1,je ; do i=is,ie
+      e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
+      h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
+      if (e_v(i,J,K+1) >= D_shallow_v(i,J)) then
+        hatv(i,J,k) = h_arith
+      else
+        h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
+        if (e_v(i,J,K) <= D_shallow_v(i,J)) then
+          hatv(i,J,k) = h_harm
+        else
+          wt_arith = (e_v(i,J,K) - D_shallow_v(i,J)) / (h_arith + h_neglect)
+          hatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+        endif
+      endif
+      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+    enddo ; enddo ; enddo
+  elseif (CS%hvel_scheme == HARMONIC) then
+    do k=1,nz ; do J=js-1,je ; do i=is,ie
+      hatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
+                      ((h(i,j+1,k) + h(i,j,k)) + h_neglect)
+      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+    enddo ; enddo ; enddo
+  endif
+
+  if (CS%BT_OBC%v_OBCs_on_PE) then
+    do J=js-1,je
       ! Reset v-velocity point thicknesses and their sums at OBC points
       if ((J >= CS%BT_OBC%Js_v_N_obc) .and. (J <= CS%BT_OBC%Je_v_N_obc)) then
         do i = max(is,CS%BT_OBC%is_v_N_obc), min(ie,CS%BT_OBC%ie_v_N_obc)
@@ -4503,14 +4502,14 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           endif
         enddo
       endif
-    endif
+    enddo
+  endif
 
-    ! Determine the fractional thickness of each layer at the velocity points.
-    do i=is,ie ; Ihatvtot(i,J) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo
-    do k=1,nz ; do i=is,ie
-      CS%frhatv(i,J,k) = hatv(i,J,k) * Ihatvtot(i,J)
-    enddo ; enddo
-  enddo
+  ! Determine the fractional thickness of each layer at the velocity points.
+  do J=js-1,je ; do i=is,ie ; Ihatvtot(i,J) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo ; enddo
+  do k=1,nz ; do J=js-1,je ; do i=is,ie
+    CS%frhatv(i,J,k) = hatv(i,J,k) * Ihatvtot(i,J)
+  enddo ; enddo ; enddo
 
   if (CS%debug) then
     call uvchksum("btcalc frhat[uv]", CS%frhatu, CS%frhatv, G%HI, &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -859,7 +859,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, uhbt0, vhbt0, ubt_prev, vbt_prev, &
   !$omp       ubt_trans, vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, &
   !$omp       Datu, Datv, f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, &
-  !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v)
+  !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, &
+  !$omp       PFu_avg, PFv_avg)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -2178,7 +2179,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       ubt_trans, vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, &
   !$omp       Datu, Datv, f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, &
   !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, &
-  !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
+  !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2, PFu_avg, PFv_avg)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1218,8 +1218,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 ! Calculate the initial barotropic velocities from the layer's velocities.
   call btstep_ubt_from_layer(U_in, V_in, wt_u, wt_v, ubt, vbt, G, GV, CS)
 
-  uhbt(:,:) = 0.0 ; vhbt(:,:) = 0.0
-  u_accel_bt(:,:) = 0.0 ; v_accel_bt(:,:) = 0.0
+  do concurrent (j=SZJW_(CS), i=SZIBW_(CS))
+    uhbt(i,j) = 0.0 ; u_accel_bt(i,j) = 0.0
+  enddo
+  do concurrent (j=SZJBW_(CS), i=SZIW_(CS))
+    vhbt(i,j) = 0.0 ; v_accel_bt(i,j) = 0.0
+  enddo
 
   if (apply_OBCs) then
     ubt_first(:,:) = ubt(:,:) ; vbt_first(:,:) = vbt(:,:)
@@ -1231,8 +1235,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 ! between the accelerations due to the average of the layer equations and the
 ! barotropic calculation.
 
-  !$OMP parallel do default(shared)
-  do j=js,je ; do I=is-1,ie ; if (G%mask2dCu(I,j) > 0.0) then
+  do concurrent (j=js:je, I=is-1:ie) local(Htot_avg) ; if (G%mask2dCu(I,j) > 0.0) then
     if (CS%nonlin_stress) then
       if (GV%Boussinesq) then
         Htot_avg = 0.5*(max(CS%bathyT(i,j)*GV%Z_to_H + eta(i,j), 0.0) + &
@@ -1256,9 +1259,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     BT_force_u(I,j) = forces%taux(I,j) * GV%RZ_to_H * CS%IDatu(I,j)*visc_rem_u(I,j,1)
   else
     BT_force_u(I,j) = 0.0
-  endif ; enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=js-1,je ; do i=is,ie ; if (G%mask2dCv(i,J) > 0.0) then
+  endif ; enddo
+  do concurrent (J=js-1:je, i=is:ie) local(Htot_avg) ; if (G%mask2dCv(i,J) > 0.0) then
     if (CS%nonlin_stress) then
       if (GV%Boussinesq) then
         Htot_avg = 0.5*(max(CS%bathyT(i,j)*GV%Z_to_H + eta(i,j), 0.0) + &
@@ -1282,7 +1284,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     BT_force_v(i,J) = forces%tauy(i,J) * GV%RZ_to_H * CS%IDatv(i,J)*visc_rem_v(i,J,1)
   else
     BT_force_v(i,J) = 0.0
-  endif ; enddo ; enddo
+  endif ; enddo
   if (associated(taux_bot) .and. associated(tauy_bot)) then
     !$OMP parallel do default(shared)
     do j=js,je ; do I=is-1,ie ; if (G%mask2dCu(I,j) > 0.0) then
@@ -1296,14 +1298,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! bc_accel_u & bc_accel_v are only available on the potentially
   ! non-symmetric computational domain.
-  !$OMP parallel do default(shared)
-  do j=js,je ; do k=1,nz ; do I=Isq,Ieq
+  do k=1,nz ; do concurrent (j=js:je, I=Isq:Ieq)
     BT_force_u(I,j) = BT_force_u(I,j) + wt_u(I,j,k) * bc_accel_u(I,j,k)
-  enddo ; enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=Jsq,Jeq ; do k=1,nz ; do i=is,ie
+  enddo ; enddo
+  do k=1,nz ; do concurrent (J=Jsq:Jeq, i=is:ie)
     BT_force_v(i,J) = BT_force_v(i,J) + wt_v(i,J,k) * bc_accel_v(i,J,k)
-  enddo ; enddo ; enddo
+  enddo ; enddo
 
   if (CS%gradual_BT_ICs) then
     !$OMP parallel do default(shared)
@@ -4547,7 +4547,7 @@ end function find_uhbt
 
 !> The function find_duhbt_du determines the marginal zonal face area for a given velocity, or
 !! with INTEGRAL_BT_CONT=True for a given time-integrated velocity.
-function find_duhbt_du(u, BTC) result(duhbt_du)
+pure function find_duhbt_du(u, BTC) result(duhbt_du)
   real, intent(in) :: u    !< The local zonal velocity [L T-1 ~> m s-1] or time integrated velocity [L ~> m]
   type(local_BT_cont_u_type), intent(in) :: BTC !< A structure containing various fields that
                            !! allow the barotropic transports to be calculated consistently
@@ -4680,7 +4680,7 @@ end function find_vhbt
 
 !> The function find_dvhbt_dv determines the marginal meridional face area for a given velocity, or
 !! with INTEGRAL_BT_CONT=True for a given time-integrated velocity.
-function find_dvhbt_dv(v, BTC) result(dvhbt_dv)
+pure function find_dvhbt_dv(v, BTC) result(dvhbt_dv)
   real, intent(in) :: v    !< The local meridional velocity [L T-1 ~> m s-1] or time integrated velocity [L ~> m]
   type(local_BT_cont_v_type), intent(in) :: BTC !< A structure containing various fields that
                            !! allow the barotropic transports to be calculated consistently

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2459,6 +2459,10 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     dtbt_diag = dt/(nstep+nfilter) ! Note that this is not dtbt.
   endif
 
+  !$omp target enter data &
+  !$omp   map(alloc: uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, vbt_trans, PFu, PFv, Cor_u, Cor_v, &
+  !$omp       p_surf_dyn)
+
   ! Zero out the arrays for various time-averaged quantities.
   if (find_etaav) then
     do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1)
@@ -2812,6 +2816,10 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
       endif
     endif
   enddo ! end of do n=1,ntimestep
+
+  !$omp target exit data &
+  !$omp   map(release: uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, vbt_trans, PFu, PFv, Cor_u, Cor_v, &
+  !$omp       p_surf_dyn)
 
   ! Reset the time information in the diag type.
   if (do_hifreq_output) call enable_averaging(time_int_in, time_end_in, CS%diag)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1444,38 +1444,29 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   endif
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
   if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
-  !$OMP parallel default(shared) private(u_max_cor,uint_cor,v_max_cor,vint_cor,eta_cor_max,Htot)
-  !$OMP do
-  do j=js-1,je+1 ; do I=is-1,ie ; av_rem_u(I,j) = 0.0 ; enddo ; enddo
-  !$OMP do
-  do J=js-1,je ; do i=is-1,ie+1 ; av_rem_v(i,J) = 0.0 ; enddo ; enddo
-  !$OMP do
-  do j=js,je ; do k=1,nz ; do I=is-1,ie
+  do concurrent (j=js-1:je+1, I=is-1:ie) ; av_rem_u(I,j) = 0.0 ; enddo
+  do concurrent (J=js-1:je, i=is-1:ie+1) ; av_rem_v(i,J) = 0.0 ; enddo
+  do k=1,nz ; do concurrent (j=js:je, I=is-1:ie)
     av_rem_u(I,j) = av_rem_u(I,j) + CS%frhatu(I,j,k) * visc_rem_u(I,j,k)
-  enddo ; enddo ; enddo
-  !$OMP do
-  do J=js-1,je ; do k=1,nz ; do i=is,ie
+  enddo ; enddo
+  do k=1,nz ; do concurrent (J=js-1:je, i=is:ie)
     av_rem_v(i,J) = av_rem_v(i,J) + CS%frhatv(i,J,k) * visc_rem_v(i,J,k)
-  enddo ; enddo ; enddo
+  enddo ; enddo
   if (CS%strong_drag) then
-    !$OMP do
     do j=js,je ; do I=is-1,ie
       bt_rem_u(I,j) = G%mask2dCu(I,j) * &
          ((nstep * av_rem_u(I,j)) / (1.0 + (nstep-1)*av_rem_u(I,j)))
     enddo ; enddo
-    !$OMP do
     do J=js-1,je ; do i=is,ie
       bt_rem_v(i,J) = G%mask2dCv(i,J) * &
          ((nstep * av_rem_v(i,J)) / (1.0 + (nstep-1)*av_rem_v(i,J)))
     enddo ; enddo
   else
-    !$OMP do
     do j=js,je ; do I=is-1,ie
       bt_rem_u(I,j) = 0.0
       if (G%mask2dCu(I,j) * av_rem_u(I,j) > 0.0) &
         bt_rem_u(I,j) = G%mask2dCu(I,j) * (av_rem_u(I,j)**Instep)
     enddo ; enddo
-    !$OMP do
     do J=js-1,je ; do i=is,ie
       bt_rem_v(i,J) = 0.0
       if (G%mask2dCv(i,J) * av_rem_v(i,J) > 0.0) &
@@ -1483,7 +1474,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     enddo ; enddo
   endif
   if (CS%linear_wave_drag) then
-    !$OMP do
     do j=js,je ; do I=is-1,ie ; if (CS%lin_drag_u(I,j) > 0.0) then
       Htot = 0.5 * (eta(i,j) + eta(i+1,j))
       if (GV%Boussinesq) &
@@ -1492,7 +1482,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
       Rayleigh_u(I,j) = CS%lin_drag_u(I,j) / Htot
     endif ; enddo ; enddo
-    !$OMP do
     do J=js-1,je ; do i=is,ie ; if (CS%lin_drag_v(i,J) > 0.0) then
       Htot = 0.5 * (eta(i,j) + eta(i,j+1))
       if (GV%Boussinesq) &
@@ -1505,20 +1494,17 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! Avoid changing the velocities at OBC points due to non-OBC calculations.
   if (CS%BT_OBC%u_OBCs_on_PE) then
-    !$OMP do
     do j=js,je ; do I=is-1,ie ; if (CS%BT_OBC%u_OBC_type(I,j) /= 0) then
       bt_rem_u(I,j) = 1.0
     endif ; enddo ; enddo
   endif
   if (CS%BT_OBC%v_OBCs_on_PE) then
-    !$OMP do
     do J=js-1,je ; do i=is,ie ; if (CS%BT_OBC%v_OBC_type(i,J) /= 0) then
       bt_rem_v(i,J) = 1.0
     endif ; enddo ; enddo
   endif
 
   ! Set the mass source, after first initializing the halos to 0.
-  !$OMP do
   do j=jsvf-1,jevf+1 ; do i=isvf-1,ievf+1 ; eta_src(i,j) = 0.0 ; enddo ; enddo
   if (CS%bound_BT_corr) then ; if ((use_BT_Cont.or.integral_BT_cont) .and. CS%BT_cont_bounds) then
     do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
@@ -1555,11 +1541,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (abs(CS%eta_cor(i,j)) > dt*CS%eta_cor_bound(i,j)) &
       CS%eta_cor(i,j) = sign(dt*CS%eta_cor_bound(i,j), CS%eta_cor(i,j))
   enddo ; enddo ; endif ; endif
-  !$OMP do
   do j=js,je ; do i=is,ie
     eta_src(i,j) = G%mask2dT(i,j) * (Instep * CS%eta_cor(i,j))
   enddo ; enddo
-  !$OMP end parallel
 
   if (CS%dynamic_psurf) then
     ice_is_rigid = (associated(forces%rigidity_ice_u) .and. &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3046,28 +3046,22 @@ subroutine btloop_find_PF(PFu, PFv, isv, iev, jsv, jev, eta_PF_BT, eta_PF, &
     is_v = isv ; ie_v = iev ; js_u = jsv-1 ; je_u = jev+1
   endif
 
-  !$OMP do schedule(static)
-  do j=js_u,je_u ; do I=isv-1,iev
+  do concurrent (j=js_u:je_u, I=isv-1:iev)
     PFu(I,j) = (((eta_PF_BT(i,j)-eta_PF(i,j))*gtot_E(i,j)) - &
                 ((eta_PF_BT(i+1,j)-eta_PF(i+1,j))*gtot_W(i+1,j))) * &
                 dgeo_de * CS%IdxCu(I,j)
-  enddo ; enddo
-  !$OMP end do nowait
+  enddo
 
-  !$OMP do schedule(static)
-  do J=jsv-1,jev ; do i=is_v,ie_v
+  do concurrent (J=jsv-1:jev, i=is_v:ie_v)
     PFv(i,J) = (((eta_PF_BT(i,j)-eta_PF(i,j))*gtot_N(i,j)) - &
                 ((eta_PF_BT(i,j+1)-eta_PF(i,j+1))*gtot_S(i,j+1))) * &
                 dgeo_de * CS%IdyCv(i,J)
-  enddo ; enddo
-  !$OMP end do nowait
+  enddo
 
   if (find_etaav .and. (abs(wt_accel2_n) > 0.0)) then
-    !$OMP do
-    do j=G%jsc,G%jec ; do i=G%isc,G%iec
+    do concurrent (j=G%jsc:G%jec, i=G%isc:G%iec)
       eta_sum(i,j) = eta_sum(i,j) + wt_accel2_n * eta_PF_BT(i,j)
-    enddo ; enddo
-    !$OMP end do nowait
+    enddo
   endif
 
 end subroutine btloop_find_PF

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2610,20 +2610,16 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     endif
 
     ! Contribute to the running sums of the transports and velocities.
-    !$OMP do
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       CS%ubtav(I,j) = CS%ubtav(I,j) + wt_trans(n) * ubt_trans(I,j)
       uhbtav(I,j) = uhbtav(I,j) + wt_trans(n) * uhbt(I,j)
       ubt_wtd(I,j) = ubt_wtd(I,j) + wt_vel(n) * ubt(I,j)
-    enddo ; enddo
-    !$OMP end do nowait
-    !$OMP do
-    do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent (J=js-1:je, i=is:ie)
       CS%vbtav(i,J) = CS%vbtav(i,J) + wt_trans(n) * vbt_trans(i,J)
       vhbtav(i,J) = vhbtav(i,J) + wt_trans(n) * vhbt(i,J)
       vbt_wtd(i,J) = vbt_wtd(i,J) + wt_vel(n) * vbt(i,J)
-    enddo ; enddo
-    !$OMP end do nowait
+    enddo
 
     if (CS%debug_bt) then
       call uvchksum("BT [uv]hbt just after OBC", uhbt, vhbt, CS%debug_BT_HI, haloshift=iev-ie, &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2391,42 +2391,36 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
 
   ! Zero out the arrays for various time-averaged quantities.
   if (find_etaav) then
-    !$OMP do
-    do j=jsvf-1,jevf+1 ; do i=isvf-1,ievf+1
+    do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1)
       eta_sum(i,j) = 0.0 ; eta_wtd(i,j) = 0.0
-    enddo ; enddo
+    enddo
   else
-    !$OMP do
-    do j=jsvf-1,jevf+1 ; do i=isvf-1,ievf+1
+    do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1)
       eta_wtd(i,j) = 0.0
-    enddo ; enddo
+    enddo
   endif
-  !$OMP do
-  do j=js,je ; do I=is-1,ie
+  do concurrent (j=js:je, I=is-1:ie)
     CS%ubtav(I,j) = 0.0 ; uhbtav(I,j) = 0.0
     PFu_avg(I,j) = 0.0 ; Coru_avg(I,j) = 0.0
     LDu_avg(I,j) = 0.0 ; ubt_wtd(I,j) = 0.0
-  enddo ; enddo
-  !$OMP do
-  do j=jsvf-1,jevf+1 ; do I=isvf-1,ievf
+  enddo
+  do concurrent (j=jsvf-1:jevf+1, I=isvf-1:ievf)
     ubt_trans(I,j) = 0.0
-  enddo ; enddo
-  !$OMP do
-  do J=js-1,je ; do i=is,ie
+  enddo
+  do concurrent (J=js-1:je, i=is:ie)
     CS%vbtav(i,J) = 0.0 ; vhbtav(i,J) = 0.0
     PFv_avg(i,J) = 0.0 ; Corv_avg(i,J) = 0.0
     LDv_avg(i,J) = 0.0 ; vbt_wtd(i,J) = 0.0
-  enddo ; enddo
-  !$OMP do
-  do J=jsvf-1,jevf ; do i=isvf-1,ievf+1
+  enddo
+  do concurrent (J=jsvf-1:jevf, i=isvf-1:ievf+1)
     vbt_trans(i,J) = 0.0
-  enddo ; enddo
+  enddo
   if (integral_BT_cont) then
     ubt_int(:,:) = 0.0 ; uhbt_int(:,:) = 0.0
     vbt_int(:,:) = 0.0 ; vhbt_int(:,:) = 0.0
   endif
 
-  p_surf_dyn(:,:) = 0.0
+  do concurrent (j=SZJW_(CS), i=SZIW_(CS)) ; p_surf_dyn(i,j) = 0.0 ; enddo
 
   ! Set up the group pass used for halo updates within the barotropic time stepping loops.
   call create_group_pass(CS%pass_eta_ubt, eta, CS%BT_Domain)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1039,36 +1039,30 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !   Use u_Cor and v_Cor as the reference values for the Coriolis terms,
   ! including the viscous remnant.
-  !$OMP parallel do default(shared)
-  do j=js-1,je+1 ; do I=is-1,ie ; ubt_Cor(I,j) = 0.0 ; enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=js-1,je ; do i=is-1,ie+1 ; vbt_Cor(i,J) = 0.0 ; enddo ; enddo
-  !$OMP parallel do default(shared)
-  do j=js,je ; do k=1,nz ; do I=is-1,ie
+  do concurrent (j=js-1:je+1, I=is-1:ie) ; ubt_Cor(I,j) = 0.0 ; enddo
+  do concurrent (J=js-1:je, i=is-1:ie+1) ; vbt_Cor(i,J) = 0.0 ; enddo
+  do k=1,nz ; do concurrent (j=js:je, I=is-1:ie)
     ubt_Cor(I,j) = ubt_Cor(I,j) + wt_u(I,j,k) * U_Cor(I,j,k)
-  enddo ; enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=js-1,je ; do k=1,nz ; do i=is,ie
+  enddo ; enddo
+  do k=1,nz ; do concurrent (J=js-1:je, i=is:ie)
     vbt_Cor(i,J) = vbt_Cor(i,J) + wt_v(i,J,k) * V_Cor(i,J,k)
-  enddo ; enddo ; enddo
+  enddo ; enddo
 
   ! The gtot arrays are the effective layer-weighted reduced gravities for
   ! accelerations across the various faces, with names for the relative
   ! locations of the faces to the pressure point.  They will have their halos
   ! updated later on.
-  !$OMP parallel do default(shared)
-  do j=js,je
-    do k=1,nz ; do I=is-1,ie
+  do k=1,nz
+    do concurrent (j=js:je, i=is-1:ie)
       gtot_E(i,j)   = gtot_E(i,j)   + pbce(i,j,k)   * wt_u(I,j,k)
       gtot_W(i+1,j) = gtot_W(i+1,j) + pbce(i+1,j,k) * wt_u(I,j,k)
-    enddo ; enddo
+    enddo
   enddo
-  !$OMP parallel do default(shared)
-  do J=js-1,je
-    do k=1,nz ; do i=is,ie
+  do k=1,nz
+    do concurrent (J=js-1:je, i=is:ie)
       gtot_N(i,j)   = gtot_N(i,j)   + pbce(i,j,k)   * wt_v(i,J,k)
       gtot_S(i,j+1) = gtot_S(i,j+1) + pbce(i,j+1,k) * wt_v(i,J,k)
-    enddo ; enddo
+    enddo
   enddo
 
   if (CS%BT_OBC%u_OBCs_on_PE) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -6109,6 +6109,7 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
     id_clock_sync = cpu_clock_id('(Ocean BT global synch)', grain=CLOCK_ROUTINE)
 
   ! send initialized data to GPU
+  !$omp target enter data map(to: CS)
   !$omp target enter data map(to: CS%bathyT)
   !$omp target enter data map(to: CS%D_u_Cor, CS%D_v_Cor)
   !$omp target enter data map(to: CS%dx_Cv, CS%dy_Cu)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -853,7 +853,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
 !--- end setup for group halo update
 
-  !$omp target enter data map(alloc: ubt_Cor, vbt_Cor)
+  !$omp target enter data &
+  !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -913,10 +915,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     ! These calculations can be done almost immediately, but the halo updates
     ! must be done before the [abcd]mer and [abcd]zon are calculated.
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
+    !$omp target update from(q)
     if (nonblock_setup) then
       call start_group_pass(CS%pass_q_DCor, CS%BT_Domain, clock=id_clock_pass_pre)
     else
       call do_group_pass(CS%pass_q_DCor, CS%BT_Domain, clock=id_clock_pass_pre)
+      !$omp target update to(q)
     endif
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
   endif
@@ -1098,6 +1102,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (nonblock_setup .and. .not.CS%linearized_BT_PV) then
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
     call complete_group_pass(CS%pass_q_DCor, CS%BT_Domain, clock=id_clock_pass_pre)
+      !$omp target update to(q)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
   endif
 
@@ -1810,11 +1815,13 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   if (id_clock_calc_post > 0) call cpu_clock_end(id_clock_calc_post)
   if (id_clock_pass_post > 0) call cpu_clock_begin(id_clock_pass_post)
+  !$omp target update from(e_anom)
   if (G%nonblocking_updates) then
     call start_group_pass(CS%pass_e_anom, G%Domain)
   else
     if (find_etaav) call do_group_pass(CS%pass_etaav, G%Domain)
     call do_group_pass(CS%pass_e_anom, G%Domain)
+    !$omp target update to(e_anom)
   endif
   if (id_clock_pass_post > 0) call cpu_clock_end(id_clock_pass_post)
   if (id_clock_calc_post > 0) call cpu_clock_begin(id_clock_calc_post)
@@ -1858,6 +1865,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     call complete_group_pass(CS%pass_e_anom, G%Domain)
     if (find_etaav) call start_group_pass(CS%pass_etaav, G%Domain)
     call start_group_pass(CS%pass_ubta_uhbta, G%DoMain)
+    !$omp target update to(e_anom)
   else
     call do_group_pass(CS%pass_ubta_uhbta, G%Domain)
   endif
@@ -2119,7 +2127,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 
-  !$omp target exit data map(release: ubt_Cor, vbt_Cor)
+  !$omp target exit data &
+  !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4310,8 +4310,6 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   type(ocean_OBC_type), optional, pointer :: OBC !< Open boundary control structure.
 
   ! Local variables
-  real :: hatu(SZIB_(G),SZJ_(G),SZK_(GV)) ! The layer thicknesses interpolated to u points [H ~> m or kg m-2]
-  real :: hatv(SZI_(G),SZJB_(G),SZK_(GV))  ! The layer thicknesses interpolated to v points [H ~> m or kg m-2]
   real :: hatutot(SZIB_(G),SZJ_(G))    ! The sum of the layer thicknesses interpolated to u points [H ~> m or kg m-2].
   real :: hatvtot(SZI_(G),SZJB_(G))     ! The sum of the layer thicknesses interpolated to v points [H ~> m or kg m-2].
   real :: Ihatutot(SZIB_(G),SZJ_(G))   ! Ihatutot is the inverse of hatutot [H-1 ~> m-1 or m2 kg-1].
@@ -4361,13 +4359,13 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
 
   if (present(h_u)) then
     do k=1,nz ; do j=js,je ; do I=is-1,ie
-      hatu(I,j,k) = h_u(I,j,k)
-      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+      CS%frhatu(I,j,k) = h_u(I,j,k)
+      hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
     do k=1,nz ; do j=js,je ; do I=is-1,ie
-      hatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
-      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+      CS%frhatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
+      hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
@@ -4379,25 +4377,25 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
       h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
       if (e_u(I,j,K+1) >= D_shallow_u(I,j)) then
-        hatu(I,j,k) = h_arith
+        CS%frhatu(I,j,k) = h_arith
       else
         h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
         if (e_u(I,j,K) <= D_shallow_u(I,j)) then
-          hatu(I,j,k) = h_harm
+          CS%frhatu(I,j,k) = h_harm
         else
           wt_arith = (e_u(I,j,K) - D_shallow_u(I,j)) / (h_arith + h_neglect)
-          hatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+          CS%frhatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
-      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+      hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then
     !   Interpolates thicknesses onto u grid points with the
     ! second order accurate estimate h = 2*(h+ * h-)/(h+ + h-).
     do k=1,nz ; do j=js,je ; do I=is-1,ie
-      hatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
+      CS%frhatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
                       ((h(i+1,j,k) + h(i,j,k)) + h_neglect)
-      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+      hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   endif
 
@@ -4409,8 +4407,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%u_OBC_type(I,j) > 0) then ! Eastern boundary condition
             hatutot(I,j) = 0.0
             do k=1,nz
-              hatu(I,j,k) = h(i,j,k)
-              hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+              CS%frhatu(I,j,k) = h(i,j,k)
+              hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
             enddo
           endif
         enddo
@@ -4420,8 +4418,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%u_OBC_type(I,j) < 0) then ! Western boundary condition
             hatutot(I,j) = 0.0
             do k=1,nz
-              hatu(I,j,k) = h(i+1,j,k)
-              hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+              CS%frhatu(I,j,k) = h(i+1,j,k)
+              hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
             enddo
           endif
         enddo
@@ -4432,20 +4430,20 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   ! Determine the fractional thickness of each layer at the velocity points.
   do j=js,je ; do I=is-1,ie ; Ihatutot(I,j) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo ; enddo
   do k=1,nz ; do j=js,je ; do I=is-1,ie
-    CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I,j)
+    CS%frhatu(I,j,k) = CS%frhatu(I,j,k) * Ihatutot(I,j)
   enddo ; enddo ; enddo
 
   do J=js-1,je ; do i=is,ie ; hatvtot(i,J) = 0.0 ; enddo ; enddo
 
   if (present(h_v)) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
-      hatv(i,J,k) = h_v(i,J,k)
-      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+      CS%frhatv(i,J,k) = h_v(i,J,k)
+      hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
-      hatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
-      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+      CS%frhatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
+      hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
@@ -4457,23 +4455,23 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
       h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
       if (e_v(i,J,K+1) >= D_shallow_v(i,J)) then
-        hatv(i,J,k) = h_arith
+        CS%frhatv(i,J,k) = h_arith
       else
         h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
         if (e_v(i,J,K) <= D_shallow_v(i,J)) then
-          hatv(i,J,k) = h_harm
+          CS%frhatv(i,J,k) = h_harm
         else
           wt_arith = (e_v(i,J,K) - D_shallow_v(i,J)) / (h_arith + h_neglect)
-          hatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+          CS%frhatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
-      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+      hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
-      hatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
+      CS%frhatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
                       ((h(i,j+1,k) + h(i,j,k)) + h_neglect)
-      hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+      hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   endif
 
@@ -4485,8 +4483,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%v_OBC_type(i,J) > 0) then ! Northern boundary condition
             hatvtot(i,J) = 0.0
             do k=1,nz
-              hatv(i,J,k) = h(i,j,k)
-              hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+              CS%frhatv(i,J,k) = h(i,j,k)
+              hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
             enddo
           endif
         enddo
@@ -4496,8 +4494,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%v_OBC_type(i,J) < 0) then ! Southern boundary condition
             hatvtot(i,J) = 0.0
             do k=1,nz
-              hatv(i,J,k) = h(i,j+1,k)
-              hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
+              CS%frhatv(i,J,k) = h(i,j+1,k)
+              hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
             enddo
           endif
         enddo
@@ -4508,7 +4506,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   ! Determine the fractional thickness of each layer at the velocity points.
   do J=js-1,je ; do i=is,ie ; Ihatvtot(i,J) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo ; enddo
   do k=1,nz ; do J=js-1,je ; do i=is,ie
-    CS%frhatv(i,J,k) = hatv(i,J,k) * Ihatvtot(i,J)
+    CS%frhatv(i,J,k) = CS%frhatv(i,J,k) * Ihatvtot(i,J)
   enddo ; enddo ; enddo
 
   if (CS%debug) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -859,7 +859,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
   !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
   !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v, uh0, vh0)
+  !$omp       CS%OBCmask_v, uh0, vh0, BT_cont, BT_cont%FA_u_E0, BT_cont%FA_u_EE, BT_cont%FA_u_W0, &
+  !$omp       BT_cont%FA_u_WW, BT_cont%FA_v_N0, BT_cont%FA_v_NN, BT_cont%FA_v_S0, BT_cont%FA_v_SS, &
+  !$omp       BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, BT_cont%vBT_SS)
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
@@ -2189,7 +2191,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
   !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
   !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v, uh0, vh0)
+  !$omp       CS%OBCmask_v, uh0, vh0, BT_cont, BT_cont%FA_u_E0, BT_cont%FA_u_EE, BT_cont%FA_u_W0, &
+  !$omp       BT_cont%FA_u_WW, BT_cont%FA_v_N0, BT_cont%FA_v_NN, BT_cont%FA_v_S0, BT_cont%FA_v_SS, &
+  !$omp       BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, BT_cont%vBT_SS)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -993,8 +993,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     enddo ; enddo
   endif
 
-  !$OMP parallel do default(shared) private(visc_rem)
-  do k=1,nz ; do j=js,je ; do I=is-1,ie
+  do concurrent (k=1:nz, j=js:je, I=is-1:ie) local(visc_rem)
     ! rem needs to be greater than visc_rem_u and 1-Instep/visc_rem_u.
     ! The 0.5 below is just for safety.
     ! NOTE: subroundoff is a negligible value used to prevent division by zero.
@@ -1005,15 +1004,14 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     visc_rem = max(visc_rem, 1. - 0.5 * Instep / (visc_rem + subroundoff))
     visc_rem = max(visc_rem, 0.)
     wt_u(I,j,k) = CS%frhatu(I,j,k) * visc_rem
-  enddo ; enddo ; enddo
-  !$OMP parallel do default(shared) private(visc_rem)
-  do k=1,nz ; do J=js-1,je ; do i=is,ie
+  enddo
+  do concurrent (k=1:nz, J=js-1:je, i=is:ie) local(visc_rem)
     ! As above, rem must be greater than visc_rem_v and 1-Instep/visc_rem_v.
     visc_rem = min(visc_rem_v(I,j,k), 1.)
     visc_rem = max(visc_rem, 1. - 0.5 * Instep / (visc_rem + subroundoff))
     visc_rem = max(visc_rem, 0.)
     wt_v(i,J,k) = CS%frhatv(i,J,k) * visc_rem
-  enddo ; enddo ; enddo
+  enddo
 
   if (.not. CS%wt_uv_bug) then
     do j=js,je ; do I=is-1,ie ; Iwt_u_tot(I,j) = wt_u(I,j,1) ; enddo ; enddo

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4360,11 +4360,15 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   if (present(h_u)) then
     do k=1,nz ; do j=js,je ; do I=is-1,ie
       CS%frhatu(I,j,k) = h_u(I,j,k)
+    enddo ; enddo ; enddo
+    do j=js,je ; do I=is-1,ie ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
     do k=1,nz ; do j=js,je ; do I=is-1,ie
       CS%frhatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
+    enddo ; enddo ; enddo
+    do j=js,je ; do I=is-1,ie ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
@@ -4387,6 +4391,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           CS%frhatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
+    enddo ; enddo ; enddo
+    do j=js,je ; do I=is-1,ie ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then
@@ -4395,6 +4401,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     do k=1,nz ; do j=js,je ; do I=is-1,ie
       CS%frhatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
                       ((h(i+1,j,k) + h(i,j,k)) + h_neglect)
+    enddo ; enddo ; enddo
+    do j=js,je ; do I=is-1,ie ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo ; enddo
   endif
@@ -4438,11 +4446,15 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   if (present(h_v)) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
       CS%frhatv(i,J,k) = h_v(i,J,k)
+    enddo ; enddo ; enddo
+    do J=js-1,je ; do i=is,ie ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
       CS%frhatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
+    enddo ; enddo ; enddo
+    do J=js-1,je ; do i=is,ie ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
@@ -4465,12 +4477,16 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           CS%frhatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
+    enddo ; enddo ; enddo
+    do J=js-1,je ; do i=is,ie ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then
     do k=1,nz ; do J=js-1,je ; do i=is,ie
       CS%frhatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
                       ((h(i,j+1,k) + h(i,j,k)) + h_neglect)
+    enddo ; enddo ; enddo
+    do J=js-1,je ; do i=is,ie ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo ; enddo
   endif

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1684,7 +1684,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   allocate(wt_vel(nstep+nfilter)) ; allocate(wt_eta(nstep+nfilter))
   allocate(wt_trans(nstep+nfilter+1)) ; allocate(wt_accel(nstep+nfilter+1))
   allocate(wt_accel2(nstep+nfilter+1))
-  do n=1,nstep+nfilter
+  do concurrent (n=1:nstep+nfilter)
     ! Modify this to use a different filter...
 
     ! This is a filter that ramps down linearly over a time dt_filt.
@@ -1700,8 +1700,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     ! wt_eta(n) = wt_vel(n)
 
     ! The rest should not be changed.
+  enddo
+  ! do sum reduction on CPU to preserve fp summation order (nstep+filter is small)
+  do n=1,nstep+nfilter
     sum_wt_vel = sum_wt_vel + wt_vel(n) ; sum_wt_eta = sum_wt_eta + wt_eta(n)
   enddo
+  ! leaving this prefix sum on CPU, but could be ported using openmp scan
   wt_trans(nstep+nfilter+1) = 0.0 ; wt_accel(nstep+nfilter+1) = 0.0
   do n=nstep+nfilter,1,-1
     wt_trans(n) = wt_trans(n+1) + wt_eta(n)
@@ -1711,7 +1715,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! Normalize the weights.
   I_sum_wt_vel = 1.0 / sum_wt_vel ; I_sum_wt_accel = 1.0 / sum_wt_accel
   I_sum_wt_eta = 1.0 / sum_wt_eta ; I_sum_wt_trans = 1.0 / sum_wt_trans
-  do n=1,nstep+nfilter
+  do concurrent (n=1:nstep+nfilter)
     wt_vel(n) = wt_vel(n) * I_sum_wt_vel
     if (CS%answer_date < 20190101) then
       wt_accel2(n) = wt_accel(n)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4375,7 +4375,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   h_neglect = GV%H_subroundoff
 
-  do j=js,je ; do I=is-1,ie ; hatutot(I,j) = 0.0 ; enddo ; enddo
+  !$omp target enter data map(alloc: hatutot, hatvtot, Ihatutot, Ihatvtot, CS, CS%frhatu, CS%frhatv) &
+  !$omp   map(to: h_u, h_v)
+
+  do concurrent (j=js:je, I=is-1:ie) ; hatutot(I,j) = 0.0 ; enddo
 
   if (present(h_u)) then
     do concurrent (k=1:nz, j=js:je, I=is-1:ie)
@@ -4393,6 +4396,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
+    !$omp target data map(alloc: e_u, D_shallow_u)
     do concurrent (j=js:je, I=is-1:ie)
       e_u(I,j,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
       D_shallow_u(I,j) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
@@ -4412,6 +4416,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
         endif
       endif
     enddo
+    !$omp end target data
     do concurrent (j=js:je, I=is-1:ie) ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
     enddo ; enddo
@@ -4482,6 +4487,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
+    !$omp target data map(alloc: e_v, D_shallow_v)
     do concurrent (J=js-1:je, i=is:ie)
       e_v(i,J,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
       D_shallow_v(i,J) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
@@ -4501,6 +4507,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
         endif
       endif
     enddo
+    !$omp end target data
     do concurrent (J=js-1:je, i=is:ie) ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
     enddo ; enddo
@@ -4550,6 +4557,9 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   do concurrent (k=1:nz, J=js-1:je, i=is:ie)
     CS%frhatv(i,J,k) = CS%frhatv(i,J,k) * Ihatvtot(i,J)
   enddo
+
+  !$omp target exit data map(release: hatutot, hatvtot, Ihatutot, Ihatvtot, h_u, h_v, CS) &
+  !$omp   map(from: CS%frhatu, CS%frhatv)
 
   if (CS%debug) then
     call uvchksum("btcalc frhat[uv]", CS%frhatu, CS%frhatv, G%HI, &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1127,10 +1127,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! Determine the difference between the sum of the layer fluxes and the
   ! barotropic fluxes found from the same input velocities.
   if (add_uh0) then
-    !$OMP parallel do default(shared)
-    do j=js,je ; do I=is-1,ie ; uhbt(I,j) = 0.0 ; ubt(I,j) = 0.0 ; enddo ; enddo
-    !$OMP parallel do default(shared)
-    do J=js-1,je ; do i=is,ie ; vhbt(i,J) = 0.0 ; vbt(i,J) = 0.0 ; enddo ; enddo
+    do concurrent (j=js:je, I=is-1:ie) ; uhbt(I,j) = 0.0 ; ubt(I,j) = 0.0 ; enddo
+    do concurrent (J=js-1:je, i=is:ie) ; vhbt(i,J) = 0.0 ; vbt(i,J) = 0.0 ; enddo
     if (CS%visc_rem_u_uh0) then
       !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nz ; do I=is-1,ie
@@ -1143,16 +1141,14 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
         vbt(i,J) = vbt(i,J) + wt_v(i,J,k) * v_vh0(i,J,k)
       enddo ; enddo ; enddo
     else
-      !$OMP parallel do default(shared)
-      do j=js,je ; do k=1,nz ; do I=is-1,ie
+      do k=1,nz ; do concurrent (j=js:je, I=is-1:ie)
         uhbt(I,j) = uhbt(I,j) + uh0(I,j,k)
         ubt(I,j) = ubt(I,j) + CS%frhatu(I,j,k) * u_uh0(I,j,k)
-      enddo ; enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=js-1,je ; do k=1,nz ; do i=is,ie
+      enddo ; enddo
+      do k=1,nz ; do concurrent (J=js-1:je, i=is:ie)
         vhbt(i,J) = vhbt(i,J) + vh0(i,J,k)
         vbt(i,J) = vbt(i,J) + CS%frhatv(i,J,k) * v_vh0(i,J,k)
-      enddo ; enddo ; enddo
+      enddo ; enddo
     endif
     if ((use_BT_cont .or. integral_BT_cont) .and. CS%adjust_BT_cont) then
       ! Use the additional input transports to broaden the fits
@@ -1184,14 +1180,17 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
         vhbt0(i,J) = vhbt(i,J) - find_vhbt(dt*vbt(i,J), BTCL_v(i,J)) * Idt
       enddo ; enddo
     elseif (use_BT_cont) then
-      !$OMP parallel do default(shared)
-      do j=js,je ; do I=is-1,ie
+      ! target data stmt to ensure only the affected parts of the array are
+      ! returned to the CPU. Not sure why it's returning the whole uhbt0/vhbt0 -
+      ! some of which is garbage
+      !$omp target data map(from: uhbt0(is-1:ie, js:ie), vhbt0(is:ie, js-1:je))
+      do concurrent (j=js:je, I=is-1:ie)
         uhbt0(I,j) = uhbt(I,j) - find_uhbt(ubt(I,j), BTCL_u(I,j))
-      enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=js-1,je ; do i=is,ie
+      enddo
+      do concurrent (J=js-1:je, i=is:ie)
         vhbt0(i,J) = vhbt(i,J) - find_vhbt(vbt(i,J), BTCL_v(i,J))
-      enddo ; enddo
+      enddo
+      !$omp end target data
     else
       !$OMP parallel do default(shared)
       do j=js,je ; do I=is-1,ie
@@ -4526,7 +4525,7 @@ end subroutine btcalc
 !> The function find_uhbt determines the zonal transport for a given velocity, or with
 !! INTEGRAL_BT_CONT=True it determines the time-integrated zonal transport for a given
 !! time-integrated velocity.
-function find_uhbt(u, BTC) result(uhbt)
+pure function find_uhbt(u, BTC) result(uhbt)
   real, intent(in) :: u    !< The local zonal velocity [L T-1 ~> m s-1] or time integrated velocity [L ~> m]
   type(local_BT_cont_u_type), intent(in) :: BTC !< A structure containing various fields that
                            !! allow the barotropic transports to be calculated consistently
@@ -4660,7 +4659,7 @@ end function uhbt_to_ubt
 !> The function find_vhbt determines the meridional transport for a given velocity, or with
 !! INTEGRAL_BT_CONT=True it determines the time-integrated meridional transport for a given
 !! time-integrated velocity.
-function find_vhbt(v, BTC) result(vhbt)
+pure function find_vhbt(v, BTC) result(vhbt)
   real, intent(in) :: v    !< The local meridional velocity [L T-1 ~> m s-1] or time integrated velocity [L ~> m]
   type(local_BT_cont_v_type), intent(in) :: BTC !< A structure containing various fields that
                            !! allow the barotropic transports to be calculated consistently

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4312,8 +4312,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   ! Local variables
   real :: hatu(SZIB_(G),SZJ_(G),SZK_(GV)) ! The layer thicknesses interpolated to u points [H ~> m or kg m-2]
   real :: hatv(SZI_(G),SZJB_(G),SZK_(GV))  ! The layer thicknesses interpolated to v points [H ~> m or kg m-2]
-  real :: hatutot(SZIB_(G))    ! The sum of the layer thicknesses interpolated to u points [H ~> m or kg m-2].
-  real :: hatvtot(SZI_(G))     ! The sum of the layer thicknesses interpolated to v points [H ~> m or kg m-2].
+  real :: hatutot(SZIB_(G),SZJ_(G))    ! The sum of the layer thicknesses interpolated to u points [H ~> m or kg m-2].
+  real :: hatvtot(SZI_(G),SZJB_(G))     ! The sum of the layer thicknesses interpolated to v points [H ~> m or kg m-2].
   real :: Ihatutot(SZIB_(G))   ! Ihatutot is the inverse of hatutot [H-1 ~> m-1 or m2 kg-1].
   real :: Ihatvtot(SZI_(G))    ! Ihatvtot is the inverse of hatvtot [H-1 ~> m-1 or m2 kg-1].
   real :: h_arith              ! The arithmetic mean thickness [H ~> m or kg m-2].
@@ -4361,17 +4361,17 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   !$OMP parallel do default(none) shared(is,ie,js,je,nz,h_u,CS,h_neglect,h,use_default,G,GV) &
   !$OMP                          private(hatu,hatutot,Ihatutot,e_u,D_shallow_u,h_arith,h_harm,wt_arith,Z_to_H)
   do j=js,je
-    do I=is-1,ie ; hatutot(I) = 0.0 ; enddo
+    do I=is-1,ie ; hatutot(I,j) = 0.0 ; enddo
 
     if (present(h_u)) then
       do k=1,nz ; do I=is-1,ie
         hatu(I,j,k) = h_u(I,j,k)
-        hatutot(I) = hatutot(I) + hatu(I,j,k)
+        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == ARITHMETIC) then
       do k=1,nz ; do I=is-1,ie
         hatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
-        hatutot(I) = hatutot(I) + hatu(I,j,k)
+        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HYBRID .or. use_default) then
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
@@ -4393,7 +4393,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
             hatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
-        hatutot(I) = hatutot(I) + hatu(I,j,k)
+        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HARMONIC) then
       !   Interpolates thicknesses onto u grid points with the
@@ -4401,7 +4401,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       do k=1,nz ; do I=is-1,ie
         hatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
                         ((h(i+1,j,k) + h(i,j,k)) + h_neglect)
-        hatutot(I) = hatutot(I) + hatu(I,j,k)
+        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
       enddo ; enddo
     endif
 
@@ -4410,10 +4410,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       if ((j >= CS%BT_OBC%js_u_E_obc) .and. (j <= CS%BT_OBC%je_u_E_obc)) then
         do I = max(is-1,CS%BT_OBC%Is_u_E_obc), min(ie,CS%BT_OBC%Ie_u_E_obc)
           if (CS%BT_OBC%u_OBC_type(I,j) > 0) then ! Eastern boundary condition
-            hatutot(I) = 0.0
+            hatutot(I,j) = 0.0
             do k=1,nz
               hatu(I,j,k) = h(i,j,k)
-              hatutot(I) = hatutot(I) + hatu(I,j,k)
+              hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
             enddo
           endif
         enddo
@@ -4421,10 +4421,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       if ((j >= CS%BT_OBC%js_u_W_obc) .and. (j <= CS%BT_OBC%je_u_W_obc)) then
         do I = max(is-1,CS%BT_OBC%Is_u_W_obc), min(ie,CS%BT_OBC%Ie_u_W_obc)
           if (CS%BT_OBC%u_OBC_type(I,j) < 0) then ! Western boundary condition
-            hatutot(I) = 0.0
+            hatutot(I,j) = 0.0
             do k=1,nz
               hatu(I,j,k) = h(i+1,j,k)
-              hatutot(I) = hatutot(I) + hatu(I,j,k)
+              hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
             enddo
           endif
         enddo
@@ -4432,7 +4432,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     endif
 
     ! Determine the fractional thickness of each layer at the velocity points.
-    do I=is-1,ie ; Ihatutot(I) = G%mask2dCu(I,j) / (hatutot(I) + h_neglect) ; enddo
+    do I=is-1,ie ; Ihatutot(I) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo
     do k=1,nz ; do I=is-1,ie
       CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I)
     enddo ; enddo
@@ -4441,16 +4441,16 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   !$OMP parallel do default(none) shared(is,ie,js,je,nz,CS,G,GV,h_v,h_neglect,h,use_default) &
   !$OMP                          private(hatv,hatvtot,Ihatvtot,e_v,D_shallow_v,h_arith,h_harm,wt_arith,Z_to_H)
   do J=js-1,je
-    do i=is,ie ; hatvtot(i) = 0.0 ; enddo
+    do i=is,ie ; hatvtot(i,J) = 0.0 ; enddo
     if (present(h_v)) then
       do k=1,nz ; do i=is,ie
         hatv(i,J,k) = h_v(i,J,k)
-        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
+        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == ARITHMETIC) then
       do k=1,nz ; do i=is,ie
         hatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
-        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
+        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HYBRID .or. use_default) then
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
@@ -4472,13 +4472,13 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
             hatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
-        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
+        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HARMONIC) then
       do k=1,nz ; do i=is,ie
         hatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
                         ((h(i,j+1,k) + h(i,j,k)) + h_neglect)
-        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
+        hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
       enddo ; enddo
     endif
 
@@ -4487,10 +4487,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       if ((J >= CS%BT_OBC%Js_v_N_obc) .and. (J <= CS%BT_OBC%Je_v_N_obc)) then
         do i = max(is,CS%BT_OBC%is_v_N_obc), min(ie,CS%BT_OBC%ie_v_N_obc)
           if (CS%BT_OBC%v_OBC_type(i,J) > 0) then ! Northern boundary condition
-            hatvtot(i) = 0.0
+            hatvtot(i,J) = 0.0
             do k=1,nz
               hatv(i,J,k) = h(i,j,k)
-              hatvtot(i) = hatvtot(i) + hatv(i,J,k)
+              hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
             enddo
           endif
         enddo
@@ -4498,10 +4498,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       if ((J >= CS%BT_OBC%Js_v_S_obc) .and. (J <= CS%BT_OBC%Je_v_S_obc)) then
         do i = max(is,CS%BT_OBC%is_v_S_obc), min(ie,CS%BT_OBC%ie_v_S_obc)
           if (CS%BT_OBC%v_OBC_type(i,J) < 0) then ! Southern boundary condition
-            hatvtot(i) = 0.0
+            hatvtot(i,J) = 0.0
             do k=1,nz
               hatv(i,J,k) = h(i,j+1,k)
-              hatvtot(i) = hatvtot(i) + hatv(i,J,k)
+              hatvtot(i,J) = hatvtot(i,J) + hatv(i,J,k)
             enddo
           endif
         enddo
@@ -4509,7 +4509,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     endif
 
     ! Determine the fractional thickness of each layer at the velocity points.
-    do i=is,ie ; Ihatvtot(i) = G%mask2dCv(i,J) / (hatvtot(i) + h_neglect) ; enddo
+    do i=is,ie ; Ihatvtot(i) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo
     do k=1,nz ; do i=is,ie
       CS%frhatv(i,J,k) = hatv(i,J,k) * Ihatvtot(i)
     enddo ; enddo

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -845,7 +845,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! share with the main part of the MOM6 code.
   if (find_etaav) then
     call create_group_pass(CS%pass_etaav, etaav, G%Domain)
-  endif
+  endif                                                              
   call create_group_pass(CS%pass_e_anom, e_anom, G%Domain)
   call create_group_pass(CS%pass_ubta_uhbta, CS%ubtav, CS%vbtav, G%Domain)
   call create_group_pass(CS%pass_ubta_uhbta, uhbtav, vhbtav, G%Domain)
@@ -855,7 +855,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
-  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q)
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -1164,8 +1164,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       ! Fill in the halo data for ubt, vbt, uhbt, and vhbt.
       if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
       if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
+      !$omp target update from(ubt, vbt)
       call pass_vector(ubt, vbt, CS%BT_Domain, complete=.false., halo=1+ievf-ie)
       call pass_vector(uhbt, vhbt, CS%BT_Domain, complete=.true., halo=1+ievf-ie)
+      !$omp target update to(ubt, vbt)
       if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
       if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
 
@@ -2129,7 +2131,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !$omp target exit data &
   !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
-  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q)
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt)
 
 end subroutine btstep
 
@@ -2463,7 +2465,9 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     ! Update the range of valid points, either by doing a halo update or by marching inward.
     if ((iev - stencil < ie) .or. (jev - stencil < je)) then
       if (id_clock_calc > 0) call cpu_clock_end(id_clock_calc)
+      !$omp target update from(ubt, vbt)
       call do_group_pass(CS%pass_eta_ubt, CS%BT_Domain, clock=id_clock_pass_step)
+      !$omp target update to(ubt, vbt)
       isv = isvf ; iev = ievf ; jsv = jsvf ; jev = jevf
       if (id_clock_calc > 0) call cpu_clock_begin(id_clock_calc)
     else

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2167,8 +2167,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     call complete_group_pass(CS%pass_ubta_uhbta, G%Domain)
   endif
 
-  deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
-
   !$omp target exit data &
   !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
@@ -2177,6 +2175,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF, &
   !$omp       gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, wt_vel, wt_eta, &
   !$omp       wt_trans, wt_accel, wt_accel2)
+
+  deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5218,30 +5218,43 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  !$OMP parallel do default(shared) private(eta_h,h_tot,d_eta)
+  !$omp target teams distribute private(eta_h,h_tot,d_eta) &
+  !$omp   map(to: CS, G, G%bathyT, GV, h, eta) &
+  !$omp   map(tofrom: CS%eta_cor) &
+  !$omp   map(alloc: eta_h, h_tot)
   do j=js,je
+    !$omp parallel
+    !$omp do simd
     do i=is,ie ; h_tot(i) = h(i,j,1) ; enddo
     if (GV%Boussinesq) then
+      !$omp do simd
       do i=is,ie ; eta_h(i) = h(i,j,1) - G%bathyT(i,j)*GV%Z_to_H ; enddo
     else
+      !$omp do simd
       do i=is,ie ; eta_h(i) = h(i,j,1) ; enddo
     endif
-    do k=2,nz ; do i=is,ie
-      eta_h(i) = eta_h(i) + h(i,j,k)
-      h_tot(i) = h_tot(i) + h(i,j,k)
-    enddo ; enddo
+    do k=2,nz
+      !$omp do simd
+      do i=is,ie
+        eta_h(i) = eta_h(i) + h(i,j,k)
+        h_tot(i) = h_tot(i) + h(i,j,k)
+      enddo
+    enddo
 
     if (set_cor) then
+      !$omp do private(d_eta)
       do i=is,ie
         d_eta = eta_h(i) - eta(i,j)
         CS%eta_cor(i,j) = d_eta
       enddo
     else
+      !$omp do private(d_eta)
       do i=is,ie
         d_eta = eta_h(i) - eta(i,j)
         CS%eta_cor(i,j) = CS%eta_cor(i,j) + d_eta
       enddo
     endif
+    !$omp end parallel
   enddo
 
 end subroutine bt_mass_source

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -858,7 +858,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
   !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, Datu, Datv, &
-  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF)
+  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF, &
+  !$omp       gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -1405,7 +1406,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
     if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
     ! ensure correct data on host to be exchanged
-    !$omp target update from(ubt_Cor, vbt_Cor)
+    !$omp target update from(ubt_Cor, vbt_Cor, gtot_E, gtot_W, gtot_N, gtot_S)
     call start_group_pass(CS%pass_gtot, CS%BT_Domain)
     call start_group_pass(CS%pass_ubt_Cor, G%Domain)
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
@@ -1427,12 +1428,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     call complete_group_pass(CS%pass_gtot, CS%BT_Domain)
     call complete_group_pass(CS%pass_ubt_Cor, G%Domain)
   else
-    !$omp target update from(ubt_Cor, vbt_Cor)
+    !$omp target update from(ubt_Cor, vbt_Cor, gtot_E, gtot_W, gtot_N, gtot_S)
     call do_group_pass(CS%pass_gtot, CS%BT_Domain)
     call do_group_pass(CS%pass_ubt_Cor, G%Domain)
   endif
   ! Update MPI-updated values are on GPU
-  !$omp target update to(Ubt_Cor, vbt_Cor)
+  !$omp target update to(Ubt_Cor, vbt_Cor, gtot_E, gtot_W, gtot_N, gtot_S)
   ! The various elements of gtot are positive definite but directional, so use
   ! the polarity arrays to sort out when the directions have shifted.
   do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1)
@@ -1611,22 +1612,25 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
   if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
   if (nonblock_setup) then
-    !$omp target update from(bt_rem_u, bt_rem_v)
+    !$omp target update from(bt_rem_u, bt_rem_v, eta_src)
     !$omp target update if(integral_BT_cont) from(eta_IC)
     !$omp target update if(.not.interp_eta_PF) from(eta_PF)
     !$omp target update if(interp_eta_PF) from(eta_PF_1, d_eta_PF)
+    !$omp target update if(CS%dynamic_psurf) from(dyn_coef_eta)
     call start_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
     ! The following halo update is not needed without wide halos.  RWH
   else
-    !$omp target update from(bt_rem_u, bt_rem_v)
+    !$omp target update from(bt_rem_u, bt_rem_v, eta_src)
     !$omp target update if(integral_BT_cont) from(eta_IC)
     !$omp target update if(.not.interp_eta_PF) from(eta_PF)
     !$omp target update if(interp_eta_PF) from(eta_PF_1, d_eta_PF)
+    !$omp target update if(CS%dynamic_psurf) from(dyn_coef_eta)
     call do_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
-    !$omp target update to(bt_rem_u, bt_rem_v)
+    !$omp target update to(bt_rem_u, bt_rem_v, eta_src)
     !$omp target update if(integral_BT_cont) to(eta_IC)
     !$omp target update if(.not.interp_eta_PF) to(eta_PF)
     !$omp target update if(interp_eta_PF) to(eta_PF_1, d_eta_PF)
+    !$omp target update if(CS%dynamic_psurf) to(dyn_coef_eta)
     if (.not.use_BT_cont) then
       !$omp target update from(Datu, Datv)
       call do_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
@@ -1650,10 +1654,11 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     endif
     call complete_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
     call complete_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
-    !$omp target update to(bt_rem_u, bt_rem_v, BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
+    !$omp target update to(bt_rem_u, bt_rem_v, BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v, eta_src)
     !$omp target update if(integral_BT_cont) to(eta_IC)
     !$omp target update if(.not.interp_eta_PF) to(eta_PF)
     !$omp target update if(interp_eta_PF) to(eta_PF_1, d_eta_PF)
+    !$omp target update if(CS%dynamic_psurf) to(dyn_coef_eta)
 
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -1728,6 +1733,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   allocate(wt_vel(nstep+nfilter)) ; allocate(wt_eta(nstep+nfilter))
   allocate(wt_trans(nstep+nfilter+1)) ; allocate(wt_accel(nstep+nfilter+1))
   allocate(wt_accel2(nstep+nfilter+1))
+  ! leaving above arrays to be managed by compiler
   do concurrent (n=1:nstep+nfilter)
     ! Modify this to use a different filter...
 
@@ -2164,7 +2170,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
   !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, Datu, Datv, &
-  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF)
+  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF, &
+  !$omp       gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -857,18 +857,15 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 ! barotropic momentum equations.  This has to be done quite early to start
 ! the halo update that needs to be completed before the next calculations.
   if (CS%linearized_BT_PV) then
-    !$OMP parallel do default(shared)
-    do J=jsvf-2,jevf+1 ; do I=isvf-2,ievf+1
+    do concurrent (J=jsvf-2:jevf+1, I=isvf-2:ievf+1)
       q(I,J) = CS%q_D(I,j)
-    enddo ; enddo
-    !$OMP parallel do default(shared)
-    do j=jsvf-1,jevf+1 ; do I=isvf-2,ievf+1
+    enddo
+    do concurrent (j=jsvf-1:jevf+1, I=isvf-2:ievf+1)
       DCor_u(I,j) = CS%D_u_Cor(I,j)
-    enddo ; enddo
-    !$OMP parallel do default(shared)
-    do J=jsvf-2,jevf+1 ; do i=isvf-1,ievf+1
+    enddo
+    do concurrent (J=jsvf-2:jevf+1, i=isvf-1:ievf+1)
       DCor_v(i,J) = CS%D_v_Cor(i,J)
-    enddo ; enddo
+    enddo
   else
     q(:,:) = 0.0 ; DCor_u(:,:) = 0.0 ; DCor_v(:,:) = 0.0
     if (GV%Boussinesq) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4314,8 +4314,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   real :: hatv(SZI_(G),SZJB_(G),SZK_(GV))  ! The layer thicknesses interpolated to v points [H ~> m or kg m-2]
   real :: hatutot(SZIB_(G),SZJ_(G))    ! The sum of the layer thicknesses interpolated to u points [H ~> m or kg m-2].
   real :: hatvtot(SZI_(G),SZJB_(G))     ! The sum of the layer thicknesses interpolated to v points [H ~> m or kg m-2].
-  real :: Ihatutot(SZIB_(G))   ! Ihatutot is the inverse of hatutot [H-1 ~> m-1 or m2 kg-1].
-  real :: Ihatvtot(SZI_(G))    ! Ihatvtot is the inverse of hatvtot [H-1 ~> m-1 or m2 kg-1].
+  real :: Ihatutot(SZIB_(G),SZJ_(G))   ! Ihatutot is the inverse of hatutot [H-1 ~> m-1 or m2 kg-1].
+  real :: Ihatvtot(SZI_(G),SZJB_(G))    ! Ihatvtot is the inverse of hatvtot [H-1 ~> m-1 or m2 kg-1].
   real :: h_arith              ! The arithmetic mean thickness [H ~> m or kg m-2].
   real :: h_harm               ! The harmonic mean thicknesses [H ~> m or kg m-2].
   real :: h_neglect            ! A thickness that is so small it is usually lost
@@ -4432,9 +4432,9 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     endif
 
     ! Determine the fractional thickness of each layer at the velocity points.
-    do I=is-1,ie ; Ihatutot(I) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo
+    do I=is-1,ie ; Ihatutot(I,j) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo
     do k=1,nz ; do I=is-1,ie
-      CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I)
+      CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I,j)
     enddo ; enddo
   enddo
 
@@ -4509,9 +4509,9 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     endif
 
     ! Determine the fractional thickness of each layer at the velocity points.
-    do i=is,ie ; Ihatvtot(i) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo
+    do i=is,ie ; Ihatvtot(i,J) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo
     do k=1,nz ; do i=is,ie
-      CS%frhatv(i,J,k) = hatv(i,J,k) * Ihatvtot(i)
+      CS%frhatv(i,J,k) = hatv(i,J,k) * Ihatvtot(i,J)
     enddo ; enddo
   enddo
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -920,8 +920,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   endif
 
   ! Zero out various wide-halo arrays.
-  !$OMP parallel do default(shared)
-  do j=CS%jsdw,CS%jedw ; do i=CS%isdw,CS%iedw
+  do concurrent (j=CS%jsdw:CS%jedw, i=CS%isdw:CS%iedw)
     gtot_E(i,j) = 0.0 ; gtot_W(i,j) = 0.0
     gtot_N(i,j) = 0.0 ; gtot_S(i,j) = 0.0
     eta(i,j) = 0.0
@@ -933,20 +932,18 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       eta_IC(i,j) = 0.0
     endif
     if (CS%dynamic_psurf) dyn_coef_eta(i,j) = 0.0
-  enddo ; enddo
+  enddo
   !   The halo regions of various arrays need to be initialized to
   ! non-NaNs in case the neighboring domains are not part of the ocean.
   ! Otherwise a halo update later on fills in the correct values.
-  !$OMP parallel do default(shared)
-  do j=CS%jsdw,CS%jedw ; do I=CS%isdw-1,CS%iedw
+  do concurrent (j=CS%jsdw:CS%jedw, I=CS%isdw-1:CS%iedw)
     Cor_ref_u(I,j) = 0.0 ; BT_force_u(I,j) = 0.0 ; ubt(I,j) = 0.0
     Datu(I,j) = 0.0 ; bt_rem_u(I,j) = 0.0 ; uhbt0(I,j) = 0.0
-  enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=CS%jsdw-1,CS%jedw ; do i=CS%isdw,CS%iedw
+  enddo
+  do concurrent (J=CS%jsdw-1:CS%jedw, i=CS%isdw:CS%iedw)
     Cor_ref_v(i,J) = 0.0 ; BT_force_v(i,J) = 0.0 ; vbt(i,J) = 0.0
     Datv(i,J) = 0.0 ; bt_rem_v(i,J) = 0.0 ; vhbt0(i,J) = 0.0
-  enddo ; enddo
+  enddo
 
   if (apply_OBCs) then
     SpV_col_avg(:,:) = 0.0

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1459,14 +1459,14 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     av_rem_v(i,J) = av_rem_v(i,J) + CS%frhatv(i,J,k) * visc_rem_v(i,J,k)
   enddo ; enddo
   if (CS%strong_drag) then
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       bt_rem_u(I,j) = G%mask2dCu(I,j) * &
          ((nstep * av_rem_u(I,j)) / (1.0 + (nstep-1)*av_rem_u(I,j)))
-    enddo ; enddo
-    do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent (J=js-1:je, i=is:ie)
       bt_rem_v(i,J) = G%mask2dCv(i,J) * &
          ((nstep * av_rem_v(i,J)) / (1.0 + (nstep-1)*av_rem_v(i,J)))
-    enddo ; enddo
+    enddo
   else
     do concurrent (j=js:je, I=is-1:ie)
       bt_rem_u(I,j) = 0.0
@@ -1480,40 +1480,40 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     enddo
   endif
   if (CS%linear_wave_drag) then
-    do j=js,je ; do I=is-1,ie ; if (CS%lin_drag_u(I,j) > 0.0) then
+    do concurrent (j=js:je, I=is-1:ie, CS%lin_drag_u(I,j) > 0.0)
       Htot = 0.5 * (eta(i,j) + eta(i+1,j))
       if (GV%Boussinesq) &
         Htot = Htot + 0.5*GV%Z_to_H * (CS%bathyT(i,j) + CS%bathyT(i+1,j))
       bt_rem_u(I,j) = bt_rem_u(I,j) * (Htot / (Htot + CS%lin_drag_u(I,j) * dtbt))
 
       Rayleigh_u(I,j) = CS%lin_drag_u(I,j) / Htot
-    endif ; enddo ; enddo
-    do J=js-1,je ; do i=is,ie ; if (CS%lin_drag_v(i,J) > 0.0) then
+    enddo
+    do concurrent (J=js-1:je, i=is:ie, CS%lin_drag_v(i,J) > 0.0)
       Htot = 0.5 * (eta(i,j) + eta(i,j+1))
       if (GV%Boussinesq) &
         Htot = Htot + 0.5*GV%Z_to_H * (CS%bathyT(i,j) + CS%bathyT(i,j+1))
       bt_rem_v(i,J) = bt_rem_v(i,J) * (Htot / (Htot + CS%lin_drag_v(i,J) * dtbt))
 
       Rayleigh_v(i,J) = CS%lin_drag_v(i,J) / Htot
-    endif ; enddo ; enddo
+    enddo
   endif
 
   ! Avoid changing the velocities at OBC points due to non-OBC calculations.
   if (CS%BT_OBC%u_OBCs_on_PE) then
-    do j=js,je ; do I=is-1,ie ; if (CS%BT_OBC%u_OBC_type(I,j) /= 0) then
+    do concurrent (j=js:je, I=is-1:ie, CS%BT_OBC%u_OBC_type(I,j) /= 0)
       bt_rem_u(I,j) = 1.0
-    endif ; enddo ; enddo
+    enddo
   endif
   if (CS%BT_OBC%v_OBCs_on_PE) then
-    do J=js-1,je ; do i=is,ie ; if (CS%BT_OBC%v_OBC_type(i,J) /= 0) then
+    do concurrent (J=js-1:je, i=is:ie, CS%BT_OBC%v_OBC_type(i,J) /= 0)
       bt_rem_v(i,J) = 1.0
-    endif ; enddo ; enddo
+    enddo
   endif
 
   ! Set the mass source, after first initializing the halos to 0.
   do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1) ; eta_src(i,j) = 0.0 ; enddo
   if (CS%bound_BT_corr) then ; if ((use_BT_Cont.or.integral_BT_cont) .and. CS%BT_cont_bounds) then
-    do concurrent (j=js:je, i=is:ie) local(uint_cor, vint_cor, u_max_cor, v_max_cor, eta_cor_max); if (G%mask2dT(i,j) > 0.0) then
+    do concurrent (j=js:je, i=is:ie, G%mask2dT(i,j) > 0.0) local(uint_cor, vint_cor, u_max_cor, v_max_cor, eta_cor_max)
       if (CS%eta_cor(i,j) > 0.0) then
         !   Limit the source (outward) correction to be a fraction the mass that
         ! can be transported out of the cell by velocities with a CFL number of CFL_cor.
@@ -1542,11 +1542,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
         CS%eta_cor(i,j) = max(CS%eta_cor(i,j), -max(0.0,Htot))
       endif
-    endif ; enddo
-  else ; do j=js,je ; do i=is,ie
-    if (abs(CS%eta_cor(i,j)) > dt*CS%eta_cor_bound(i,j)) &
+    enddo
+  else
+    do concurrent (j=js:je, i=is:ie, abs(CS%eta_cor(i,j)) > dt*CS%eta_cor_bound(i,j))
       CS%eta_cor(i,j) = sign(dt*CS%eta_cor_bound(i,j), CS%eta_cor(i,j))
-  enddo ; enddo ; endif ; endif
+    enddo
+  endif ; endif
   do concurrent (j=js:je, i=is:ie)
     eta_src(i,j) = G%mask2dT(i,j) * (Instep * CS%eta_cor(i,j))
   enddo
@@ -1563,8 +1564,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       else
         H_to_Z = GV%H_to_RZ / CS%Rho_BT_lin
       endif
-      !$OMP parallel do default(shared) private(Idt_max2,H_eff_dx2,dyn_coef_max,ice_strength)
-      do j=js,je ; do i=is,ie
+      do concurrent (j=js:je, i=is:ie) local(Idt_max2,H_eff_dx2,dyn_coef_max,ice_strength)
       ! First determine the maximum stable value for dyn_coef_eta.
 
       !   This estimate of the maximum stable time step is pretty accurate for
@@ -1591,7 +1591,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
       ! Units of dyn_coef: [L2 T-2 H-1 ~> m s-2 or m4 s-2 kg-1]
       dyn_coef_eta(i,j) = min(dyn_coef_max, ice_strength * H_to_Z)
-    enddo ; enddo ; endif
+    enddo ; endif
   endif
 
   if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
@@ -5067,14 +5067,14 @@ subroutine BT_cont_to_face_areas(BT_cont, Datu, Datv, G, US, MS, halo)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   hs = 1 ; if (present(halo)) hs = max(halo,0)
 
-  do j=js-hs,je+hs ; do I=is-1-hs,ie+hs
+  do concurrent (j=js-hs:je+hs, I=is-1-hs:ie+hs)
     Datu(I,j) = max(BT_cont%FA_u_EE(I,j), BT_cont%FA_u_E0(I,j), &
                     BT_cont%FA_u_W0(I,j), BT_cont%FA_u_WW(I,j))
-  enddo ; enddo
-  do J=js-1-hs,je+hs ; do i=is-hs,ie+hs
+  enddo
+  do concurrent (J=js-1-hs:je+hs, i=is-hs:ie+hs)
     Datv(i,J) = max(BT_cont%FA_v_NN(i,J), BT_cont%FA_v_N0(i,J), &
                     BT_cont%FA_v_S0(i,J), BT_cont%FA_v_SS(i,J))
-  enddo ; enddo
+  enddo
 
 end subroutine BT_cont_to_face_areas
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1505,9 +1505,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   endif
 
   ! Set the mass source, after first initializing the halos to 0.
-  do j=jsvf-1,jevf+1 ; do i=isvf-1,ievf+1 ; eta_src(i,j) = 0.0 ; enddo ; enddo
+  do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1) ; eta_src(i,j) = 0.0 ; enddo
   if (CS%bound_BT_corr) then ; if ((use_BT_Cont.or.integral_BT_cont) .and. CS%BT_cont_bounds) then
-    do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
+    do concurrent (j=js:je, i=is:ie) ; if (G%mask2dT(i,j) > 0.0) then
       if (CS%eta_cor(i,j) > 0.0) then
         !   Limit the source (outward) correction to be a fraction the mass that
         ! can be transported out of the cell by velocities with a CFL number of CFL_cor.
@@ -1536,14 +1536,14 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
         CS%eta_cor(i,j) = max(CS%eta_cor(i,j), -max(0.0,Htot))
       endif
-    endif ; enddo ; enddo
+    endif ; enddo
   else ; do j=js,je ; do i=is,ie
     if (abs(CS%eta_cor(i,j)) > dt*CS%eta_cor_bound(i,j)) &
       CS%eta_cor(i,j) = sign(dt*CS%eta_cor_bound(i,j), CS%eta_cor(i,j))
   enddo ; enddo ; endif ; endif
-  do j=js,je ; do i=is,ie
+  do concurrent (j=js:je, i=is:ie)
     eta_src(i,j) = G%mask2dT(i,j) * (Instep * CS%eta_cor(i,j))
-  enddo ; enddo
+  enddo
 
   if (CS%dynamic_psurf) then
     ice_is_rigid = (associated(forces%rigidity_ice_u) .and. &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -853,6 +853,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
 !--- end setup for group halo update
 
+  !$omp target enter data map(alloc: ubt_Cor, vbt_Cor)
+
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
 ! the halo update that needs to be completed before the next calculations.
@@ -1392,6 +1394,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (nonblock_setup) then
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
     if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
+    ! ensure correct data on host to be exchanged
+    !$omp target update from(ubt_Cor, vbt_Cor)
     call start_group_pass(CS%pass_gtot, CS%BT_Domain)
     call start_group_pass(CS%pass_ubt_Cor, G%Domain)
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
@@ -1413,9 +1417,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     call complete_group_pass(CS%pass_gtot, CS%BT_Domain)
     call complete_group_pass(CS%pass_ubt_Cor, G%Domain)
   else
+    !$omp target update from(ubt_Cor, vbt_Cor)
     call do_group_pass(CS%pass_gtot, CS%BT_Domain)
     call do_group_pass(CS%pass_ubt_Cor, G%Domain)
   endif
+  ! Update MPI-updated values are on GPU
+  !$omp target update to(Ubt_Cor, vbt_Cor)
   ! The various elements of gtot are positive definite but directional, so use
   ! the polarity arrays to sort out when the directions have shifted.
   do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1)
@@ -2111,6 +2118,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   endif
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
+
+  !$omp target exit data map(release: ubt_Cor, vbt_Cor)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -857,7 +857,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
-  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v)
+  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, Datu, Datv, &
+  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -1104,7 +1105,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (nonblock_setup .and. .not.CS%linearized_BT_PV) then
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
     call complete_group_pass(CS%pass_q_DCor, CS%BT_Domain, clock=id_clock_pass_pre)
-      !$omp target update to(q)
+      !$omp target update to(q, DCor_u, DCor_v)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
   endif
 
@@ -1452,8 +1453,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! Now start new halo updates.
   if (nonblock_setup) then
-    if (.not.use_BT_cont) &
+    if (.not.use_BT_cont) then
+      !$omp target update from(Datu, Datv)
       call start_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
+    endif
 
     ! The following halo update is not needed without wide halos.  RWH
     !$omp target update from(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
@@ -1609,14 +1612,26 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
   if (nonblock_setup) then
     !$omp target update from(bt_rem_u, bt_rem_v)
+    !$omp target update if(integral_BT_cont) from(eta_IC)
+    !$omp target update if(.not.interp_eta_PF) from(eta_PF)
+    !$omp target update if(interp_eta_PF) from(eta_PF_1, d_eta_PF)
     call start_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
     ! The following halo update is not needed without wide halos.  RWH
   else
     !$omp target update from(bt_rem_u, bt_rem_v)
+    !$omp target update if(integral_BT_cont) from(eta_IC)
+    !$omp target update if(.not.interp_eta_PF) from(eta_PF)
+    !$omp target update if(interp_eta_PF) from(eta_PF_1, d_eta_PF)
     call do_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
     !$omp target update to(bt_rem_u, bt_rem_v)
-    if (.not.use_BT_cont) &
+    !$omp target update if(integral_BT_cont) to(eta_IC)
+    !$omp target update if(.not.interp_eta_PF) to(eta_PF)
+    !$omp target update if(interp_eta_PF) to(eta_PF_1, d_eta_PF)
+    if (.not.use_BT_cont) then
+      !$omp target update from(Datu, Datv)
       call do_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
+      !$omp target update to(Datu, Datv)
+    endif
     !$omp target update from(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
     call do_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
     !$omp target update to(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
@@ -1629,10 +1644,16 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
     if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
 
-    if (.not.use_BT_cont) call complete_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
+    if (.not.use_BT_cont) then
+      call complete_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
+      !$omp target update to(Datu, Datv)
+    endif
     call complete_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
     call complete_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
     !$omp target update to(bt_rem_u, bt_rem_v, BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
+    !$omp target update if(integral_BT_cont) to(eta_IC)
+    !$omp target update if(.not.interp_eta_PF) to(eta_PF)
+    !$omp target update if(interp_eta_PF) to(eta_PF_1, d_eta_PF)
 
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -2142,7 +2163,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
-  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v)
+  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, Datu, Datv, &
+  !$omp       f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, d_eta_PF)
 
 end subroutine btstep
 
@@ -2476,9 +2498,9 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     ! Update the range of valid points, either by doing a halo update or by marching inward.
     if ((iev - stencil < ie) .or. (jev - stencil < je)) then
       if (id_clock_calc > 0) call cpu_clock_end(id_clock_calc)
-      !$omp target update from(ubt, vbt)
+      !$omp target update from(ubt, vbt, eta)
       call do_group_pass(CS%pass_eta_ubt, CS%BT_Domain, clock=id_clock_pass_step)
-      !$omp target update to(ubt, vbt)
+      !$omp target update to(ubt, vbt, eta)
       isv = isvf ; iev = ievf ; jsv = jsvf ; jev = jevf
       if (id_clock_calc > 0) call cpu_clock_begin(id_clock_calc)
     else

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -853,9 +853,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
 !--- end setup for group halo update
 
+  ! transfers of derived types and members being kept to minimize .attach. and .detach. data
   !$omp target enter data &
   !$omp   map(to: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, bc_accel_v, &
-  !$omp       visc_rem_u, visc_rem_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, &
+  !$omp       forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, &
   !$omp       CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, CS%ua_polarity, &
   !$omp       CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, &
   !$omp       CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, CS%OBCmask_v, uh0, vh0) &
@@ -2186,7 +2187,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !$omp target exit data &
   !$omp   map(release: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, &
-  !$omp       bc_accel_v, visc_rem_u, visc_rem_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, &
+  !$omp       bc_accel_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, &
   !$omp       CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, &
   !$omp       CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, CS%ubtav, &
   !$omp       CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, CS%OBCmask_v, uh0, vh0) &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4311,7 +4311,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
 
   ! Local variables
   real :: hatu(SZIB_(G),SZJ_(G),SZK_(GV)) ! The layer thicknesses interpolated to u points [H ~> m or kg m-2]
-  real :: hatv(SZI_(G),SZK_(GV))  ! The layer thicknesses interpolated to v points [H ~> m or kg m-2]
+  real :: hatv(SZI_(G),SZJB_(G),SZK_(GV))  ! The layer thicknesses interpolated to v points [H ~> m or kg m-2]
   real :: hatutot(SZIB_(G))    ! The sum of the layer thicknesses interpolated to u points [H ~> m or kg m-2].
   real :: hatvtot(SZI_(G))     ! The sum of the layer thicknesses interpolated to v points [H ~> m or kg m-2].
   real :: Ihatutot(SZIB_(G))   ! Ihatutot is the inverse of hatutot [H-1 ~> m-1 or m2 kg-1].
@@ -4444,13 +4444,13 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     do i=is,ie ; hatvtot(i) = 0.0 ; enddo
     if (present(h_v)) then
       do k=1,nz ; do i=is,ie
-        hatv(i,k) = h_v(i,J,k)
-        hatvtot(i) = hatvtot(i) + hatv(i,k)
+        hatv(i,J,k) = h_v(i,J,k)
+        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == ARITHMETIC) then
       do k=1,nz ; do i=is,ie
-        hatv(i,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
-        hatvtot(i) = hatvtot(i) + hatv(i,k)
+        hatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
+        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HYBRID .or. use_default) then
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
@@ -4462,23 +4462,23 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
         e_v(i,K) = e_v(i,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
         h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
         if (e_v(i,K+1) >= D_shallow_v(i)) then
-          hatv(i,k) = h_arith
+          hatv(i,J,k) = h_arith
         else
           h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
           if (e_v(i,K) <= D_shallow_v(i)) then
-            hatv(i,k) = h_harm
+            hatv(i,J,k) = h_harm
           else
             wt_arith = (e_v(i,K) - D_shallow_v(i)) / (h_arith + h_neglect)
-            hatv(i,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+            hatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
-        hatvtot(i) = hatvtot(i) + hatv(i,k)
+        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
       enddo ; enddo
     elseif (CS%hvel_scheme == HARMONIC) then
       do k=1,nz ; do i=is,ie
-        hatv(i,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
+        hatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
                         ((h(i,j+1,k) + h(i,j,k)) + h_neglect)
-        hatvtot(i) = hatvtot(i) + hatv(i,k)
+        hatvtot(i) = hatvtot(i) + hatv(i,J,k)
       enddo ; enddo
     endif
 
@@ -4489,8 +4489,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%v_OBC_type(i,J) > 0) then ! Northern boundary condition
             hatvtot(i) = 0.0
             do k=1,nz
-              hatv(i,k) = h(i,j,k)
-              hatvtot(i) = hatvtot(i) + hatv(i,k)
+              hatv(i,J,k) = h(i,j,k)
+              hatvtot(i) = hatvtot(i) + hatv(i,J,k)
             enddo
           endif
         enddo
@@ -4500,8 +4500,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           if (CS%BT_OBC%v_OBC_type(i,J) < 0) then ! Southern boundary condition
             hatvtot(i) = 0.0
             do k=1,nz
-              hatv(i,k) = h(i,j+1,k)
-              hatvtot(i) = hatvtot(i) + hatv(i,k)
+              hatv(i,J,k) = h(i,j+1,k)
+              hatvtot(i) = hatvtot(i) + hatv(i,J,k)
             enddo
           endif
         enddo
@@ -4511,7 +4511,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     ! Determine the fractional thickness of each layer at the velocity points.
     do i=is,ie ; Ihatvtot(i) = G%mask2dCv(i,J) / (hatvtot(i) + h_neglect) ; enddo
     do k=1,nz ; do i=is,ie
-      CS%frhatv(i,J,k) = hatv(i,k) * Ihatvtot(i)
+      CS%frhatv(i,J,k) = hatv(i,J,k) * Ihatvtot(i)
     enddo ; enddo
   enddo
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -855,7 +855,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
-  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v)
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
+  !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
+  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -1164,10 +1166,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       ! Fill in the halo data for ubt, vbt, uhbt, and vhbt.
       if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
       if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
-      !$omp target update from(ubt, vbt)
+      !$omp target update from(ubt, vbt, uhbt, vhbt)
       call pass_vector(ubt, vbt, CS%BT_Domain, complete=.false., halo=1+ievf-ie)
       call pass_vector(uhbt, vhbt, CS%BT_Domain, complete=.true., halo=1+ievf-ie)
-      !$omp target update to(ubt, vbt)
+      !$omp target update to(ubt, vbt, uhbt, vhbt)
       if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
       if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
 
@@ -1454,6 +1456,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       call start_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
 
     ! The following halo update is not needed without wide halos.  RWH
+    !$omp target update from(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
     call start_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
   endif
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
@@ -1614,7 +1617,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     !$omp target update to(bt_rem_u, bt_rem_v)
     if (.not.use_BT_cont) &
       call do_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
+    !$omp target update from(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
     call do_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
+    !$omp target update to(BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
   endif
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
   if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -1627,7 +1632,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (.not.use_BT_cont) call complete_group_pass(CS%pass_Dat_uv, CS%BT_Domain)
     call complete_group_pass(CS%pass_force_hbt0_Cor_ref, CS%BT_Domain)
     call complete_group_pass(CS%pass_eta_bt_rem, CS%BT_Domain)
-    !$omp target update to(bt_rem_u, bt_rem_v)
+    !$omp target update to(bt_rem_u, bt_rem_v, BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v)
 
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -2135,7 +2140,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   !$omp target exit data &
   !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
-  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v)
+  !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
+  !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
+  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1722,8 +1722,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   allocate(wt_vel(nstep+nfilter)) ; allocate(wt_eta(nstep+nfilter))
   allocate(wt_trans(nstep+nfilter+1)) ; allocate(wt_accel(nstep+nfilter+1))
   allocate(wt_accel2(nstep+nfilter+1))
-  !$omp target enter data map(alloc: wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
-  do concurrent (n=1:nstep+nfilter)
+  do n=1,nstep+nfilter
     ! Modify this to use a different filter...
 
     ! This is a filter that ramps down linearly over a time dt_filt.
@@ -1741,22 +1740,19 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     ! The rest should not be changed.
   enddo
   ! do sum reduction on CPU to preserve fp summation order (nstep+filter is small)
-  do concurrent (n=1:nstep+nfilter) reduce(+:sum_wt_vel, sum_wt_eta)
+  do n=1,nstep+nfilter
     sum_wt_vel = sum_wt_vel + wt_vel(n) ; sum_wt_eta = sum_wt_eta + wt_eta(n)
   enddo
-  !$omp target update from(wt_vel, wt_eta)
-  ! leaving this prefix sum on CPU, but could be ported using openmp scan
   wt_trans(nstep+nfilter+1) = 0.0 ; wt_accel(nstep+nfilter+1) = 0.0
   do n=nstep+nfilter,1,-1
     wt_trans(n) = wt_trans(n+1) + wt_eta(n)
     wt_accel(n) = wt_accel(n+1) + wt_vel(n)
     sum_wt_accel = sum_wt_accel + wt_accel(n) ; sum_wt_trans = sum_wt_trans + wt_trans(n)
   enddo
-  !$omp target update to(wt_trans, wt_accel)
   ! Normalize the weights.
   I_sum_wt_vel = 1.0 / sum_wt_vel ; I_sum_wt_accel = 1.0 / sum_wt_accel
   I_sum_wt_eta = 1.0 / sum_wt_eta ; I_sum_wt_trans = 1.0 / sum_wt_trans
-  do concurrent (n=1:nstep+nfilter)
+  do n=1,nstep+nfilter
     wt_vel(n) = wt_vel(n) * I_sum_wt_vel
     if (CS%answer_date < 20190101) then
       wt_accel2(n) = wt_accel(n)
@@ -1782,8 +1778,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   else
     I_sum_wt_vel = 1.0 ; I_sum_wt_eta = 1.0 ; I_sum_wt_accel = 1.0 ; I_sum_wt_trans = 1.0
   endif
-
-  !$omp target update from(wt_accel, wt_accel2) ! needed inside btstep_timeloop
 
   ! March the barotropic solver through all of its time steps.
   call btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL_v, eta_IC, &
@@ -2173,7 +2167,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       ubt_trans, vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v, &
   !$omp       Datu, Datv, f_4_u, f_4_v, eta, eta_pred, eta_sum, eta_wtd, eta_IC, eta_PF, eta_PF_1, &
   !$omp       d_eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, eta_src, dyn_coef_eta, BTCL_u, BTCL_v, &
-  !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2, PFu_avg, PFv_avg)
+  !$omp       PFu_avg, PFv_avg)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1790,9 +1790,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   endif
 
   ! Note that it is possible that eta_out and eta_in are the same array.
-  do j=js,je ; do i=is,ie
+  do concurrent (j=js:je, i=is:ie)
     eta_out(i,j) = eta_wtd(i,j) * I_sum_wt_eta
-  enddo ; enddo
+  enddo
 
   ! Accumulator is updated at the end of every baroclinic time step.
   ! Harmonic analysis will not be performed of a field that is not registered.

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -984,12 +984,11 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! Copy input arrays into their wide-halo counterparts.
   if (interp_eta_PF) then
-    !$OMP parallel do default(shared)
-    do j=G%jsd,G%jed ; do i=G%isd,G%ied ! Was "do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1" but doing so breaks OBC. Not sure why?
+    do concurrent (j=G%jsd:G%jed, i=G%isd:G%ied) ! Was "do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1" but doing so breaks OBC. Not sure why?
       eta(i,j) = eta_in(i,j)
       eta_PF_1(i,j) = eta_PF_start(i,j)
       d_eta_PF(i,j) = eta_PF_in(i,j) - eta_PF_start(i,j)
-    enddo ; enddo
+    enddo
   else
     do concurrent (j=G%Jsd:G%Jed, i=G%isd:G%ied) !: Was "do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1" but doing so breaks OBC. Not sure why?
       eta(i,j) = eta_in(i,j)
@@ -997,10 +996,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     enddo
   endif
   if (integral_BT_cont) then
-    !$OMP parallel do default(shared)
-    do j=G%jsd,G%jed ; do i=G%isd,G%ied
+    do concurrent (j=G%jsd:G%jed, i=G%isd:G%ied)
       eta_IC(i,j) = eta_in(i,j)
-    enddo ; enddo
+    enddo
   endif
 
   do concurrent (k=1:nz, j=js:je, I=is-1:ie) local(visc_rem)
@@ -1024,27 +1022,27 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   enddo
 
   if (.not. CS%wt_uv_bug) then
-    do j=js,je ; do I=is-1,ie ; Iwt_u_tot(I,j) = wt_u(I,j,1) ; enddo ; enddo
-    do k=2,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie) ; Iwt_u_tot(I,j) = wt_u(I,j,1) ; enddo
+    do k=2,nz ; do concurrent (j=js:je, I=is-1:ie)
       Iwt_u_tot(I,j) = Iwt_u_tot(I,j) + wt_u(I,j,k)
-    enddo ; enddo ; enddo
-    do j=js,je ; do I=is-1,ie
-      if (abs(Iwt_u_tot(I,j)) > 0.0 ) Iwt_u_tot(I,j) = G%mask2dCu(I,j) / Iwt_u_tot(I,j)
     enddo ; enddo
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie, abs(Iwt_u_tot(I,j)) > 0.0)
+      Iwt_u_tot(I,j) = G%mask2dCu(I,j) / Iwt_u_tot(I,j)
+    enddo
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       wt_u(I,j,k) = wt_u(I,j,k) * Iwt_u_tot(I,j)
-    enddo ; enddo ; enddo
+    enddo
 
-    do J=js-1,je ; do i=is,ie ; Iwt_v_tot(i,J) = wt_v(i,J,1) ; enddo ; enddo
-    do k=2,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie) ; Iwt_v_tot(i,J) = wt_v(i,J,1) ; enddo
+    do k=2,nz ; do concurrent (J=js-1:je, i=is:ie)
       Iwt_v_tot(i,J) = Iwt_v_tot(i,J) + wt_v(i,J,k)
-    enddo ; enddo ; enddo
-    do J=js-1,je ; do i=is,ie
-      if (abs(Iwt_v_tot(i,J)) > 0.0 ) Iwt_v_tot(i,J) = G%mask2dCv(i,J) / Iwt_v_tot(i,J)
     enddo ; enddo
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie, abs(Iwt_v_tot(i,J)) > 0.0)
+      Iwt_v_tot(i,J) = G%mask2dCv(i,J) / Iwt_v_tot(i,J)
+    enddo
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       wt_v(i,J,k) = wt_v(i,J,k) * Iwt_v_tot(i,J)
-    enddo ; enddo ; enddo
+    enddo
   endif
 
   !   Use u_Cor and v_Cor as the reference values for the Coriolis terms,
@@ -1076,20 +1074,20 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   enddo
 
   if (CS%BT_OBC%u_OBCs_on_PE) then
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       if (CS%BT_OBC%u_OBC_type(I,j) > 0) & ! Eastern boundary condition
         gtot_W(i+1,j) = gtot_W(i,j)  ! Perhaps this should be gtot_E(i,j)?
       if (CS%BT_OBC%u_OBC_type(I,j) < 0) & ! Western boundary condition
         gtot_E(i,j) = gtot_E(i+1,j)  ! Perhaps this should be gtot_W(i+1,j)?
-    enddo ; enddo
+    enddo
   endif
   if (CS%BT_OBC%v_OBCs_on_PE) then
-    do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie)
       if (CS%BT_OBC%v_OBC_type(i,J) > 0) & ! Northern boundary condition
         gtot_S(i,j+1) = gtot_S(i,j)  !### Should this be gtot_N(i,j) to use wt_v at the same point?
       if (CS%BT_OBC%v_OBC_type(i,J) < 0) & ! Southern boundary condition
         gtot_N(i,j) = gtot_N(i,j+1)  ! Perhaps this should be gtot_S(i,j+1)?
-    enddo ; enddo
+    enddo
   endif
 
   if (CS%calculate_SAL) then
@@ -1127,6 +1125,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! Set up fields related to the open boundary conditions.  These calls include halo updates that
   ! must occur on all PEs when there are open boundary conditions anywhere.
   if (apply_OBCs) then
+    !$omp target update from(eta, Datu, Datv, BTCL_u, BTCL_v)
     if (nonblock_setup .and. apply_OBC_flather .and. .not.GV%Boussinesq) &
       call complete_group_pass(CS%pass_SpV_avg, CS%BT_domain)
 
@@ -1141,16 +1140,14 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     do concurrent (j=js:je, I=is-1:ie) ; uhbt(I,j) = 0.0 ; ubt(I,j) = 0.0 ; enddo
     do concurrent (J=js-1:je, i=is:ie) ; vhbt(i,J) = 0.0 ; vbt(i,J) = 0.0 ; enddo
     if (CS%visc_rem_u_uh0) then
-      !$OMP parallel do default(shared)
-      do j=js,je ; do k=1,nz ; do I=is-1,ie
+      do k=1,nz ; do concurrent (j=js:je, I=is-1:ie)
         uhbt(I,j) = uhbt(I,j) + uh0(I,j,k)
         ubt(I,j) = ubt(I,j) + wt_u(I,j,k) * u_uh0(I,j,k)
-      enddo ; enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=js-1,je ; do k=1,nz ; do i=is,ie
+      enddo ; enddo
+      do k=1,nz ; do concurrent (J=js-1:je, i=is:ie)
         vhbt(i,J) = vhbt(i,J) + vh0(i,J,k)
         vbt(i,J) = vbt(i,J) + wt_v(i,J,k) * v_vh0(i,J,k)
-      enddo ; enddo ; enddo
+      enddo ; enddo
     else
       do k=1,nz ; do concurrent (j=js:je, I=is-1:ie)
         uhbt(I,j) = uhbt(I,j) + uh0(I,j,k)
@@ -1174,7 +1171,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       !$omp target update to(ubt, vbt, uhbt, vhbt)
       if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
       if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
-
+      !$omp target update from(BTCL_u, BTCL_v)
       if (integral_BT_cont) then
         call adjust_local_BT_cont_types(ubt, uhbt, vbt, vhbt, BTCL_u, BTCL_v, &
                                         G, US, MS, 1+ievf-ie, dt_baroclinic=dt)
@@ -1182,16 +1179,15 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
         call adjust_local_BT_cont_types(ubt, uhbt, vbt, vhbt, BTCL_u, BTCL_v, &
                                         G, US, MS, 1+ievf-ie)
       endif
+      !$omp target update to(BTCL_u, BTCL_v)
     endif
     if (integral_BT_cont) then
-      !$OMP parallel do default(shared)
-      do j=js,je ; do I=is-1,ie
+      do concurrent (j=js:je, I=is-1:ie)
         uhbt0(I,j) = uhbt(I,j) - find_uhbt(dt*ubt(I,j), BTCL_u(I,j)) * Idt
-      enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=js-1,je ; do i=is,ie
+      enddo
+      do concurrent (J=js-1:je, i=is:ie)
         vhbt0(i,J) = vhbt(i,J) - find_vhbt(dt*vbt(i,J), BTCL_v(i,J)) * Idt
-      enddo ; enddo
+      enddo
     elseif (use_BT_cont) then
       do concurrent (j=js:je, I=is-1:ie)
         uhbt0(I,j) = uhbt(I,j) - find_uhbt(ubt(I,j), BTCL_u(I,j))
@@ -1200,26 +1196,22 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
         vhbt0(i,J) = vhbt(i,J) - find_vhbt(vbt(i,J), BTCL_v(i,J))
       enddo
     else
-      !$OMP parallel do default(shared)
-      do j=js,je ; do I=is-1,ie
+      do concurrent (j=js:je, I=is-1:ie)
         uhbt0(I,j) = uhbt(I,j) - Datu(I,j)*ubt(I,j)
-      enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=js-1,je ; do i=is,ie
+      enddo
+      do concurrent (J=js-1:je, i=is:ie)
         vhbt0(i,J) = vhbt(i,J) - Datv(i,J)*vbt(i,J)
-      enddo ; enddo
+      enddo
     endif
     if (CS%BT_OBC%u_OBCs_on_PE) then  ! Zero out the reference transport at OBC points
-      !$OMP parallel do default(shared)
-      do j=js,je ; do I=is-1,ie ; if (CS%BT_OBC%u_OBC_type(I,j) /= 0) then
+      do concurrent(j=js:je, I=is-1:ie, CS%BT_OBC%u_OBC_type(I,j) /= 0)
         uhbt0(I,j) = 0.0
-      endif ; enddo ; enddo
+      enddo
     endif
     if (CS%BT_OBC%v_OBCs_on_PE) then  !Zero out the reference transport at OBC points
-      !$OMP parallel do default(shared)
-      do J=js-1,je ; do i=is,ie ; if (CS%BT_OBC%v_OBC_type(i,J) /= 0) then
+      do concurrent (J=js-1:je, i=is:ie, CS%BT_OBC%v_OBC_type(i,J) /= 0)
         vhbt0(i,J) = 0.0
-      endif ; enddo ; enddo
+      enddo
     endif
   endif
 
@@ -1234,6 +1226,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   enddo
 
   if (apply_OBCs) then
+    !$omp target update from(ubt, vbt)
     ubt_first(:,:) = ubt(:,:) ; vbt_first(:,:) = vbt(:,:)
   endif
 
@@ -1294,14 +1287,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     BT_force_v(i,J) = 0.0
   endif ; enddo
   if (associated(taux_bot) .and. associated(tauy_bot)) then
-    !$OMP parallel do default(shared)
-    do j=js,je ; do I=is-1,ie ; if (G%mask2dCu(I,j) > 0.0) then
+    do concurrent (j=js:je, I=is-1:ie, G%mask2dCu(I,j) > 0.0)
       BT_force_u(I,j) = BT_force_u(I,j) - taux_bot(I,j) * GV%RZ_to_H * CS%IDatu(I,j)
-    endif ; enddo ; enddo
-    !$OMP parallel do default(shared)
-    do J=js-1,je ; do i=is,ie ; if (G%mask2dCv(i,J) > 0.0) then
+    enddo
+    do concurrent (J=js-1:je, i=is:ie, G%mask2dCv(i,J) > 0.0)
       BT_force_v(i,J) = BT_force_v(i,J) - tauy_bot(i,J) * GV%RZ_to_H * CS%IDatv(i,J)
-    endif ; enddo ; enddo
+    enddo
   endif
 
   ! bc_accel_u & bc_accel_v are only available on the potentially
@@ -1314,32 +1305,30 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   enddo ; enddo
 
   if (CS%gradual_BT_ICs) then
-    !$OMP parallel do default(shared)
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       BT_force_u(I,j) = BT_force_u(I,j) + (ubt(I,j) - CS%ubt_IC(I,j)) * Idt
       ubt(I,j) = CS%ubt_IC(I,j)
       if (abs(ubt(I,j)) < CS%vel_underflow) ubt(I,j) = 0.0
-    enddo ; enddo
-    !$OMP parallel do default(shared)
-    do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent (J=js-1:je, i=is:ie)
       BT_force_v(i,J) = BT_force_v(i,J) + (vbt(i,J) - CS%vbt_IC(i,J)) * Idt
       vbt(i,J) = CS%vbt_IC(i,J)
       if (abs(vbt(i,J)) < CS%vel_underflow) vbt(i,J) = 0.0
-    enddo ; enddo
+    enddo
   endif
 
   ! Compute instantaneous tidal velocities and apply frequency-dependent drag.
   ! Note that the filtered velocities are only updated during the current predictor step,
   ! and are calculated using the barotropic velocity from the previous correction step.
   if (CS%use_filter) then
+    !$omp target update from(ubt, vbt)
     call Filt_accum(ubt(G%IsdB:G%IedB,G%jsd:G%jed), ufilt, CS%Time, US, CS%Filt_CS_u)
     call Filt_accum(vbt(G%isd:G%ied,G%JsdB:G%JedB), vfilt, CS%Time, US, CS%Filt_CS_v)
   endif
 
   if (CS%use_filter .and. CS%linear_freq_drag) then
     call wave_drag_calc(ufilt, vfilt, Drag_u, Drag_v, G, CS%Drag_CS)
-    !$OMP do
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       Htot = 0.5 * (eta(i,j) + eta(i+1,j))
       if (GV%Boussinesq) &
         Htot = Htot + 0.5*GV%Z_to_H * (CS%bathyT(i,j) + CS%bathyT(i+1,j))
@@ -1349,9 +1338,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       else
         Drag_u(I,j) = 0.0
       endif
-    enddo ; enddo
-    !$OMP do
-    do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent (J=js-1:je, i=is:ie)
       Htot = 0.5 * (eta(i,j) + eta(i,j+1))
       if (GV%Boussinesq) &
         Htot = Htot + 0.5*GV%Z_to_H * (CS%bathyT(i,j) + CS%bathyT(i,j+1))
@@ -1361,21 +1349,19 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       else
         Drag_v(i,J) = 0.0
       endif
-    enddo ; enddo
+    enddo
   endif
 
   ! Mask out the forcing at OBC points
   if (CS%BT_OBC%u_OBCs_on_PE) then
-    !$OMP do
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       BT_force_u(I,j) = CS%OBCmask_u(I,j) * BT_force_u(I,j)
-    enddo ; enddo
+    enddo
   endif
   if (CS%BT_OBC%v_OBCs_on_PE) then
-    !$OMP do
-    do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie)
       BT_force_v(i,J) = CS%OBCmask_v(i,J) * BT_force_v(i,J)
-    enddo ; enddo
+    enddo
   endif
 
   if ((Isq > is-1) .or. (Jsq > js-1)) then
@@ -1384,6 +1370,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
     if (id_clock_pass_pre > 0) call cpu_clock_begin(id_clock_pass_pre)
     tmp_u(:,:) = 0.0 ; tmp_v(:,:) = 0.0
+    !$omp target update from(BT_force_u, BT_force_v)
     do j=js,je ; do I=Isq,Ieq ; tmp_u(I,j) = BT_force_u(I,j) ; enddo ; enddo
     do J=Jsq,Jeq ; do i=is,ie ; tmp_v(i,J) = BT_force_v(i,J) ; enddo ; enddo
     if (nonblock_setup) then
@@ -1392,6 +1379,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       call do_group_pass(CS%pass_tmp_uv, G%Domain)
       do j=jsd,jed ; do I=IsdB,IedB ; BT_force_u(I,j) = tmp_u(I,j) ; enddo ; enddo
       do J=JsdB,JedB ; do i=isd,ied ; BT_force_v(i,J) = tmp_v(i,J) ; enddo ; enddo
+      !$omp target update to(BT_force_u, BT_force_v)
     endif
     if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
@@ -1419,6 +1407,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       call complete_group_pass(CS%pass_tmp_uv, G%Domain)
       do j=jsd,jed ; do I=IsdB,IedB ; BT_force_u(I,j) = tmp_u(I,j) ; enddo ; enddo
       do J=JsdB,JedB ; do i=isd,ied ; BT_force_v(i,J) = tmp_v(i,J) ; enddo ; enddo
+      !$omp target update to(BT_force_u, BT_force_v)
     endif
     call complete_group_pass(CS%pass_gtot, CS%BT_Domain)
     call complete_group_pass(CS%pass_ubt_Cor, G%Domain)
@@ -2872,20 +2861,18 @@ subroutine btstep_find_Cor(q, DCor_u, DCor_v, f_4_u, f_4_v, isvf, ievf, jsvf, je
       f_4_u(2,I,j) = CS%OBCmask_u(I,j) * DCor_v(i+1,J-1) * q(I,J-1)
     enddo
   else  !### if (CS%answer_date < 20250601) then  ! Uncomment this later.
-    !$OMP parallel do default(shared)
-    do J=jsvf-1,jevf ; do i=isvf-1,ievf+1
+    do concurrent (J=jsvf-1:jevf, i=isvf-1:ievf+1)
       f_4_v(1,i,J) = CS%OBCmask_v(i,J) * DCor_u(I-1,j) * ((q(I,J) + q(I-1,J-1)) + q(I-1,J)) / 3.0
       f_4_v(2,i,J) = CS%OBCmask_v(i,J) * DCor_u(I,j) * (q(I,J) + (q(I-1,J) + q(I,J-1))) / 3.0
       f_4_v(4,i,J) = CS%OBCmask_v(i,J) * DCor_u(I,j+1) * (q(I,J) + (q(I-1,J) + q(I,J+1))) / 3.0
       f_4_v(3,i,J) = CS%OBCmask_v(i,J) * DCor_u(I-1,j+1) * ((q(I,J) + q(I-1,J+1)) + q(I-1,J)) / 3.0
-    enddo ; enddo
-    !$OMP parallel do default(shared)
-    do j=jsvf-1,jevf+1 ; do I=isvf-1,ievf
+    enddo
+    do concurrent (j=jsvf-1:jevf+1, I=isvf-1:ievf)
       f_4_u(4,I,j) = CS%OBCmask_u(I,j) * DCor_v(i+1,J) * (q(I,J) + (q(I+1,J) + q(I,J-1))) / 3.0
       f_4_u(3,I,j) = CS%OBCmask_u(I,j) * DCor_v(i,J) * (q(I,J) + (q(I-1,J) + q(I,J-1))) / 3.0
       f_4_u(1,I,j) = CS%OBCmask_u(I,j) * DCor_v(i,J-1) * ((q(I,J) + q(I-1,J-1)) + q(I,J-1)) / 3.0
       f_4_u(2,I,j) = CS%OBCmask_u(I,j) * DCor_v(i+1,J-1) * ((q(I,J) + q(I+1,J-1)) + q(I,J-1)) / 3.0
-    enddo ; enddo
+    enddo
   ! else
   !   C1_3 = 1.0 / 3.0
   !   !$OMP parallel do default(shared)
@@ -5125,72 +5112,62 @@ subroutine find_face_areas(Datu, Datv, G, GV, US, CS, MS, halo, eta, add_max)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   hs = max(halo,0)
 
-  !$OMP parallel default(shared) private(H1,H2,Z_to_H)
   if (present(eta)) then
     ! The use of harmonic mean thicknesses ensure positive definiteness.
     if (GV%Boussinesq) then
-      !$OMP do
-      do j=js-hs,je+hs ; do I=is-1-hs,ie+hs
+      do concurrent (j=js-hs:je+hs, I=is-1-hs:ie+hs)
         H1 = CS%bathyT(i,j)*GV%Z_to_H + eta(i,j) ; H2 = CS%bathyT(i+1,j)*GV%Z_to_H + eta(i+1,j)
         Datu(I,j) = 0.0 ; if ((H1 > 0.0) .and. (H2 > 0.0)) &
         Datu(I,j) = CS%dy_Cu(I,j) * (2.0 * H1 * H2) / (H1 + H2)
 !       Datu(I,j) = CS%dy_Cu(I,j) * 0.5 * (H1 + H2)
-      enddo ; enddo
-      !$OMP do
-      do J=js-1-hs,je+hs ; do i=is-hs,ie+hs
+      enddo
+      do concurrent (J=js-1-hs:je+hs, i=is-hs:ie+hs)
         H1 = CS%bathyT(i,j)*GV%Z_to_H + eta(i,j) ; H2 = CS%bathyT(i,j+1)*GV%Z_to_H + eta(i,j+1)
         Datv(i,J) = 0.0 ; if ((H1 > 0.0) .and. (H2 > 0.0)) &
         Datv(i,J) = CS%dx_Cv(i,J) * (2.0 * H1 * H2) / (H1 + H2)
 !       Datv(i,J) = CS%dy_v(i,J) * 0.5 * (H1 + H2)
-      enddo ; enddo
+      enddo
     else
-      !$OMP do
-      do j=js-hs,je+hs ; do I=is-1-hs,ie+hs
+      do concurrent (j=js-hs:je+hs, I=is-1-hs:ie+hs)
         Datu(I,j) = 0.0 ; if ((eta(i,j) > 0.0) .and. (eta(i+1,j) > 0.0)) &
         Datu(I,j) = CS%dy_Cu(I,j) * (2.0 * eta(i,j) * eta(i+1,j)) / &
                                   (eta(i,j) + eta(i+1,j))
         ! Datu(I,j) = CS%dy_Cu(I,j) * 0.5 * (eta(i,j) + eta(i+1,j))
-      enddo ; enddo
-      !$OMP do
-      do J=js-1-hs,je+hs ; do i=is-hs,ie+hs
+      enddo
+      do concurrent (J=js-1-hs:je+hs, i=is-hs:ie+hs)
         Datv(i,J) = 0.0 ; if ((eta(i,j) > 0.0) .and. (eta(i,j+1) > 0.0)) &
         Datv(i,J) = CS%dx_Cv(i,J) * (2.0 * eta(i,j) * eta(i,j+1)) / &
                                   (eta(i,j) + eta(i,j+1))
         ! Datv(i,J) = CS%dy_v(i,J) * 0.5 * (eta(i,j) + eta(i,j+1))
-      enddo ; enddo
+      enddo
     endif
   elseif (present(add_max)) then
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
 
-    !$OMP do
-    do j=js-hs,je+hs ; do I=is-1-hs,ie+hs
+    do concurrent (j=js-hs:je+hs, I=is-1-hs:ie+hs)
       Datu(I,j) = CS%dy_Cu(I,j) * Z_to_H * &
                  max(max(CS%bathyT(i+1,j), CS%bathyT(i,j)) + (G%Z_ref + add_max), 0.0)
-    enddo ; enddo
-    !$OMP do
-    do J=js-1-hs,je+hs ; do i=is-hs,ie+hs
+    enddo
+    do concurrent (J=js-1-hs:je+hs, i=is-hs:ie+hs)
       Datv(i,J) = CS%dx_Cv(i,J) * Z_to_H * &
                  max(max(CS%bathyT(i,j+1), CS%bathyT(i,j)) + (G%Z_ref + add_max), 0.0)
-    enddo ; enddo
+    enddo
   else
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
 
-    !$OMP do
-    do j=js-hs,je+hs ; do I=is-1-hs,ie+hs
+    do concurrent (j=js-hs:je+hs, I=is-1-hs:ie+hs)
       H1 = (CS%bathyT(i,j) + G%Z_ref) * Z_to_H ; H2 = (CS%bathyT(i+1,j) + G%Z_ref) * Z_to_H
       Datu(I,j) = 0.0
       if ((H1 > 0.0) .and. (H2 > 0.0)) &
         Datu(I,j) = CS%dy_Cu(I,j) * (2.0 * H1 * H2) / (H1 + H2)
-    enddo ; enddo
-    !$OMP do
-    do J=js-1-hs,je+hs ; do i=is-hs,ie+hs
+    enddo
+    do concurrent (J=js-1-hs:je+hs, i=is-hs:ie+hs)
       H1 = (CS%bathyT(i,j) + G%Z_ref) * Z_to_H ; H2 = (CS%bathyT(i,j+1) + G%Z_ref) * Z_to_H
       Datv(i,J) = 0.0
       if ((H1 > 0.0) .and. (H2 > 0.0)) &
         Datv(i,J) = CS%dx_Cv(i,J) * (2.0 * H1 * H2) / (H1 + H2)
-    enddo ; enddo
+    enddo
   endif
-  !$OMP end parallel
 
 end subroutine find_face_areas
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3385,20 +3385,17 @@ subroutine btstep_layer_accel(dt, u_accel_bt, v_accel_bt, pbce, gtot_E, gtot_W, 
   accel_underflow = CS%vel_underflow * Idt
 
   ! Now calculate each layer's accelerations.
-  !$OMP parallel do default(shared)
-  do k=1,nz
-    do j=js,je ; do I=is-1,ie
-      accel_layer_u(I,j,k) = (u_accel_bt(I,j) - &
-           (((pbce(i+1,j,k) - gtot_W(i+1,j)) * e_anom(i+1,j)) - &
-            ((pbce(i,j,k) - gtot_E(i,j)) * e_anom(i,j))) * CS%IdxCu(I,j) )
-      if (abs(accel_layer_u(I,j,k)) < accel_underflow) accel_layer_u(I,j,k) = 0.0
-    enddo ; enddo
-    do J=js-1,je ; do i=is,ie
-      accel_layer_v(i,J,k) = (v_accel_bt(i,J) - &
-           (((pbce(i,j+1,k) - gtot_S(i,j+1)) * e_anom(i,j+1)) - &
-            ((pbce(i,j,k) - gtot_N(i,j)) * e_anom(i,j))) * CS%IdyCv(i,J) )
-      if (abs(accel_layer_v(i,J,k)) < accel_underflow) accel_layer_v(i,J,k) = 0.0
-    enddo ; enddo
+  do concurrent (k=1:nz, j=js:je, I=is-1:ie)
+    accel_layer_u(I,j,k) = (u_accel_bt(I,j) - &
+          (((pbce(i+1,j,k) - gtot_W(i+1,j)) * e_anom(i+1,j)) - &
+          ((pbce(i,j,k) - gtot_E(i,j)) * e_anom(i,j))) * CS%IdxCu(I,j) )
+    if (abs(accel_layer_u(I,j,k)) < accel_underflow) accel_layer_u(I,j,k) = 0.0
+  enddo
+  do concurrent (k=1:nz, J=js-1:je, i=is:ie)
+    accel_layer_v(i,J,k) = (v_accel_bt(i,J) - &
+          (((pbce(i,j+1,k) - gtot_S(i,j+1)) * e_anom(i,j+1)) - &
+          ((pbce(i,j,k) - gtot_N(i,j)) * e_anom(i,j))) * CS%IdyCv(i,J) )
+    if (abs(accel_layer_v(i,J,k)) < accel_underflow) accel_layer_v(i,J,k) = 0.0
   enddo
 
 end subroutine btstep_layer_accel

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1418,23 +1418,21 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   endif
   ! The various elements of gtot are positive definite but directional, so use
   ! the polarity arrays to sort out when the directions have shifted.
-  do j=jsvf-1,jevf+1 ; do i=isvf-1,ievf+1
+  do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1)
     if (CS%ua_polarity(i,j) < 0.0) call swap(gtot_E(i,j), gtot_W(i,j))
     if (CS%va_polarity(i,j) < 0.0) call swap(gtot_N(i,j), gtot_S(i,j))
-  enddo ; enddo
+  enddo
 
-  !$OMP parallel do default(shared)
-  do j=js,je ; do I=is-1,ie
+  do concurrent (j=js:je, I=is-1:ie)
     Cor_ref_u(I,j) =  &
         (((f_4_u(4,I,j) * vbt_Cor(i+1,j)) + (f_4_u(1,I,j) * vbt_Cor(i  ,j-1))) + &
          ((f_4_u(3,I,j) * vbt_Cor(i  ,j)) + (f_4_u(2,I,j) * vbt_Cor(i+1,j-1))))
-  enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=js-1,je ; do i=is,ie
+  enddo
+  do concurrent (J=js-1:je, i=is:ie)
     Cor_ref_v(i,J) = -1.0 * &
         (((f_4_v(1,i,J) * ubt_Cor(I-1,j)) + (f_4_v(4,i,J) * ubt_Cor(I  ,j+1))) + &
          ((f_4_v(2,i,J) * ubt_Cor(I  ,j)) + (f_4_v(3,i,J) * ubt_Cor(I-1,j+1))))
-  enddo ; enddo
+  enddo
 
   ! Now start new halo updates.
   if (nonblock_setup) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4324,9 +4324,9 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
                                ! The harmonic mean uses a weight of (1 - wt_arith).
   real :: e_u(SZIB_(G),SZJ_(G),SZK_(GV)+1) ! The interface heights at u-velocity points [H ~> m or kg m-2]
   real :: e_v(SZI_(G),SZJB_(G),SZK_(GV)+1)  ! The interface heights at v-velocity points [H ~> m or kg m-2]
-  real :: D_shallow_u(SZI_(G)) ! The height of the shallower of the adjacent bathymetric depths
+  real :: D_shallow_u(SZI_(G),SZJB_(G)) ! The height of the shallower of the adjacent bathymetric depths
                                ! around a u-point (positive upward) [H ~> m or kg m-2]
-  real :: D_shallow_v(SZIB_(G))! The height of the shallower of the adjacent bathymetric depths
+  real :: D_shallow_v(SZIB_(G),SZJ_(G))! The height of the shallower of the adjacent bathymetric depths
                                ! around a v-point (positive upward) [H ~> m or kg m-2]
   real :: Z_to_H               ! A local conversion factor [H Z-1 ~> nondim or kg m-3]
 
@@ -4377,19 +4377,19 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
       do I=is-1,ie
         e_u(I,j,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
-        D_shallow_u(I) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
+        D_shallow_u(I,j) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
       enddo
       do k=nz,1,-1 ; do I=is-1,ie
         e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
         h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
-        if (e_u(I,j,K+1) >= D_shallow_u(I)) then
+        if (e_u(I,j,K+1) >= D_shallow_u(I,j)) then
           hatu(I,j,k) = h_arith
         else
           h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
-          if (e_u(I,j,K) <= D_shallow_u(I)) then
+          if (e_u(I,j,K) <= D_shallow_u(I,j)) then
             hatu(I,j,k) = h_harm
           else
-            wt_arith = (e_u(I,j,K) - D_shallow_u(I)) / (h_arith + h_neglect)
+            wt_arith = (e_u(I,j,K) - D_shallow_u(I,j)) / (h_arith + h_neglect)
             hatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
@@ -4456,19 +4456,19 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
       do i=is,ie
         e_v(i,J,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
-        D_shallow_v(I) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
+        D_shallow_v(i,J) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
       enddo
       do k=nz,1,-1 ; do i=is,ie
         e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
         h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
-        if (e_v(i,J,K+1) >= D_shallow_v(i)) then
+        if (e_v(i,J,K+1) >= D_shallow_v(i,J)) then
           hatv(i,J,k) = h_arith
         else
           h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
-          if (e_v(i,J,K) <= D_shallow_v(i)) then
+          if (e_v(i,J,K) <= D_shallow_v(i,J)) then
             hatv(i,J,k) = h_harm
           else
-            wt_arith = (e_v(i,J,K) - D_shallow_v(i)) / (h_arith + h_neglect)
+            wt_arith = (e_v(i,J,K) - D_shallow_v(i,J)) / (h_arith + h_neglect)
             hatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2548,17 +2548,14 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
         vhbt(i,J) = (vhbt_int(i,J) - vhbt_int_prev(i,J)) * Idtbt
       enddo ; enddo
     elseif (use_BT_cont) then
-      !$OMP do schedule(static)
-      do j=jsv,jev ; do I=isv-1,iev
+      do concurrent (j=jsv:jev, I=isv-1:iev)
         ubt_trans(I,j) = trans_wt1*ubt(I,j) + trans_wt2*ubt_prev(I,j)
         uhbt(I,j) = find_uhbt(ubt_trans(I,j), BTCL_u(I,j)) + uhbt0(I,j)
-      enddo ; enddo
-      !$OMP end do nowait
-      !$OMP do schedule(static)
-      do J=jsv-1,jev ; do i=isv,iev
+      enddo
+      do concurrent (J=jsv-1:jev, i=isv:iev)
         vbt_trans(i,J) = trans_wt1*vbt(i,J) + trans_wt2*vbt_prev(i,J)
         vhbt(i,J) = find_vhbt(vbt_trans(i,J), BTCL_v(i,J)) + vhbt0(i,J)
-      enddo ; enddo
+      enddo
     else
       !$OMP do schedule(static)
       do j=jsv,jev ; do I=isv-1,iev

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4322,8 +4322,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
                                ! in roundoff and can be neglected [H ~> m or kg m-2].
   real :: wt_arith             ! The weight for the arithmetic mean thickness [nondim].
                                ! The harmonic mean uses a weight of (1 - wt_arith).
-  real :: e_u(SZIB_(G),SZK_(GV)+1) ! The interface heights at u-velocity points [H ~> m or kg m-2]
-  real :: e_v(SZI_(G),SZK_(GV)+1)  ! The interface heights at v-velocity points [H ~> m or kg m-2]
+  real :: e_u(SZIB_(G),SZJ_(G),SZK_(GV)+1) ! The interface heights at u-velocity points [H ~> m or kg m-2]
+  real :: e_v(SZI_(G),SZJB_(G),SZK_(GV)+1)  ! The interface heights at v-velocity points [H ~> m or kg m-2]
   real :: D_shallow_u(SZI_(G)) ! The height of the shallower of the adjacent bathymetric depths
                                ! around a u-point (positive upward) [H ~> m or kg m-2]
   real :: D_shallow_v(SZIB_(G))! The height of the shallower of the adjacent bathymetric depths
@@ -4376,20 +4376,20 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     elseif (CS%hvel_scheme == HYBRID .or. use_default) then
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
       do I=is-1,ie
-        e_u(I,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
+        e_u(I,j,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
         D_shallow_u(I) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
       enddo
       do k=nz,1,-1 ; do I=is-1,ie
-        e_u(I,K) = e_u(I,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
+        e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
         h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
-        if (e_u(I,K+1) >= D_shallow_u(I)) then
+        if (e_u(I,j,K+1) >= D_shallow_u(I)) then
           hatu(I,j,k) = h_arith
         else
           h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
-          if (e_u(I,K) <= D_shallow_u(I)) then
+          if (e_u(I,j,K) <= D_shallow_u(I)) then
             hatu(I,j,k) = h_harm
           else
-            wt_arith = (e_u(I,K) - D_shallow_u(I)) / (h_arith + h_neglect)
+            wt_arith = (e_u(I,j,K) - D_shallow_u(I)) / (h_arith + h_neglect)
             hatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
@@ -4455,20 +4455,20 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     elseif (CS%hvel_scheme == HYBRID .or. use_default) then
       Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
       do i=is,ie
-        e_v(i,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
+        e_v(i,J,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
         D_shallow_v(I) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
       enddo
       do k=nz,1,-1 ; do i=is,ie
-        e_v(i,K) = e_v(i,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
+        e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
         h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
-        if (e_v(i,K+1) >= D_shallow_v(i)) then
+        if (e_v(i,J,K+1) >= D_shallow_v(i)) then
           hatv(i,J,k) = h_arith
         else
           h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
-          if (e_v(i,K) <= D_shallow_v(i)) then
+          if (e_v(i,J,K) <= D_shallow_v(i)) then
             hatv(i,J,k) = h_harm
           else
-            wt_arith = (e_v(i,K) - D_shallow_v(i)) / (h_arith + h_neglect)
+            wt_arith = (e_v(i,J,K) - D_shallow_v(i)) / (h_arith + h_neglect)
             hatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -857,7 +857,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
-  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v)
+  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v)
 
 !   Calculate the constant coefficients for the Coriolis force terms in the
 ! barotropic momentum equations.  This has to be done quite early to start
@@ -917,12 +917,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     ! These calculations can be done almost immediately, but the halo updates
     ! must be done before the [abcd]mer and [abcd]zon are calculated.
     if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
-    !$omp target update from(q)
+    !$omp target update from(q, DCor_u, DCor_v)
     if (nonblock_setup) then
       call start_group_pass(CS%pass_q_DCor, CS%BT_Domain, clock=id_clock_pass_pre)
     else
       call do_group_pass(CS%pass_q_DCor, CS%BT_Domain, clock=id_clock_pass_pre)
-      !$omp target update to(q)
+      !$omp target update to(q, DCor_u, DCor_v)
     endif
     if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
   endif
@@ -2142,7 +2142,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp   map(release: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
   !$omp       Corv_avg, LDu_avg, LDv_avg, e_anom, q, ubt, vbt, bt_rem_u, bt_rem_v, BT_force_u, &
   !$omp       BT_force_v, u_accel_bt, v_accel_bt, uhbt, vhbt, ubt_prev, vbt_prev, ubt_trans, &
-  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v)
+  !$omp       vbt_trans, Cor_u, Cor_v, Cor_ref_u, Cor_ref_v, PFu, PFv, DCor_u, DCor_v)
 
 end subroutine btstep
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -859,7 +859,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
   !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
   !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v, uh0, vh0)
+  !$omp       CS%OBCmask_v)
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
@@ -2189,7 +2189,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
   !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
   !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v, uh0, vh0)
+  !$omp       CS%OBCmask_v)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 
@@ -2529,6 +2529,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     ! Update the range of valid points, either by doing a halo update or by marching inward.
     if ((iev - stencil < ie) .or. (jev - stencil < je)) then
       if (id_clock_calc > 0) call cpu_clock_end(id_clock_calc)
+      ! TODO: direct GPU-to-GPU transfer
       !$omp target update from(ubt, vbt, eta)
       call do_group_pass(CS%pass_eta_ubt, CS%BT_Domain, clock=id_clock_pass_step)
       !$omp target update to(ubt, vbt, eta)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1565,33 +1565,34 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
         H_to_Z = GV%H_to_RZ / CS%Rho_BT_lin
       endif
       do concurrent (j=js:je, i=is:ie) local(Idt_max2,H_eff_dx2,dyn_coef_max,ice_strength)
-      ! First determine the maximum stable value for dyn_coef_eta.
+        ! First determine the maximum stable value for dyn_coef_eta.
 
-      !   This estimate of the maximum stable time step is pretty accurate for
-      ! gravity waves, but it is a conservative estimate since it ignores the
-      ! stabilizing effect of the bottom drag.
-      Idt_max2 = 0.5 * (dgeo_de * (1.0 + 2.0*CS%bebt)) * (G%IareaT(i,j) * &
-            (((gtot_E(i,j) * (Datu(I,j)*G%IdxCu(I,j))) + &
-              (gtot_W(i,j) * (Datu(I-1,j)*G%IdxCu(I-1,j)))) + &
-             ((gtot_N(i,j) * (Datv(i,J)*G%IdyCv(i,J))) + &
-              (gtot_S(i,j) * (Datv(i,J-1)*G%IdyCv(i,J-1))))) + &
-            ((G%Coriolis2Bu(I,J) + G%Coriolis2Bu(I-1,J-1)) + &
-             (G%Coriolis2Bu(I-1,J) + G%Coriolis2Bu(I,J-1))) * CS%BT_Coriolis_scale**2 )
-      H_eff_dx2 = max(H_min_dyn * ((G%IdxT(i,j)**2) + (G%IdyT(i,j)**2)), &
-                      G%IareaT(i,j) * &
-                        (((Datu(I,j)*G%IdxCu(I,j)) + (Datu(I-1,j)*G%IdxCu(I-1,j))) + &
-                         ((Datv(i,J)*G%IdyCv(i,J)) + (Datv(i,J-1)*G%IdyCv(i,J-1))) ) )
-      dyn_coef_max = CS%const_dyn_psurf * max(0.0, 1.0 - dtbt**2 * Idt_max2) / &
-                     (dtbt**2 * H_eff_dx2)
+        !   This estimate of the maximum stable time step is pretty accurate for
+        ! gravity waves, but it is a conservative estimate since it ignores the
+        ! stabilizing effect of the bottom drag.
+        Idt_max2 = 0.5 * (dgeo_de * (1.0 + 2.0*CS%bebt)) * (G%IareaT(i,j) * &
+              (((gtot_E(i,j) * (Datu(I,j)*G%IdxCu(I,j))) + &
+                (gtot_W(i,j) * (Datu(I-1,j)*G%IdxCu(I-1,j)))) + &
+              ((gtot_N(i,j) * (Datv(i,J)*G%IdyCv(i,J))) + &
+                (gtot_S(i,j) * (Datv(i,J-1)*G%IdyCv(i,J-1))))) + &
+              ((G%Coriolis2Bu(I,J) + G%Coriolis2Bu(I-1,J-1)) + &
+              (G%Coriolis2Bu(I-1,J) + G%Coriolis2Bu(I,J-1))) * CS%BT_Coriolis_scale**2 )
+        H_eff_dx2 = max(H_min_dyn * ((G%IdxT(i,j)**2) + (G%IdyT(i,j)**2)), &
+                        G%IareaT(i,j) * &
+                          (((Datu(I,j)*G%IdxCu(I,j)) + (Datu(I-1,j)*G%IdxCu(I-1,j))) + &
+                          ((Datv(i,J)*G%IdyCv(i,J)) + (Datv(i,J-1)*G%IdyCv(i,J-1))) ) )
+        dyn_coef_max = CS%const_dyn_psurf * max(0.0, 1.0 - dtbt**2 * Idt_max2) / &
+                      (dtbt**2 * H_eff_dx2)
 
-      ! ice_strength has units of [L2 Z-1 T-2 ~> m s-2]. rigidity_ice_[uv] has units of [L4 Z-1 T-1 ~> m3 s-1].
-      ice_strength = ((forces%rigidity_ice_u(I,j) + forces%rigidity_ice_u(I-1,j)) + &
-                      (forces%rigidity_ice_v(i,J) + forces%rigidity_ice_v(i,J-1))) / &
-                      (CS%ice_strength_length**2 * dtbt)
+        ! ice_strength has units of [L2 Z-1 T-2 ~> m s-2]. rigidity_ice_[uv] has units of [L4 Z-1 T-1 ~> m3 s-1].
+        ice_strength = ((forces%rigidity_ice_u(I,j) + forces%rigidity_ice_u(I-1,j)) + &
+                        (forces%rigidity_ice_v(i,J) + forces%rigidity_ice_v(i,J-1))) / &
+                        (CS%ice_strength_length**2 * dtbt)
 
-      ! Units of dyn_coef: [L2 T-2 H-1 ~> m s-2 or m4 s-2 kg-1]
-      dyn_coef_eta(i,j) = min(dyn_coef_max, ice_strength * H_to_Z)
-    enddo ; endif
+        ! Units of dyn_coef: [L2 T-2 H-1 ~> m s-2 or m4 s-2 kg-1]
+        dyn_coef_eta(i,j) = min(dyn_coef_max, ice_strength * H_to_Z)
+      enddo
+    endif
   endif
 
   if (id_clock_calc_pre > 0) call cpu_clock_end(id_clock_calc_pre)
@@ -1686,14 +1687,14 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   endif
 
   if (CS%id_ubtdt > 0) then
-    do j=js-1,je+1 ; do I=is-1,ie
+    do concurrent (j=js-1:je+1, I=is-1:ie)
       ubt_st(I,j) = ubt(I,j)
-    enddo ; enddo
+    enddo
   endif
   if (CS%id_vbtdt > 0) then
-    do J=js-1,je ; do i=is-1,ie+1
+    do concurrent (J=js-1:je, i=is-1:ie+1)
       vbt_st(i,J) = vbt(i,J)
-    enddo ; enddo
+    enddo
   endif
 
   if (query_averaging_enabled(CS%diag)) then
@@ -1815,19 +1816,17 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     ! This block of code may be unnecessary because e_anom is only used for accelerations that
     ! are then recalculated at OBC points.
     if (CS%BT_OBC%u_OBCs_on_PE) then  ! copy back the value for u-points on the boundary.
-      !GOMP parallel do default(shared)
-      do j=js,je ; do I=is-1,ie
+      do concurrent (j=js:je, I=is-1:ie)
         if (CS%BT_OBC%u_OBC_type(I,j) > 0) e_anom(i+1,j) = e_anom(i,j)  ! OBC_DIRECTION_E
         if (CS%BT_OBC%u_OBC_type(I,j) < 0) e_anom(i,j) = e_anom(i+1,j)  ! OBC_DIRECTION_W
-      enddo ; enddo
+      enddo
     endif
 
     if (CS%BT_OBC%v_OBCs_on_PE) then  ! copy back the value for v-points on the boundary.
-      !GOMP parallel do default(shared)
-      do J=js-1,je ; do i=is,ie
+      do concurrent (J=js-1:je, i=is:ie)
         if (CS%BT_OBC%v_OBC_type(i,J) > 0) e_anom(i,j+1) = e_anom(i,j)  ! OBC_DIRECTION_N
         if (CS%BT_OBC%v_OBC_type(i,J) < 0) e_anom(i,j) = e_anom(i,j+1)  ! OBC_DIRECTION_S
-      enddo ; enddo
+      enddo
     endif
   endif
 
@@ -1858,35 +1857,37 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! Find or store the weighted time-mean velocities and transports.
   if (CS%answer_date < 20190101) then
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       CS%ubtav(I,j) = CS%ubtav(I,j) * I_sum_wt_trans
       uhbtav(I,j) = uhbtav(I,j) * I_sum_wt_trans
       ubt_wtd(I,j) = ubt_wtd(I,j) * I_sum_wt_vel
-    enddo ; enddo
+    enddo
 
-    do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie)
       CS%vbtav(i,J) = CS%vbtav(i,J) * I_sum_wt_trans
       vhbtav(i,J) = vhbtav(i,J) * I_sum_wt_trans
       vbt_wtd(i,J) = vbt_wtd(i,J) * I_sum_wt_vel
-    enddo ; enddo
+    enddo
   endif
 
   if (CS%use_filter .and. CS%linear_freq_drag) then ! Apply frequency-dependent drag
-    !$OMP do
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       u_accel_bt(I,j) = u_accel_bt(I,j) - Drag_u(I,j)
-    enddo ; enddo
-    !$OMP do
-    do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent (J=js-1:je, i=is:ie)
       v_accel_bt(i,J) = v_accel_bt(i,J) - Drag_v(i,J)
-    enddo ; enddo
+    enddo
 
-    if ((CS%id_LDu_bt > 0) .or. (associated(ADp%bt_lwd_u))) then ; do j=js,je ; do I=is-1,ie
-      LDu_avg(I,j) = LDu_avg(I,j) - Drag_u(I,j)
-    enddo ; enddo ; endif
-    if ((CS%id_LDv_bt > 0) .or. (associated(ADp%bt_lwd_v))) then ; do J=js-1,je ; do i=is,ie
-      LDv_avg(i,J) = LDv_avg(i,J) - Drag_v(i,J)
-    enddo ; enddo ; endif
+    if ((CS%id_LDu_bt > 0) .or. (associated(ADp%bt_lwd_u))) then
+      do concurrent (j=js:je, I=is-1:ie)
+        LDu_avg(I,j) = LDu_avg(I,j) - Drag_u(I,j)
+      enddo
+    endif
+    if ((CS%id_LDv_bt > 0) .or. (associated(ADp%bt_lwd_v))) then
+      do concurrent (J=js-1:je, i=is:ie)
+        LDv_avg(i,J) = LDv_avg(i,J) - Drag_v(i,J)
+      enddo
+    endif
   endif
 
   if (id_clock_calc_post > 0) call cpu_clock_end(id_clock_calc_post)
@@ -1929,8 +1930,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (query_averaging_enabled(CS%diag)) then
 
     if (CS%gradual_BT_ICs) then
-      do j=js,je ; do I=is-1,ie ; CS%ubt_IC(I,j) = ubt_wtd(I,j) ; enddo ; enddo
-      do J=js-1,je ; do i=is,ie ; CS%vbt_IC(i,J) = vbt_wtd(i,J) ; enddo ; enddo
+      do concurrent (j=js:je, I=is-1:ie) ; CS%ubt_IC(I,j) = ubt_wtd(I,j) ; enddo
+      do concurrent (J=js-1:je, i=is:ie) ; CS%vbt_IC(i,J) = vbt_wtd(i,J) ; enddo
     endif
 
     ! Calculate various time-averaged barotropic diagnostics.
@@ -1943,76 +1944,80 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       if (CS%id_LDv_bt > 0) call post_data(CS%id_LDv_bt, LDv_avg, CS%diag)
     else ! if (CS%answer_date < 20190101) then
       if (CS%id_PFu_bt > 0) then
-        do j=js,je ; do I=is-1,ie
+        do concurrent (j=js:je, I=is-1:ie)
           PFu_avg(I,j) = PFu_avg(I,j) * I_sum_wt_accel
-        enddo ; enddo
+        enddo
+        !$omp target update from(PFu_avg)
         call post_data(CS%id_PFu_bt, PFu_avg, CS%diag)
       endif
       if (CS%id_PFv_bt > 0) then
-        do J=js-1,je ; do i=is,ie
+        do concurrent (J=js-1:je, i=is:ie)
           PFv_avg(i,J) = PFv_avg(i,J) * I_sum_wt_accel
-        enddo ; enddo
+        enddo
+        !$omp target update from(PFv_avg)
         call post_data(CS%id_PFv_bt, PFv_avg, CS%diag)
       endif
       if (CS%id_Coru_bt > 0) then
-        do j=js,je ; do I=is-1,ie
+        do concurrent (j=js:je, I=is-1:ie)
           Coru_avg(I,j) = Coru_avg(I,j) * I_sum_wt_accel
-        enddo ; enddo
+        enddo
+        !$omp target update from(Coru_avg)
         call post_data(CS%id_Coru_bt, Coru_avg, CS%diag)
       endif
       if (CS%id_Corv_bt > 0) then
-        do J=js-1,je ; do i=is,ie
+        do concurrent (J=js-1:je, i=is:ie)
           Corv_avg(i,J) = Corv_avg(i,J) * I_sum_wt_accel
-        enddo ; enddo
+        enddo
+        !$omp target update from(Corv_avg)
         call post_data(CS%id_Corv_bt, Corv_avg, CS%diag)
       endif
     endif
 
     ! Diagnostics for time tendency
     if (CS%id_ubtdt > 0) then
-      do j=js,je ; do I=is-1,ie
+      do concurrent (j=js:je, I=is-1:ie)
         ubt_dt(I,j) = (ubt_wtd(I,j) - ubt_st(I,j))*Idt
-      enddo ; enddo
+      enddo
       call post_data(CS%id_ubtdt, ubt_dt(IsdB:IedB,jsd:jed), CS%diag)
     endif
     if (CS%id_vbtdt > 0) then
-      do J=js-1,je ; do i=is,ie
+      do concurrent (J=js-1:je, i=is:ie)
         vbt_dt(i,J) = (vbt_wtd(i,J) - vbt_st(i,J))*Idt
-      enddo ; enddo
+      enddo
       call post_data(CS%id_vbtdt, vbt_dt(isd:ied,JsdB:JedB), CS%diag)
     endif
 
     ! Copy decomposed barotropic accelerations to ADp
     if (associated(ADp%bt_pgf_u)) then
       ! Note that CS%IdxCu is 0 at OBC points, so ADp%bt_pgf_u is zeroed out there.
-      do k=1,nz ; do j=js,je ; do I=is-1,ie
+      do concurrent (k=1:nz, j=js:je, I=is-1:ie)
         ADp%bt_pgf_u(I,j,k) = PFu_avg(I,j) - &
           (((pbce(i+1,j,k) - gtot_W(i+1,j)) * e_anom(i+1,j)) - &
            ((pbce(i,j,k) - gtot_E(i,j)) * e_anom(i,j))) * CS%IdxCu(I,j)
-      enddo ; enddo ; enddo
+      enddo
     endif
     if (associated(ADp%bt_pgf_v)) then
       ! Note that CS%IdyCv is 0 at OBC points, so ADp%bt_pgf_v is zeroed out there.
-      do k=1,nz ; do J=js-1,je ; do i=is,ie
+      do concurrent (k=1:nz, J=js-1:je, i=is:ie)
         ADp%bt_pgf_v(i,J,k) = PFv_avg(i,J) - &
           (((pbce(i,j+1,k) - gtot_S(i,j+1)) * e_anom(i,j+1)) - &
            ((pbce(i,j,k) - gtot_N(i,j)) * e_anom(i,j))) * CS%IdyCv(i,J)
-      enddo ; enddo ; enddo
+      enddo
     endif
 
-    if (associated(ADp%bt_cor_u)) then ; do j=js,je ; do I=is-1,ie
+    if (associated(ADp%bt_cor_u)) then ; do concurrent (j=js:je, I=is-1:ie)
       ADp%bt_cor_u(I,j) = Coru_avg(I,j)
-    enddo ; enddo ; endif
-    if (associated(ADp%bt_cor_v)) then ; do J=js-1,je ; do i=is,ie
+    enddo ; endif
+    if (associated(ADp%bt_cor_v)) then ; do concurrent (J=js-1:je, i=is:ie)
       ADp%bt_cor_v(i,J) = Corv_avg(i,J)
-    enddo ; enddo ; endif
+    enddo ; endif
 
-    if (associated(ADp%bt_lwd_u)) then ; do j=js,je ; do I=is-1,ie
+    if (associated(ADp%bt_lwd_u)) then ; do concurrent (j=js:je, I=is-1:ie)
       ADp%bt_lwd_u(I,j) = LDu_avg(I,j)
-    enddo ; enddo ; endif
-    if (associated(ADp%bt_lwd_v)) then ; do J=js-1,je ; do i=is,ie
+    enddo ; endif
+    if (associated(ADp%bt_lwd_v)) then ; do concurrent (J=js-1:je, i=is:ie)
       ADp%bt_lwd_v(i,J) = LDv_avg(i,J)
-    enddo ; enddo ; endif
+    enddo ; endif
 
     if (CS%id_ubtforce > 0) call post_data(CS%id_ubtforce, BT_force_u(IsdB:IedB,jsd:jed), CS%diag)
     if (CS%id_vbtforce > 0) call post_data(CS%id_vbtforce, BT_force_v(isd:ied,JsdB:JedB), CS%diag)
@@ -2114,40 +2119,46 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       endif
     endif
   else
-    if (CS%id_frhatu1 > 0) CS%frhatu1(:,:,:) = CS%frhatu(:,:,:)
-    if (CS%id_frhatv1 > 0) CS%frhatv1(:,:,:) = CS%frhatv(:,:,:)
+    if (CS%id_frhatu1 > 0) then
+      !$omp target update from(CS%frhatu)
+      CS%frhatu1(:,:,:) = CS%frhatu(:,:,:)
+    endif
+    if (CS%id_frhatv1 > 0) then
+      !$omp target update from(CS%frhatv)
+      CS%frhatv1(:,:,:) = CS%frhatv(:,:,:)
+    endif
   endif
 
   if (associated(ADp%diag_hfrac_u)) then
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       ADp%diag_hfrac_u(I,j,k) = CS%frhatu(I,j,k)
-    enddo ; enddo ; enddo
+    enddo
   endif
   if (associated(ADp%diag_hfrac_v)) then
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       ADp%diag_hfrac_v(i,J,k) = CS%frhatv(i,J,k)
-    enddo ; enddo ; enddo
+    enddo
   endif
 
   if (use_BT_cont .and. associated(ADp%diag_hu)) then
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       ADp%diag_hu(I,j,k) = BT_cont%h_u(I,j,k)
-    enddo ; enddo ; enddo
+    enddo
   endif
   if (use_BT_cont .and. associated(ADp%diag_hv)) then
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       ADp%diag_hv(i,J,k) = BT_cont%h_v(i,J,k)
-    enddo ; enddo ; enddo
+    enddo
   endif
   if (associated(ADp%visc_rem_u)) then
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       ADp%visc_rem_u(I,j,k) = visc_rem_u(I,j,k)
-    enddo ; enddo ; enddo
+    enddo
   endif
   if (associated(ADp%visc_rem_v)) then
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       ADp%visc_rem_v(i,J,k) = visc_rem_v(i,J,k)
-    enddo ; enddo ; enddo
+    enddo
   endif
 
   if (G%nonblocking_updates) then
@@ -2514,14 +2525,12 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     endif
 
     if (integral_BT_cont) then
-      !$OMP parallel do default(shared)
-      do j=jsv-1,jev+1 ; do I=isv-2,iev+1
+      do concurrent (j=jsv-1:jev+1, I=isv-2:iev+1)
         uhbt_int_prev(I,j) = uhbt_int(I,j)
-      enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=jsv-2,jev+1 ; do i=isv-1,iev+1
+      enddo
+      do concurrent (J=jsv-2:jev+1, i=isv-1:iev+1)
         vhbt_int_prev(i,J) = vhbt_int(i,J)
-      enddo ; enddo
+      enddo
     endif
 
     ! Do a predictor step update of eta
@@ -2540,10 +2549,9 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     if (interp_eta_PF) then
       ! Interpolate the effective surface pressure in time
       wt_end = n*Instep  ! This could be (n-0.5)*Instep.
-      !$OMP parallel do default(shared)
-      do j=jsv-1,jev+1 ; do i=isv-1,iev+1
+      do concurrent (j=jsv-1:jev+1, i=isv-1:iev+1)
         eta_PF(i,j) = eta_PF_1(i,j) + wt_end*d_eta_PF(i,j)
-      enddo ; enddo
+      enddo
     endif
 
     v_first = (MOD(n+G%first_direction,2)==1)
@@ -2589,25 +2597,22 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
 
     ! Determine the transports based on the updated velocities when no OBCs are applied
     if (integral_BT_cont) then
-      !$OMP do schedule(static)
-      do j=jsv,jev ; do I=isv-1,iev
+      do concurrent (j=jsv:jev, I=isv-1:iev)
         ubt_trans(I,j) = trans_wt1*ubt(I,j) + trans_wt2*ubt_prev(I,j)
         ubt_int_prev(I,j) = ubt_int(I,j) ! Store the previous integrated velocity so it can be reset by at OBC points
         ubt_int(I,j) = ubt_int(I,j) + dtbt * ubt_trans(I,j)
         uhbt_int(I,j) = find_uhbt(ubt_int(I,j), BTCL_u(I,j)) + n*dtbt*uhbt0(I,j)
         ! Estimate the mass flux within a single timestep to take the filtered average.
         uhbt(I,j) = (uhbt_int(I,j) - uhbt_int_prev(I,j)) * Idtbt
-      enddo ; enddo
-      !$OMP end do nowait
-      !$OMP do schedule(static)
-      do J=jsv-1,jev ; do i=isv,iev
+      enddo
+      do concurrent (J=jsv-1:jev, i=isv:iev)
         vbt_trans(i,J) = trans_wt1*vbt(i,J) + trans_wt2*vbt_prev(i,J)
         vbt_int_prev(i,J) = vbt_int(i,J) ! Store the previous integrated velocity so it can be reset by at OBC points
         vbt_int(i,J) = vbt_int(i,J) + dtbt * vbt_trans(i,J)
         vhbt_int(i,J) = find_vhbt(vbt_int(i,J), BTCL_v(i,J)) + n*dtbt*vhbt0(i,J)
         ! Estimate the mass flux within a single timestep to take the filtered average.
         vhbt(i,J) = (vhbt_int(i,J) - vhbt_int_prev(i,J)) * Idtbt
-      enddo ; enddo
+      enddo
     elseif (use_BT_cont) then
       do concurrent (j=jsv:jev, I=isv-1:iev)
         ubt_trans(I,j) = trans_wt1*ubt(I,j) + trans_wt2*ubt_prev(I,j)
@@ -2618,17 +2623,14 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
         vhbt(i,J) = find_vhbt(vbt_trans(i,J), BTCL_v(i,J)) + vhbt0(i,J)
       enddo
     else
-      !$OMP do schedule(static)
-      do j=jsv,jev ; do I=isv-1,iev
+      do concurrent (j=jsv:jev, I=isv-1:iev)
         ubt_trans(I,j) = trans_wt1*ubt(I,j) + trans_wt2*ubt_prev(I,j)
         uhbt(I,j) = Datu(I,j)*ubt_trans(I,j) + uhbt0(I,j)
-      enddo ; enddo
-      !$OMP end do nowait
-      !$OMP do schedule(static)
-      do J=jsv-1,jev ; do i=isv,iev
+      enddo
+      do concurrent (J=jsv-1:jev, i=isv:iev)
         vbt_trans(i,J) = trans_wt1*vbt(i,J) + trans_wt2*vbt_prev(i,J)
         vhbt(i,J) = Datv(i,J)*vbt_trans(i,J) + vhbt0(i,J)
-      enddo ; enddo
+      enddo
     endif
 
     ! This might need to be moved outside of the OMP do loop directives.
@@ -2655,19 +2657,19 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
 
     ! Apply open boundary condition considerations to revise the updated velocities and transports.
     if (CS%BT_OBC%u_OBCs_on_PE) then
-      !$OMP single
+      !$omp target update from(ubt, uhbt, ubt_trans, eta, SpV_col_avg, ubt_prev, Datu, BTCL_u, uhbt0)
       call apply_u_velocity_OBCs(ubt, uhbt, ubt_trans, eta, SpV_col_avg, ubt_prev, BT_OBC, &
              G, MS, GV, US, CS, iev-ie, dtbt, CS%bebt, use_BT_cont, integral_BT_cont, n*dtbt, &
              Datu, BTCL_u, uhbt0, ubt_int, ubt_int_prev, uhbt_int, uhbt_int_prev)
-      !$OMP end single
+      !$omp target update to(ubt, uhbt, ubt_trans)
     endif
 
     if (CS%BT_OBC%v_OBCs_on_PE) then
-      !$OMP single
+      !$omp target update from(vbt, vhbt, vbt_trans, eta, SpV_col_avg, vbt_prev, Datv, BTCL_v, vhbt0)
       call apply_v_velocity_OBCs(vbt, vhbt, vbt_trans, eta, SpV_col_avg, vbt_prev, BT_OBC, &
              G, MS, GV, US, CS, iev-ie, dtbt, CS%bebt, use_BT_cont, integral_BT_cont, n*dtbt, &
              Datv, BTCL_v, vhbt0, vbt_int, vbt_int_prev, vhbt_int, vhbt_int_prev)
-      !$OMP end single
+      !$omp target update to(vbt, vhbt, vbt_trans)
     endif
 
     ! Contribute to the running sums of the transports and velocities.
@@ -2692,12 +2694,11 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
 
     ! Update eta in a corrector step using the barotropic continuity equation.
     if (integral_BT_cont) then
-      !$OMP do
-      do j=jsv,jev ; do i=isv,iev
+      do concurrent (j=jsv:jev, i=isv:iev)
         eta(i,j) = (eta_IC(i,j) + n*eta_src(i,j)) + CS%IareaT_OBCmask(i,j) * &
                    ((uhbt_int(I-1,j) - uhbt_int(I,j)) + (vhbt_int(i,J-1) - vhbt_int(i,J)))
         eta_wtd(i,j) = eta_wtd(i,j) + eta(i,j) * wt_eta(n)
-      enddo ; enddo
+      enddo
     else
       do concurrent (j=jsv:jev, i=isv:iev)
         eta(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT_OBCmask(i,j)) * &
@@ -2715,6 +2716,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
 
     ! Issue warnings if there are unphysical values of the sea surface height or total water column mass.
     ! Leaving this unported for now
+    !$omp target update from(eta)
     if (GV%Boussinesq) then
       do j=js,je ; do i=is,ie
         if ((eta(i,j) < -GV%Z_to_H*G%bathyT(i,j)) .and. (G%mask2dT(i,j) > 0.0)) then
@@ -2741,48 +2743,36 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     ! Accumulate some diagnostics of time-averaged barotropic accelerations.
     if (do_ave) then
       if ((CS%id_PFu_bt > 0) .or. associated(ADp%bt_pgf_u)) then
-        !$OMP do
-        do j=js,je ; do I=is-1,ie
+        do concurrent (j=js:je, I=is-1:ie)
           PFu_avg(I,j)  = PFu_avg(I,j) + wt_accel2(n) * PFu(I,j)
-        enddo ; enddo
-        !$OMP end do nowait
+        enddo
       endif
       if ((CS%id_PFv_bt > 0) .or. associated(ADp%bt_pgf_v)) then
-        !$OMP do
-        do J=js-1,je ; do i=is,ie
+        do concurrent (J=js-1:je, i=is:ie)
           PFv_avg(i,J)  = PFv_avg(i,J) + wt_accel2(n) * PFv(i,J)
-        enddo ; enddo
-        !$OMP end do nowait
+        enddo
       endif
       if ((CS%id_Coru_bt > 0) .or. associated(ADp%bt_cor_u)) then
-        !$OMP do
-        do j=js,je ; do I=is-1,ie
+        do concurrent (j=js:je, I=is-1:ie)
           Coru_avg(I,j) = Coru_avg(I,j) + wt_accel2(n) * Cor_u(I,j)
-        enddo ; enddo
-        !$OMP end do nowait
+        enddo
       endif
       if ((CS%id_Corv_bt > 0) .or. associated(ADp%bt_cor_v)) then
-        !$OMP do
-        do J=js-1,je ; do i=is,ie
+        do concurrent (J=js-1:je, i=is:ie)
           Corv_avg(i,J) = Corv_avg(i,J) + wt_accel2(n) * Cor_v(i,J)
-        enddo ; enddo
-        !$OMP end do nowait
+        enddo
       endif
 
       if (CS%linear_wave_drag) then
         if ((CS%id_LDu_bt > 0) .or. (associated(ADp%bt_lwd_u))) then
-          !$OMP do
-          do j=js,je ; do I=is-1,ie
+          do concurrent (j=js:je, I=is-1:ie)
             LDu_avg(I,j) = LDu_avg(I,j) - wt_accel2(n) * (ubt(I,j) * Rayleigh_u(I,j))
-          enddo ; enddo
-          !$OMP end do nowait
+          enddo
         endif
         if ((CS%id_LDv_bt > 0) .or. (associated(ADp%bt_lwd_v))) then
-          !$OMP do
-          do J=js-1,je ; do i=is,ie
+          do concurrent (J=js-1:je, i=is:ie)
             LDv_avg(i,J) = LDv_avg(i,J) - wt_accel2(n) * (vbt(i,J) * Rayleigh_v(i,J))
-          enddo ; enddo
-          !$OMP end do nowait
+          enddo
         endif
       endif
     endif
@@ -2909,7 +2899,7 @@ subroutine truncate_velocities(ubt, vbt, dt, G, CS, isv, iev, jsv, jev)
   integer :: i, j
 
   if (CS%clip_velocity) then
-    do j=jsv,jev ; do I=isv-1,iev
+    do concurrent (j=jsv:jev, I=isv-1:iev)
       if ((ubt(I,j) * (dt * G%dy_Cu(I,j))) * G%IareaT(i+1,j) < -CS%CFL_trunc) then
         ! Add some error reporting later.
         ubt(I,j) = (-0.95*CS%CFL_trunc) * (G%areaT(i+1,j) / (dt * G%dy_Cu(I,j)))
@@ -2917,8 +2907,8 @@ subroutine truncate_velocities(ubt, vbt, dt, G, CS, isv, iev, jsv, jev)
         ! Add some error reporting later.
         ubt(I,j) = (0.95*CS%CFL_trunc) * (G%areaT(i,j) / (dt * G%dy_Cu(I,j)))
       endif
-    enddo ; enddo
-    do J=jsv-1,jev ; do i=isv,iev
+    enddo
+    do concurrent (J=jsv-1:jev, i=isv:iev)
       if ((vbt(i,J) * (dt * G%dx_Cv(i,J))) * G%IareaT(i,j+1) < -CS%CFL_trunc) then
         ! Add some error reporting later.
         vbt(i,J) = (-0.9*CS%CFL_trunc) * (G%areaT(i,j+1) / (dt * G%dx_Cv(i,J)))
@@ -2926,7 +2916,7 @@ subroutine truncate_velocities(ubt, vbt, dt, G, CS, isv, iev, jsv, jev)
         ! Add some error reporting later.
         vbt(i,J) = (0.9*CS%CFL_trunc) * (G%areaT(i,j) / (dt * G%dx_Cv(i,J)))
       endif
-    enddo ; enddo
+    enddo
   endif
 
 end subroutine truncate_velocities
@@ -2996,47 +2986,37 @@ subroutine btloop_eta_predictor(n, dtbt, ubt, vbt, eta, ubt_int, vbt_int, uhbt, 
 
   integer :: i, j
 
-  !$OMP parallel default(shared)
   if (integral_BT_cont) then
-    !$OMP do
-    do j=jsv-1,jev+1 ; do I=isv-2,iev+1
+    do concurrent (j=jsv-1:jev+1, I=isv-2:iev+1)
       uhbt_int(I,j) = find_uhbt(ubt_int(I,j) + dtbt*ubt(I,j), BTCL_u(I,j)) + n*dtbt*uhbt0(I,j)
-    enddo ; enddo
-    !$OMP end do nowait
-    !$OMP do
-    do J=jsv-2,jev+1 ; do i=isv-1,iev+1
+    enddo
+    do concurrent (J=jsv-2:jev+1, i=isv-1:iev+1)
       vhbt_int(i,J) = find_vhbt(vbt_int(i,J) + dtbt*vbt(i,J), BTCL_v(i,J)) + n*dtbt*vhbt0(i,J)
-    enddo ; enddo
-    !$OMP do
-    do j=jsv-1,jev+1 ; do i=isv-1,iev+1
+    enddo
+    do concurrent (j=jsv-1:jev+1, i=isv-1:iev+1)
       eta_pred(i,j) = (eta_IC(i,j) + n*eta_src(i,j)) + CS%IareaT_OBCmask(i,j) * &
                  ((uhbt_int(I-1,j) - uhbt_int(I,j)) + (vhbt_int(i,J-1) - vhbt_int(i,J)))
-    enddo ; enddo
+    enddo
   elseif (use_BT_cont) then
-    !$OMP do
-    do j=jsv-1,jev+1 ; do I=isv-2,iev+1
+    do concurrent (j=jsv-1:jev+1, I=isv-2:iev+1)
       uhbt(I,j) = find_uhbt(ubt(I,j), BTCL_u(I,j)) + uhbt0(I,j)
-    enddo ; enddo
-    !$OMP do
-    do J=jsv-2,jev+1 ; do i=isv-1,iev+1
+    enddo
+    do concurrent (J=jsv-2:jev+1, i=isv-1:iev+1)
       vhbt(i,J) = find_vhbt(vbt(i,J), BTCL_v(i,J)) + vhbt0(i,J)
-    enddo ; enddo
-    !$OMP do
-    do j=jsv-1,jev+1 ; do i=isv-1,iev+1
+    enddo
+    do concurrent (j=jsv-1:jev+1, i=isv-1:iev+1)
       eta_pred(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT_OBCmask(i,j)) * &
                  ((uhbt(I-1,j) - uhbt(I,j)) + (vhbt(i,J-1) - vhbt(i,J)))
-    enddo ; enddo
+    enddo
   else
-    !$OMP do
-    do j=jsv-1,jev+1 ; do i=isv-1,iev+1
+    do concurrent (j=jsv-1:jev+1, i=isv-1:iev+1)
       eta_pred(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT_OBCmask(i,j)) * &
           (((Datu(I-1,j)*ubt(I-1,j) + uhbt0(I-1,j)) - &
             (Datu(I,j)*ubt(I,j) + uhbt0(I,j))) + &
            ((Datv(i,J-1)*vbt(i,J-1) + vhbt0(i,J-1)) - &
             (Datv(i,J)*vbt(i,J) + vhbt0(i,J))))
-    enddo ; enddo
+    enddo
   endif
-  !$OMP end parallel
 
 end subroutine btloop_eta_predictor
 
@@ -3161,21 +3141,16 @@ subroutine btloop_add_dyn_PF(PFu, PFv, eta_pred, eta, dyn_coef_eta, p_surf_dyn, 
   endif
 
   ! Use the change in eta to estimate the flow divergence and dynamic pressure.
-  !$OMP do
-  do j=jsv-1,jev+1 ; do i=isv-1,iev+1
+  do concurrent (j=jsv-1:jev+1, i=isv-1:iev+1)
     p_surf_dyn(i,j) = dyn_coef_eta(i,j) * (eta_pred(i,j) - eta(i,j))
-  enddo ; enddo
+  enddo
 
-  !$OMP do schedule(static)
-  do j=js_u,je_u ; do I=isv-1,iev
+  do concurrent (j=js_u:je_u, I=isv-1:iev)
     PFu(I,j) = PFu(I,j) + (p_surf_dyn(i,j) - p_surf_dyn(i+1,j)) * CS%IdxCu(I,j)
-  enddo ; enddo
-  !$OMP end do nowait
-  !$OMP do schedule(static)
-  do J=jsv-1,jev ; do i=is_v,ie_v
+  enddo
+  do concurrent (J=jsv-1:jev, i=is_v:ie_v)
     PFv(i,J) = PFv(i,J) + (p_surf_dyn(i,j) - p_surf_dyn(i,j+1)) * CS%IdyCv(i,J)
-  enddo ; enddo
-  !$OMP end do nowait
+  enddo
 
 end subroutine btloop_add_dyn_PF
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4379,26 +4379,26 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   do j=js,je ; do I=is-1,ie ; hatutot(I,j) = 0.0 ; enddo ; enddo
 
   if (present(h_u)) then
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       CS%frhatu(I,j,k) = h_u(I,j,k)
-    enddo ; enddo ; enddo
-    do j=js,je ; do I=is-1,ie ; do k=1,nz
+    enddo
+    do concurrent (j=js:je, I=is-1:ie) ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       CS%frhatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
-    enddo ; enddo ; enddo
-    do j=js,je ; do I=is-1,ie ; do k=1,nz
+    enddo
+    do concurrent (j=js:je, I=is-1:ie) ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       e_u(I,j,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
       D_shallow_u(I,j) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
-    enddo ; enddo
-    do k=nz,1,-1 ; do j=js,je ; do I=is-1,ie
+    enddo
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
       h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
       if (e_u(I,j,K+1) >= D_shallow_u(I,j)) then
@@ -4412,26 +4412,27 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           CS%frhatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
-    enddo ; enddo ; enddo
-    do j=js,je ; do I=is-1,ie ; do k=1,nz
+    enddo
+    do concurrent (j=js:je, I=is-1:ie) ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then
     !   Interpolates thicknesses onto u grid points with the
     ! second order accurate estimate h = 2*(h+ * h-)/(h+ + h-).
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
+    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
       CS%frhatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
                       ((h(i+1,j,k) + h(i,j,k)) + h_neglect)
-    enddo ; enddo ; enddo
-    do j=js,je ; do I=is-1,ie ; do k=1,nz
+    enddo
+    do concurrent (j=js:je, I=is-1:ie) ; do k=1,nz
       hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   endif
 
   if (CS%BT_OBC%u_OBCs_on_PE) then
     do j=js,je
       ! Reset velocity point thicknesses and their sums at OBC points
       if ((j >= CS%BT_OBC%js_u_E_obc) .and. (j <= CS%BT_OBC%je_u_E_obc)) then
+        !$omp do
         do I = max(is-1,CS%BT_OBC%Is_u_E_obc), min(ie,CS%BT_OBC%Ie_u_E_obc)
           if (CS%BT_OBC%u_OBC_type(I,j) > 0) then ! Eastern boundary condition
             hatutot(I,j) = 0.0
@@ -4443,6 +4444,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
         enddo
       endif
       if ((j >= CS%BT_OBC%js_u_W_obc) .and. (j <= CS%BT_OBC%je_u_W_obc)) then
+        !$omp do
         do I = max(is-1,CS%BT_OBC%Is_u_W_obc), min(ie,CS%BT_OBC%Ie_u_W_obc)
           if (CS%BT_OBC%u_OBC_type(I,j) < 0) then ! Western boundary condition
             hatutot(I,j) = 0.0
@@ -4457,34 +4459,34 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   endif
 
   ! Determine the fractional thickness of each layer at the velocity points.
-  do j=js,je ; do I=is-1,ie ; Ihatutot(I,j) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo ; enddo
-  do k=1,nz ; do j=js,je ; do I=is-1,ie
+  do concurrent (j=js:je, I=is-1:ie) ; Ihatutot(I,j) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo
+  do concurrent (k=1:nz, j=js:je, I=is-1:ie)
     CS%frhatu(I,j,k) = CS%frhatu(I,j,k) * Ihatutot(I,j)
-  enddo ; enddo ; enddo
+  enddo
 
-  do J=js-1,je ; do i=is,ie ; hatvtot(i,J) = 0.0 ; enddo ; enddo
+  do concurrent (J=js-1:je, i=is:ie) ; hatvtot(i,J) = 0.0 ; enddo
 
   if (present(h_v)) then
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       CS%frhatv(i,J,k) = h_v(i,J,k)
-    enddo ; enddo ; enddo
-    do J=js-1,je ; do i=is,ie ; do k=1,nz
+    enddo
+    do concurrent (J=js-1:je, i=is:ie) ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   elseif (CS%hvel_scheme == ARITHMETIC) then
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       CS%frhatv(i,J,k) = 0.5 * (h(i,j+1,k) + h(i,j,k))
-    enddo ; enddo ; enddo
-    do J=js-1,je ; do i=is,ie ; do k=1,nz
+    enddo
+    do concurrent (J=js-1:je, i=is:ie) ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   elseif (CS%hvel_scheme == HYBRID .or. use_default) then
     Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
-    do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie)
       e_v(i,J,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
       D_shallow_v(i,J) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
-    enddo ; enddo
-    do k=nz,1,-1 ; do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
       h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
       if (e_v(i,J,K+1) >= D_shallow_v(i,J)) then
@@ -4498,22 +4500,23 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           CS%frhatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
       endif
-    enddo ; enddo ; enddo
-    do J=js-1,je ; do i=is,ie ; do k=1,nz
+    enddo
+    do concurrent (J=js-1:je, i=is:ie) ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   elseif (CS%hvel_scheme == HARMONIC) then
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
+    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       CS%frhatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &
                       ((h(i,j+1,k) + h(i,j,k)) + h_neglect)
-    enddo ; enddo ; enddo
-    do J=js-1,je ; do i=is,ie ; do k=1,nz
+    enddo
+    do concurrent (J=js-1:je, i=is:ie) ; do k=1,nz
       hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
-    enddo ; enddo ; enddo
+    enddo ; enddo
   endif
 
   if (CS%BT_OBC%v_OBCs_on_PE) then
-    do J=js-1,je
+    ! todo: put i,j iterations into single do concurrent
+    do concurrent (J=js-1:je)
       ! Reset v-velocity point thicknesses and their sums at OBC points
       if ((J >= CS%BT_OBC%Js_v_N_obc) .and. (J <= CS%BT_OBC%Je_v_N_obc)) then
         do i = max(is,CS%BT_OBC%is_v_N_obc), min(ie,CS%BT_OBC%ie_v_N_obc)
@@ -4541,10 +4544,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   endif
 
   ! Determine the fractional thickness of each layer at the velocity points.
-  do J=js-1,je ; do i=is,ie ; Ihatvtot(i,J) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo ; enddo
-  do k=1,nz ; do J=js-1,je ; do i=is,ie
+  do concurrent (J=js-1:je, i=is:ie) ; Ihatvtot(i,J) = G%mask2dCv(i,J) / (hatvtot(i,J) + h_neglect) ; enddo
+  do concurrent (k=1:nz, J=js-1:je, i=is:ie)
     CS%frhatv(i,J,k) = CS%frhatv(i,J,k) * Ihatvtot(i,J)
-  enddo ; enddo ; enddo
+  enddo
 
   if (CS%debug) then
     call uvchksum("btcalc frhat[uv]", CS%frhatu, CS%frhatv, G%HI, &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1194,17 +1194,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
         vhbt0(i,J) = vhbt(i,J) - find_vhbt(dt*vbt(i,J), BTCL_v(i,J)) * Idt
       enddo ; enddo
     elseif (use_BT_cont) then
-      ! target data stmt to ensure only the affected parts of the array are
-      ! returned to the CPU. Not sure why it's returning the whole uhbt0/vhbt0 -
-      ! some of which is garbage
-      !$omp target data map(from: uhbt0(is-1:ie, js:ie), vhbt0(is:ie, js-1:je))
       do concurrent (j=js:je, I=is-1:ie)
         uhbt0(I,j) = uhbt(I,j) - find_uhbt(ubt(I,j), BTCL_u(I,j))
       enddo
       do concurrent (J=js-1:je, i=is:ie)
         vhbt0(i,J) = vhbt(i,J) - find_vhbt(vbt(i,J), BTCL_v(i,J))
       enddo
-      !$omp end target data
     else
       !$OMP parallel do default(shared)
       do j=js,je ; do I=is-1,ie

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1462,16 +1462,16 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
          ((nstep * av_rem_v(i,J)) / (1.0 + (nstep-1)*av_rem_v(i,J)))
     enddo ; enddo
   else
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       bt_rem_u(I,j) = 0.0
       if (G%mask2dCu(I,j) * av_rem_u(I,j) > 0.0) &
         bt_rem_u(I,j) = G%mask2dCu(I,j) * (av_rem_u(I,j)**Instep)
-    enddo ; enddo
-    do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent (J=js-1:je, i=is:ie)
       bt_rem_v(i,J) = 0.0
       if (G%mask2dCv(i,J) * av_rem_v(i,J) > 0.0) &
         bt_rem_v(i,J) = G%mask2dCv(i,J) * (av_rem_v(i,J)**Instep)
-    enddo ; enddo
+    enddo
   endif
   if (CS%linear_wave_drag) then
     do j=js,je ; do I=is-1,ie ; if (CS%lin_drag_u(I,j) > 0.0) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -855,12 +855,11 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! transfers of derived types and members being kept to minimize .attach. and .detach. data
   !$omp target enter data &
-  !$omp   map(to: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, bc_accel_v, &
-  !$omp       forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, &
-  !$omp       CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, CS%ua_polarity, &
-  !$omp       CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, &
-  !$omp       CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, CS%OBCmask_v, uh0, vh0) &
-  !$omp   map(alloc: eta_out, etaav, accel_layer_u, accel_layer_v, uhbtav, vhbtav)
+  !$omp   map(to: G, G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, forces, forces%taux, &
+  !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
+  !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
+  !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
+  !$omp       CS%OBCmask_v, uh0, vh0)
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
@@ -2186,12 +2185,11 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2, PFu_avg, PFv_avg)
 
   !$omp target exit data &
-  !$omp   map(release: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, &
-  !$omp       bc_accel_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, &
-  !$omp       CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, &
-  !$omp       CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, CS%ubtav, &
-  !$omp       CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, CS%OBCmask_v, uh0, vh0) &
-  !$omp   map(from: eta_out, etaav, accel_layer_u, accel_layer_v, uhbtav, vhbtav)
+  !$omp   map(release: G, G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, forces, forces%taux, &
+  !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
+  !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
+  !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
+  !$omp       CS%OBCmask_v, uh0, vh0)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5163,8 +5163,8 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
   type(barotropic_CS),                intent(inout) :: CS    !< Barotropic control structure
 
   ! Local variables
-  real :: h_tot(SZI_(G))      ! The sum of the layer thicknesses [H ~> m or kg m-2].
-  real :: eta_h(SZI_(G))      ! The free surface height determined from
+  !real :: h_tot(SZI_(G),SZJ_(G))      ! The sum of the layer thicknesses [H ~> m or kg m-2].
+  real :: eta_h(SZI_(G),SZJ_(G))      ! The free surface height determined from
                               ! the sum of the layer thicknesses [H ~> m or kg m-2].
   real :: d_eta               ! The difference between estimates of the total
                               ! thicknesses [H ~> m or kg m-2].
@@ -5177,44 +5177,40 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  !$omp target teams distribute private(eta_h,h_tot,d_eta) &
-  !$omp   map(to: CS, G, G%bathyT, GV, h, eta) &
-  !$omp   map(tofrom: CS%eta_cor) &
-  !$omp   map(alloc: eta_h, h_tot)
-  do j=js,je
-    !$omp parallel
-    !$omp do simd
-    do i=is,ie ; h_tot(i) = h(i,j,1) ; enddo
-    if (GV%Boussinesq) then
-      !$omp do simd
-      do i=is,ie ; eta_h(i) = h(i,j,1) - G%bathyT(i,j)*GV%Z_to_H ; enddo
-    else
-      !$omp do simd
-      do i=is,ie ; eta_h(i) = h(i,j,1) ; enddo
-    endif
-    do k=2,nz
-      !$omp do simd
-      do i=is,ie
-        eta_h(i) = eta_h(i) + h(i,j,k)
-        h_tot(i) = h_tot(i) + h(i,j,k)
-      enddo
-    enddo
+  !$omp target enter data map(alloc: eta_h)
 
-    if (set_cor) then
-      !$omp do private(d_eta)
-      do i=is,ie
-        d_eta = eta_h(i) - eta(i,j)
-        CS%eta_cor(i,j) = d_eta
-      enddo
-    else
-      !$omp do private(d_eta)
-      do i=is,ie
-        d_eta = eta_h(i) - eta(i,j)
-        CS%eta_cor(i,j) = CS%eta_cor(i,j) + d_eta
-      enddo
-    endif
-    !$omp end parallel
+  ! do concurrent (j=js:je , i=is:ie)
+  !   h_tot(i,j) = h(i,j,1)
+  ! enddo
+
+  if (GV%Boussinesq) then
+    do concurrent (j=js:je, i=is:ie)
+      eta_h(i,j) = h(i,j,1) - G%bathyT(i,j)*GV%Z_to_H
+    enddo
+  else
+    do concurrent (j=js:je, i=is:ie)
+      eta_h(i,j) = h(i,j,1)
+    enddo
+  endif
+  do k=2,nz
+    do concurrent (j=js:je, i=is:ie)
+      eta_h(i,j) = eta_h(i,j) + h(i,j,k)
+      !h_tot(i,j) = h_tot(i,j) + h(i,j,k)
+    enddo
   enddo
+  if (set_cor) then
+    do concurrent (j=js:je, i=is:ie)
+      d_eta = eta_h(i,j) - eta(i,j)
+      CS%eta_cor(i,j) = d_eta
+    enddo
+  else
+    do concurrent (j=js:je, i=is:ie)
+      d_eta = eta_h(i,j) - eta(i,j)
+      CS%eta_cor(i,j) = CS%eta_cor(i,j) + d_eta
+    enddo
+  endif
+
+  !$omp target exit data map(release: eta_h)
 
 end subroutine bt_mass_source
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5157,7 +5157,6 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
   type(barotropic_CS),                intent(inout) :: CS    !< Barotropic control structure
 
   ! Local variables
-  !real :: h_tot(SZI_(G),SZJ_(G))      ! The sum of the layer thicknesses [H ~> m or kg m-2].
   real :: eta_h(SZI_(G),SZJ_(G))      ! The free surface height determined from
                               ! the sum of the layer thicknesses [H ~> m or kg m-2].
   real :: d_eta               ! The difference between estimates of the total
@@ -5173,10 +5172,6 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
 
   !$omp target enter data map(alloc: eta_h)
 
-  ! do concurrent (j=js:je , i=is:ie)
-  !   h_tot(i,j) = h(i,j,1)
-  ! enddo
-
   if (GV%Boussinesq) then
     do concurrent (j=js:je, i=is:ie)
       eta_h(i,j) = h(i,j,1) - G%bathyT(i,j)*GV%Z_to_H
@@ -5189,7 +5184,6 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
   do k=2,nz
     do concurrent (j=js:je, i=is:ie)
       eta_h(i,j) = eta_h(i,j) + h(i,j,k)
-      !h_tot(i,j) = h_tot(i,j) + h(i,j,k)
     enddo
   enddo
   if (set_cor) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2638,12 +2638,11 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
         eta_wtd(i,j) = eta_wtd(i,j) + eta(i,j) * wt_eta(n)
       enddo ; enddo
     else
-      !$OMP do
-      do j=jsv,jev ; do i=isv,iev
+      do concurrent (j=jsv:jev, i=isv:iev)
         eta(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT_OBCmask(i,j)) * &
                    ((uhbt(I-1,j) - uhbt(I,j)) + (vhbt(i,J-1) - vhbt(i,J)))
         eta_wtd(i,j) = eta_wtd(i,j) + eta(i,j) * wt_eta(n)
-      enddo ; enddo
+      enddo
     endif
 
     if (CS%debug_bt) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3269,8 +3269,7 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
   real :: vel_prev    ! The previous velocity [L T-1 ~> m s-1].
   integer :: i, j
 
-  !$OMP do schedule(static)
-  do j=js_u,je_u ; do I=Is_u,Ie_u
+  do concurrent (j=js_u:je_u, I=Is_u:Ie_u)
     Cor_u(I,j) = (((f_4_u(4,I,j) * vbt(i+1,J)) + (f_4_u(1,I,j) * vbt(i,J-1))) + &
                   ((f_4_u(3,I,j) * vbt(i,J)) + (f_4_u(2,I,j) * vbt(i+1,J-1)))) - &
                  Cor_ref_u(I,j)
@@ -3279,22 +3278,17 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
     ubt(I,j) = bt_rem_u(I,j) * (ubt(I,j) + &
          dtbt * ((BT_force_u(I,j) + Cor_u(I,j)) + PFu(I,j)))
     if (abs(ubt(I,j)) < CS%vel_underflow) ubt(I,j) = 0.0
-  enddo ; enddo
-  !$OMP end do nowait
+  enddo
 
   if (CS%linear_wave_drag) then
-    !$OMP do schedule(static)
-    do j=js_u,je_u ; do I=Is_u,Ie_u
+    do concurrent (j=js_u:je_u, I=Is_u:Ie_u)
       u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel_n * &
           ((Cor_u(I,j) + PFu(I,j)) - ubt(I,j)*Rayleigh_u(I,j))
-    enddo ; enddo
-    !$OMP end do nowait
+    enddo
   else
-    !$OMP do schedule(static)
-    do j=js_u,je_u ; do I=Is_u,Ie_u
+    do concurrent (j=js_u:je_u, I=Is_u:Ie_u)
       u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel_n * (Cor_u(I,j) + PFu(I,j))
-    enddo ; enddo
-    !$OMP end do nowait
+    enddo
   endif
 
 end subroutine btloop_update_u

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2810,20 +2810,18 @@ subroutine btstep_find_Cor(q, DCor_u, DCor_v, f_4_u, f_4_v, isvf, ievf, jsvf, je
   integer :: i, j
 
   if (CS%Sadourny) then
-    !$OMP parallel do default(shared)
-    do J=jsvf-1,jevf ; do i=isvf-1,ievf+1
+    do concurrent (J=jsvf-1:jevf, i=isvf-1:ievf+1)
       f_4_v(1,i,J) = CS%OBCmask_v(i,J) * DCor_u(I-1,j) * q(I-1,J)
       f_4_v(2,i,J) = CS%OBCmask_v(i,J) * DCor_u(I,j) * q(I,J)
       f_4_v(4,i,J) = CS%OBCmask_v(i,J) * DCor_u(I,j+1) * q(I,J)
       f_4_v(3,i,J) = CS%OBCmask_v(i,J) * DCor_u(I-1,j+1) * q(I-1,J)
-    enddo ; enddo
-    !$OMP parallel do default(shared)
-    do j=jsvf-1,jevf+1 ; do I=isvf-1,ievf
+    enddo
+    do concurrent (j=jsvf-1:jevf+1, I=isvf-1:ievf)
       f_4_u(4,I,j) = CS%OBCmask_u(I,j) * DCor_v(i+1,J) * q(I,J)
       f_4_u(3,I,j) = CS%OBCmask_u(I,j) * DCor_v(i,J) * q(I,J)
       f_4_u(1,I,j) = CS%OBCmask_u(I,j) * DCor_v(i,J-1) * q(I,J-1)
       f_4_u(2,I,j) = CS%OBCmask_u(I,j) * DCor_v(i+1,J-1) * q(I,J-1)
-    enddo ; enddo
+    enddo
   else  !### if (CS%answer_date < 20250601) then  ! Uncomment this later.
     !$OMP parallel do default(shared)
     do J=jsvf-1,jevf ; do i=isvf-1,ievf+1

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4429,7 +4429,8 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   endif
 
   if (CS%BT_OBC%u_OBCs_on_PE) then
-    do j=js,je
+    ! todo: put i,j iterations into single do concurrent
+    do concurrent (j=js:je)
       ! Reset velocity point thicknesses and their sums at OBC points
       if ((j >= CS%BT_OBC%js_u_E_obc) .and. (j <= CS%BT_OBC%je_u_E_obc)) then
         !$omp do
@@ -4519,6 +4520,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     do concurrent (J=js-1:je)
       ! Reset v-velocity point thicknesses and their sums at OBC points
       if ((J >= CS%BT_OBC%Js_v_N_obc) .and. (J <= CS%BT_OBC%Je_v_N_obc)) then
+        !$omp do simd
         do i = max(is,CS%BT_OBC%is_v_N_obc), min(ie,CS%BT_OBC%ie_v_N_obc)
           if (CS%BT_OBC%v_OBC_type(i,J) > 0) then ! Northern boundary condition
             hatvtot(i,J) = 0.0
@@ -4530,6 +4532,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
         enddo
       endif
       if ((J >= CS%BT_OBC%Js_v_S_obc) .and. (J <= CS%BT_OBC%Je_v_S_obc)) then
+        !$omp do simd
         do i = max(is,CS%BT_OBC%is_v_S_obc), min(ie,CS%BT_OBC%ie_v_S_obc)
           if (CS%BT_OBC%v_OBC_type(i,J) < 0) then ! Southern boundary condition
             hatvtot(i,J) = 0.0

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -859,9 +859,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
   !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
   !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v, uh0, vh0, BT_cont, BT_cont%FA_u_E0, BT_cont%FA_u_EE, BT_cont%FA_u_W0, &
-  !$omp       BT_cont%FA_u_WW, BT_cont%FA_v_N0, BT_cont%FA_v_NN, BT_cont%FA_v_S0, BT_cont%FA_v_SS, &
-  !$omp       BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, BT_cont%vBT_SS)
+  !$omp       CS%OBCmask_v, uh0, vh0)
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
@@ -2191,9 +2189,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, &
   !$omp       CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, &
   !$omp       CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, &
-  !$omp       CS%OBCmask_v, uh0, vh0, BT_cont, BT_cont%FA_u_E0, BT_cont%FA_u_EE, BT_cont%FA_u_W0, &
-  !$omp       BT_cont%FA_u_WW, BT_cont%FA_v_N0, BT_cont%FA_v_NN, BT_cont%FA_v_S0, BT_cont%FA_v_SS, &
-  !$omp       BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, BT_cont%vBT_SS)
+  !$omp       CS%OBCmask_v, uh0, vh0)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1755,19 +1755,19 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (id_clock_calc > 0) call cpu_clock_end(id_clock_calc)
   if (id_clock_calc_post > 0) call cpu_clock_begin(id_clock_calc_post)
 
-  if (find_etaav) then ; do j=js,je ; do i=is,ie
+  if (find_etaav) then ; do concurrent (j=js:je, i=is:ie)
     etaav(i,j) = eta_sum(i,j) * I_sum_wt_accel
-  enddo ; enddo ; endif
-  do j=js-1,je+1 ; do i=is-1,ie+1 ; e_anom(i,j) = 0.0 ; enddo ; enddo
+  enddo ; endif
+  do concurrent (j=js-1:je+1, i=is-1:ie+1) ; e_anom(i,j) = 0.0 ; enddo
   if (interp_eta_PF) then
     do j=js,je ; do i=is,ie
       e_anom(i,j) = dgeo_de * (0.5 * (eta(i,j) + eta_in(i,j)) - &
                                (eta_PF_1(i,j) + 0.5*d_eta_PF(i,j)))
     enddo ; enddo
   else
-    do j=js,je ; do i=is,ie
+    do concurrent (j=js:je, i=is:ie)
       e_anom(i,j) = dgeo_de * (0.5 * (eta(i,j) + eta_in(i,j)) - eta_PF(i,j))
-    enddo ; enddo
+    enddo
   endif
   if (apply_OBCs) then
     ! This block of code may be unnecessary because e_anom is only used for accelerations that
@@ -2653,6 +2653,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     endif
 
     ! Issue warnings if there are unphysical values of the sea surface height or total water column mass.
+    ! Leaving this unported for now
     if (GV%Boussinesq) then
       do j=js,je ; do i=is,ie
         if ((eta(i,j) < -GV%Z_to_H*G%bathyT(i,j)) .and. (G%mask2dT(i,j) > 0.0)) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -6107,6 +6107,20 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   if (dtbt_input <= 0.0) &
     id_clock_sync = cpu_clock_id('(Ocean BT global synch)', grain=CLOCK_ROUTINE)
 
+  ! send initialized data to GPU
+  !$omp target enter data map(to: CS%bathyT)
+  !$omp target enter data map(to: CS%D_u_Cor, CS%D_v_Cor)
+  !$omp target enter data map(to: CS%dx_Cv, CS%dy_Cu)
+  !$omp target enter data map(to: CS%eta_cor)
+  !$omp target enter data map(to: CS%frhatu, CS%frhatv)
+  !$omp target enter data map(to: CS%IareaT, CS%IareaT_OBCmask)
+  !$omp target enter data map(to: CS%IDatu, CS%IDatv)
+  !$omp target enter data map(to: CS%IdxCu, CS%IdyCv)
+  !$omp target enter data map(to: CS%OBCmask_u, CS%OBCmask_v)
+  !$omp target enter data map(to: CS%q_d)
+  !$omp target enter data map(to: CS%ua_polarity, CS%va_polarity)
+  !$omp target enter data map(to: CS%ubtav, CS%vbtav)
+
 end subroutine barotropic_init
 
 !> Copies ubtav and vbtav from private type into arrays

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -854,11 +854,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 !--- end setup for group halo update
 
   !$omp target enter data &
-  !$omp   map(to: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, bc_accel_v, visc_rem_u, visc_rem_v, &
-  !$omp       forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, CS%D_u_Cor, &
-  !$omp       CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, CS%ua_polarity, CS%va_polarity, &
-  !$omp       CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, uh0, vh0) &
-  !$omp   map(alloc: eta_out, etaav)
+  !$omp   map(to: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, bc_accel_v, &
+  !$omp       visc_rem_u, visc_rem_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, &
+  !$omp       CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, CS%ua_polarity, &
+  !$omp       CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, CS%ubtav, CS%vbtav, CS%IdxCu, &
+  !$omp       CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, CS%OBCmask_v, uh0, vh0) &
+  !$omp   map(alloc: eta_out, etaav, accel_layer_u, accel_layer_v, uhbtav, vhbtav)
 
   !$omp target enter data &
   !$omp   map(alloc: ubt_Cor, vbt_Cor, wt_u, wt_v, av_rem_u, av_rem_v, ubt_wtd, vbt_wtd, Coru_avg, &
@@ -2184,11 +2185,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   !$omp       wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2, PFu_avg, PFv_avg)
 
   !$omp target exit data &
-  !$omp   map(release: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, bc_accel_v,visc_rem_u, &
-  !$omp       visc_rem_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, CS%frhatv, CS%q_d, &
-  !$omp       CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, CS%ua_polarity, &
-  !$omp       CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, uh0, vh0) &
-  !$omp   map(from: eta_out, etaav)
+  !$omp   map(release: G%dxT, G%dyT, G%mask2dT, G%mask2dCu, G%mask2dCv, eta_in, bc_accel_u, &
+  !$omp       bc_accel_v, visc_rem_u, visc_rem_v, forces, forces%taux, forces%tauy, CS, CS%frhatu, &
+  !$omp       CS%frhatv, CS%q_d, CS%D_u_Cor, CS%D_v_Cor, CS%eta_cor, CS%bathyT, CS%IareaT, &
+  !$omp       CS%ua_polarity, CS%va_polarity, CS%IDatu, CS%IDatv, CS%dx_Cv, CS%dy_Cu, CS%ubtav, &
+  !$omp       CS%vbtav, CS%IdxCu, CS%IdyCv, CS%IareaT_OBCmask, CS%OBCmask_u, CS%OBCmask_v, uh0, vh0) &
+  !$omp   map(from: eta_out, etaav, accel_layer_u, accel_layer_v, uhbtav, vhbtav)
 
   deallocate(wt_vel, wt_eta, wt_trans, wt_accel, wt_accel2)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4866,6 +4866,10 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
   hs = max(halo,0)
   dt = 1.0 ; if (present(dt_baroclinic)) dt = dt_baroclinic
 
+  !$omp target enter data &
+  !$omp   map(alloc: u_polarity, uBT_EE, uBT_WW, FA_u_EE, FA_u_E0, FA_u_W0, FA_u_WW, &
+  !$omp              v_polarity, vBT_NN, vBT_SS, FA_v_NN, FA_v_N0, FA_v_S0, FA_v_SS)
+
   ! Copy the BT_cont arrays into symmetric, potentially wide haloed arrays.
   do concurrent (j=js-hs:je+hs, i=is-hs-1:ie+hs)
     u_polarity(i,j) = 1.0
@@ -4901,8 +4905,13 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
   call create_group_pass(BT_cont%pass_FA_uv, FA_u_WW, FA_v_SS, BT_Domain, To_All+Scalar_Pair)
 !--- end setup for group halo update
   ! Do halo updates on BT_cont.
+  ! data update directives for MPI transfers (via CPU) needed even for serial
+  !$omp target update from(u_polarity, v_polarity, uBT_EE, vBT_NN, uBT_WW, vBT_SS)
   call do_group_pass(BT_cont%pass_polarity_BT, BT_Domain)
+  !$omp target update to(u_polarity, v_polarity, uBT_EE, vBT_NN, uBT_WW, vBT_SS)
+  !$omp target update from(FA_u_EE, FA_v_NN, FA_u_E0, FA_v_N0, FA_u_W0, FA_v_S0, FA_u_WW, FA_v_SS)
   call do_group_pass(BT_cont%pass_FA_uv, BT_Domain)
+  !$omp target update to(FA_u_EE, FA_v_NN, FA_u_E0, FA_v_N0, FA_u_W0, FA_v_S0, FA_u_WW, FA_v_SS)
   if (id_clock_pass_pre > 0) call cpu_clock_end(id_clock_pass_pre)
   if (id_clock_calc_pre > 0) call cpu_clock_begin(id_clock_calc_pre)
 
@@ -4950,6 +4959,10 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
     if (abs(BTCL_v(i,J)%vBT_NN) > 0.0) BTCL_v(i,J)%vh_crvN = &
       (C1_3 * (BTCL_v(i,J)%FA_v_NN - BTCL_v(i,J)%FA_v_N0)) / BTCL_v(i,J)%vBT_NN**2
   enddo
+
+  !$omp target exit data &
+  !$omp   map(release: u_polarity, uBT_EE, uBT_WW, FA_u_EE, FA_u_E0, FA_u_W0, FA_u_WW, &
+  !$omp                v_polarity, vBT_NN, vBT_SS, FA_v_NN, FA_v_N0, FA_v_S0, FA_v_SS)
 end subroutine set_local_BT_cont_types
 
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4357,55 +4357,52 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   h_neglect = GV%H_subroundoff
 
+  do j=js,je ; do I=is-1,ie ; hatutot(I,j) = 0.0 ; enddo ; enddo
 
-  !$OMP parallel do default(none) shared(is,ie,js,je,nz,h_u,CS,h_neglect,h,use_default,G,GV) &
-  !$OMP                          private(hatu,hatutot,Ihatutot,e_u,D_shallow_u,h_arith,h_harm,wt_arith,Z_to_H)
-  do j=js,je
-    do I=is-1,ie ; hatutot(I,j) = 0.0 ; enddo
-
-    if (present(h_u)) then
-      do k=1,nz ; do I=is-1,ie
-        hatu(I,j,k) = h_u(I,j,k)
-        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
-      enddo ; enddo
-    elseif (CS%hvel_scheme == ARITHMETIC) then
-      do k=1,nz ; do I=is-1,ie
-        hatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
-        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
-      enddo ; enddo
-    elseif (CS%hvel_scheme == HYBRID .or. use_default) then
-      Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
-      do I=is-1,ie
-        e_u(I,j,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
-        D_shallow_u(I,j) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
-      enddo
-      do k=nz,1,-1 ; do I=is-1,ie
-        e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
-        h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
-        if (e_u(I,j,K+1) >= D_shallow_u(I,j)) then
-          hatu(I,j,k) = h_arith
+  if (present(h_u)) then
+    do k=1,nz ; do j=js,je ; do I=is-1,ie
+      hatu(I,j,k) = h_u(I,j,k)
+      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+    enddo ; enddo ; enddo
+  elseif (CS%hvel_scheme == ARITHMETIC) then
+    do k=1,nz ; do j=js,je ; do I=is-1,ie
+      hatu(I,j,k) = 0.5 * (h(i+1,j,k) + h(i,j,k))
+      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+    enddo ; enddo ; enddo
+  elseif (CS%hvel_scheme == HYBRID .or. use_default) then
+    Z_to_H = GV%Z_to_H ; if (.not.GV%Boussinesq) Z_to_H = GV%RZ_to_H * CS%Rho_BT_lin
+    do j=js,je ; do I=is-1,ie
+      e_u(I,j,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
+      D_shallow_u(I,j) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
+    enddo ; enddo
+    do k=nz,1,-1 ; do j=js,je ; do I=is-1,ie
+      e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
+      h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
+      if (e_u(I,j,K+1) >= D_shallow_u(I,j)) then
+        hatu(I,j,k) = h_arith
+      else
+        h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
+        if (e_u(I,j,K) <= D_shallow_u(I,j)) then
+          hatu(I,j,k) = h_harm
         else
-          h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
-          if (e_u(I,j,K) <= D_shallow_u(I,j)) then
-            hatu(I,j,k) = h_harm
-          else
-            wt_arith = (e_u(I,j,K) - D_shallow_u(I,j)) / (h_arith + h_neglect)
-            hatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
-          endif
+          wt_arith = (e_u(I,j,K) - D_shallow_u(I,j)) / (h_arith + h_neglect)
+          hatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
         endif
-        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
-      enddo ; enddo
-    elseif (CS%hvel_scheme == HARMONIC) then
-      !   Interpolates thicknesses onto u grid points with the
-      ! second order accurate estimate h = 2*(h+ * h-)/(h+ + h-).
-      do k=1,nz ; do I=is-1,ie
-        hatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
-                        ((h(i+1,j,k) + h(i,j,k)) + h_neglect)
-        hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
-      enddo ; enddo
-    endif
+      endif
+      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+    enddo ; enddo ; enddo
+  elseif (CS%hvel_scheme == HARMONIC) then
+    !   Interpolates thicknesses onto u grid points with the
+    ! second order accurate estimate h = 2*(h+ * h-)/(h+ + h-).
+    do k=1,nz ; do j=js,je ; do I=is-1,ie
+      hatu(I,j,k) = 2.0*(h(i+1,j,k) * h(i,j,k)) / &
+                      ((h(i+1,j,k) + h(i,j,k)) + h_neglect)
+      hatutot(I,j) = hatutot(I,j) + hatu(I,j,k)
+    enddo ; enddo ; enddo
+  endif
 
-    if (CS%BT_OBC%u_OBCs_on_PE) then
+  if (CS%BT_OBC%u_OBCs_on_PE) then
+    do j=js,je
       ! Reset velocity point thicknesses and their sums at OBC points
       if ((j >= CS%BT_OBC%js_u_E_obc) .and. (j <= CS%BT_OBC%je_u_E_obc)) then
         do I = max(is-1,CS%BT_OBC%Is_u_E_obc), min(ie,CS%BT_OBC%Ie_u_E_obc)
@@ -4429,14 +4426,14 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
           endif
         enddo
       endif
-    endif
+    enddo
+  endif
 
-    ! Determine the fractional thickness of each layer at the velocity points.
-    do I=is-1,ie ; Ihatutot(I,j) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo
-    do k=1,nz ; do I=is-1,ie
-      CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I,j)
-    enddo ; enddo
-  enddo
+  ! Determine the fractional thickness of each layer at the velocity points.
+  do j=js,je ; do I=is-1,ie ; Ihatutot(I,j) = G%mask2dCu(I,j) / (hatutot(I,j) + h_neglect) ; enddo ; enddo
+  do k=1,nz ; do j=js,je ; do I=is-1,ie
+    CS%frhatu(I,j,k) = hatu(I,j,k) * Ihatutot(I,j)
+  enddo ; enddo ; enddo
 
   !$OMP parallel do default(none) shared(is,ie,js,je,nz,CS,G,GV,h_v,h_neglect,h,use_default) &
   !$OMP                          private(hatv,hatvtot,Ihatvtot,e_v,D_shallow_v,h_arith,h_harm,wt_arith,Z_to_H)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -981,11 +981,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       d_eta_PF(i,j) = eta_PF_in(i,j) - eta_PF_start(i,j)
     enddo ; enddo
   else
-    !$OMP parallel do default(shared)
-    do j=G%jsd,G%jed ; do i=G%isd,G%ied !: Was "do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1" but doing so breaks OBC. Not sure why?
+    do concurrent (j=G%Jsd:G%Jed, i=G%isd:G%ied) !: Was "do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1" but doing so breaks OBC. Not sure why?
       eta(i,j) = eta_in(i,j)
       eta_PF(i,j) = eta_PF_in(i,j)
-    enddo ; enddo
+    enddo
   endif
   if (integral_BT_cont) then
     !$OMP parallel do default(shared)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1001,7 +1001,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     enddo
   endif
 
-  do concurrent (k=1:nz, j=js:je, I=is-1:ie) local(visc_rem)
+  do concurrent (k=1:nz, j=js:je, I=is-1:ie)
     ! rem needs to be greater than visc_rem_u and 1-Instep/visc_rem_u.
     ! The 0.5 below is just for safety.
     ! NOTE: subroundoff is a negligible value used to prevent division by zero.
@@ -1013,7 +1013,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     visc_rem = max(visc_rem, 0.)
     wt_u(I,j,k) = CS%frhatu(I,j,k) * visc_rem
   enddo
-  do concurrent (k=1:nz, J=js-1:je, i=is:ie) local(visc_rem)
+  do concurrent (k=1:nz, J=js-1:je, i=is:ie)
     ! As above, rem must be greater than visc_rem_v and 1-Instep/visc_rem_v.
     visc_rem = min(visc_rem_v(I,j,k), 1.)
     visc_rem = max(visc_rem, 1. - 0.5 * Instep / (visc_rem + subroundoff))
@@ -1236,7 +1236,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 ! between the accelerations due to the average of the layer equations and the
 ! barotropic calculation.
 
-  do concurrent (j=js:je, I=is-1:ie) local(Htot_avg) ; if (G%mask2dCu(I,j) > 0.0) then
+  do concurrent (j=js:je, I=is-1:ie) ; if (G%mask2dCu(I,j) > 0.0) then
     if (CS%nonlin_stress) then
       if (GV%Boussinesq) then
         Htot_avg = 0.5*(max(CS%bathyT(i,j)*GV%Z_to_H + eta(i,j), 0.0) + &
@@ -1261,7 +1261,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   else
     BT_force_u(I,j) = 0.0
   endif ; enddo
-  do concurrent (J=js-1:je, i=is:ie) local(Htot_avg) ; if (G%mask2dCv(i,J) > 0.0) then
+  do concurrent (J=js-1:je, i=is:ie) ; if (G%mask2dCv(i,J) > 0.0) then
     if (CS%nonlin_stress) then
       if (GV%Boussinesq) then
         Htot_avg = 0.5*(max(CS%bathyT(i,j)*GV%Z_to_H + eta(i,j), 0.0) + &
@@ -1513,7 +1513,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! Set the mass source, after first initializing the halos to 0.
   do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1) ; eta_src(i,j) = 0.0 ; enddo
   if (CS%bound_BT_corr) then ; if ((use_BT_Cont.or.integral_BT_cont) .and. CS%BT_cont_bounds) then
-    do concurrent (j=js:je, i=is:ie, G%mask2dT(i,j) > 0.0) local(uint_cor, vint_cor, u_max_cor, v_max_cor, eta_cor_max)
+    do concurrent (j=js:je, i=is:ie, G%mask2dT(i,j) > 0.0)
       if (CS%eta_cor(i,j) > 0.0) then
         !   Limit the source (outward) correction to be a fraction the mass that
         ! can be transported out of the cell by velocities with a CFL number of CFL_cor.
@@ -1564,7 +1564,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       else
         H_to_Z = GV%H_to_RZ / CS%Rho_BT_lin
       endif
-      do concurrent (j=js:je, i=is:ie) local(Idt_max2,H_eff_dx2,dyn_coef_max,ice_strength)
+      do concurrent (j=js:je, i=is:ie)
         ! First determine the maximum stable value for dyn_coef_eta.
 
         !   This estimate of the maximum stable time step is pretty accurate for
@@ -1741,10 +1741,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     ! The rest should not be changed.
   enddo
   ! do sum reduction on CPU to preserve fp summation order (nstep+filter is small)
-  !$omp target update from(wt_vel, wt_eta)
-  do n=1,nstep+nfilter
+  do concurrent (n=1:nstep+nfilter) reduce(+:sum_wt_vel, sum_wt_eta)
     sum_wt_vel = sum_wt_vel + wt_vel(n) ; sum_wt_eta = sum_wt_eta + wt_eta(n)
   enddo
+  !$omp target update from(wt_vel, wt_eta)
   ! leaving this prefix sum on CPU, but could be ported using openmp scan
   wt_trans(nstep+nfilter+1) = 0.0 ; wt_accel(nstep+nfilter+1) = 0.0
   do n=nstep+nfilter,1,-1

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -501,6 +501,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call cpu_clock_begin(id_clock_pres)
   call PressureForce(h, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                      CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
+  !$omp target update from(CS%PFu, CS%PFv)
   if (dyn_p_surf) then
     pres_to_eta = 1.0 / (GV%g_Earth * GV%H_to_RZ)
     !$OMP parallel do default(shared)
@@ -834,6 +835,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call cpu_clock_begin(id_clock_pres)
     call PressureForce(hp, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                        CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
+    !$omp target exit data map(from: CS%PFu, CS%PFv)
     ! Stokes shear force contribution to pressure gradient
     Use_Stokes_PGF = present(Waves)
     if (Use_Stokes_PGF) then
@@ -1243,7 +1245,8 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_C
   ALLOC_(CS%CAv_pred(isd:ied,JsdB:JedB,nz)) ; CS%CAv_pred(:,:,:)   = 0.0
   ALLOC_(CS%PFu(IsdB:IedB,jsd:jed,nz))   ; CS%PFu(:,:,:)   = 0.0
   ALLOC_(CS%PFv(isd:ied,JsdB:JedB,nz))   ; CS%PFv(:,:,:)   = 0.0
-
+  ! TODO: Replace with map(alloc:) (and remove PF[uv] = 0.)
+  !$omp target enter data map(to: CS%PFu, CS%PFv)
   ALLOC_(CS%eta(isd:ied,jsd:jed))       ; CS%eta(:,:)    = 0.0
   ALLOC_(CS%u_av(IsdB:IedB,jsd:jed,nz)) ; CS%u_av(:,:,:) = 0.0
   ALLOC_(CS%v_av(isd:ied,JsdB:JedB,nz)) ; CS%v_av(:,:,:) = 0.0
@@ -1553,6 +1556,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   endif
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
+  !$omp target enter data map(to: CS%PressureForce_CSp)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp, CS%fpmix)
@@ -1891,6 +1895,7 @@ subroutine end_dyn_split_RK2(CS)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)
   DEALLOC_(CS%CAu_pred) ; DEALLOC_(CS%CAv_pred)
   DEALLOC_(CS%PFu)   ; DEALLOC_(CS%PFv)
+  !$omp target exit data map(delete: CS%PFu, CS%PFv)
 
   if (associated(CS%taux_bot)) deallocate(CS%taux_bot)
   if (associated(CS%tauy_bot)) deallocate(CS%tauy_bot)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -684,11 +684,16 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
   !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel, CS%visc_rem_u, CS%visc_rem_v)
+  !$omp target update to(CS%BT_cont%FA_u_E0, CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, &
+  !$omp   CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, &
+  !$omp   CS%BT_cont%uBT_EE, CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt, CS%BT_cont%FA_u_E0, CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, &
+  !$omp   CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, &
+  !$omp   CS%BT_cont%uBT_EE, CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
   if (showCallTree) call callTree_leave("btstep()")
   call cpu_clock_end(id_clock_btstep)
 
@@ -968,13 +973,18 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the corrector step call to btstep.
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
-  !$omp target update to(u_bc_accel, v_bc_accel)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, u_bc_accel, v_bc_accel, CS%BT_cont%FA_u_E0, &
+  !$omp   CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, &
+  !$omp   CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, CS%BT_cont%uBT_EE, &
+  !$omp   CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
   !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt, eta_pred)
+  !$omp target update from(CS%BT_cont%FA_u_E0, CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, &
+  !$omp   CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, &
+  !$omp   CS%BT_cont%uBT_EE, CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -556,8 +556,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms,
     ! if it was not already stored from the end of the previous time step.
     call cpu_clock_begin(id_clock_Cor)
+    !$omp target update to(u_av, v_av, h_av, uh, vh)
     call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%AD_pred, &
                    G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
+    !$omp target update from(CS%CAu_pred, CS%CAv_pred)
     call cpu_clock_end(id_clock_Cor)
     if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2)")
   endif
@@ -896,8 +898,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
 ! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
   call cpu_clock_begin(id_clock_Cor)
+  !$omp target update to(u_av, v_av, h_av, uh, vh)
   call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu, CS%CAv, CS%OBC, CS%ADp, &
                  G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
+  !$omp target update from(CS%CAu, CS%CAv)
   call cpu_clock_end(id_clock_Cor)
   if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2)")
 
@@ -1091,8 +1095,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call cpu_clock_begin(id_clock_Cor)
     call disable_averaging(CS%diag)  ! These calculations should not be used for diagnostics.
     ! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
+    !$omp target update to(u_av, v_av, h_av, uh, vh)
     call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%AD_pred, &
                    G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
+    !$omp target update from(CS%CAu_pred, CS%CAv_pred)
     CS%CAu_pred_stored = .true.
     call enable_averages(dt, Time_local, CS%diag) ! Reenable the averaging
     call cpu_clock_end(id_clock_Cor)
@@ -1239,20 +1245,24 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_C
   endif
   allocate(CS)
 
+  ! TODO: Are these initializations necessary?  If not, then we can do
+  !   map(alloc:) rather than map(to:)
   ALLOC_(CS%diffu(IsdB:IedB,jsd:jed,nz)) ; CS%diffu(:,:,:) = 0.0
   ALLOC_(CS%diffv(isd:ied,JsdB:JedB,nz)) ; CS%diffv(:,:,:) = 0.0
   ALLOC_(CS%CAu(IsdB:IedB,jsd:jed,nz))   ; CS%CAu(:,:,:)   = 0.0
   ALLOC_(CS%CAv(isd:ied,JsdB:JedB,nz))   ; CS%CAv(:,:,:)   = 0.0
+  !$omp target enter data map(to: CS%CAu, CS%CAv)
   ALLOC_(CS%CAu_pred(IsdB:IedB,jsd:jed,nz)) ; CS%CAu_pred(:,:,:)   = 0.0
   ALLOC_(CS%CAv_pred(isd:ied,JsdB:JedB,nz)) ; CS%CAv_pred(:,:,:)   = 0.0
+  !$omp target enter data map(to: CS%CAu_pred, CS%CAv_pred)
   ALLOC_(CS%PFu(IsdB:IedB,jsd:jed,nz))   ; CS%PFu(:,:,:)   = 0.0
   ALLOC_(CS%PFv(isd:ied,JsdB:JedB,nz))   ; CS%PFv(:,:,:)   = 0.0
-  ! TODO: Replace with map(alloc:) (and remove PF[uv] = 0.)
   !$omp target enter data map(to: CS%PFu, CS%PFv)
   ALLOC_(CS%eta(isd:ied,jsd:jed))       ; CS%eta(:,:)    = 0.0
   ALLOC_(CS%u_av(IsdB:IedB,jsd:jed,nz)) ; CS%u_av(:,:,:) = 0.0
   ALLOC_(CS%v_av(isd:ied,JsdB:JedB,nz)) ; CS%v_av(:,:,:) = 0.0
   ALLOC_(CS%h_av(isd:ied,jsd:jed,nz))   ; CS%h_av(:,:,:) = GV%Angstrom_H
+  !$omp target enter data map(to: CS%u_av, CS%v_av, CS%h_av)
 
   thickness_units = get_thickness_units(GV)
   flux_units = get_flux_units(GV)
@@ -1635,8 +1645,10 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
       endif
       call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
       call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
+      !$omp target update to(CS%u_av, CS%v_av, CS%h_av, uh, vh)
       call CorAdCalc(CS%u_av, CS%v_av, CS%h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%ADp, &
                      G, GV, US, CS%CoriolisAdv, pbv) !, Waves=Waves)
+      !$omp target update from(CS%CAu_pred, CS%CAv_pred)
       CS%CAu_pred_stored = .true.
     endif
   else
@@ -1896,7 +1908,9 @@ subroutine end_dyn_split_RK2(CS)
 
   DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)
+  !$omp target exit data map(delete: CS%CAu, CS%CAv)
   DEALLOC_(CS%CAu_pred) ; DEALLOC_(CS%CAv_pred)
+  !$omp target exit data map(delete: CS%CAu_pred, CS%CAv_pred)
   DEALLOC_(CS%PFu)   ; DEALLOC_(CS%PFv)
   !$omp target exit data map(delete: CS%PFu, CS%PFv)
 
@@ -1907,8 +1921,9 @@ subroutine end_dyn_split_RK2(CS)
   DEALLOC_(CS%visc_rem_u) ; DEALLOC_(CS%visc_rem_v)
 
   DEALLOC_(CS%eta) ; DEALLOC_(CS%eta_PF) ; DEALLOC_(CS%pbce)
-  DEALLOC_(CS%h_av) ; DEALLOC_(CS%u_av) ; DEALLOC_(CS%v_av)
   !$omp target exit data map(delete: CS%pbce, CS%eta_PF)
+  DEALLOC_(CS%h_av) ; DEALLOC_(CS%u_av) ; DEALLOC_(CS%v_av)
+  !$omp target exit data map(delete: CS%u_av, CS%v_av, CS%h_av)
 
   call dealloc_BT_cont_type(CS%BT_cont)
   deallocate(CS%AD_pred)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -686,7 +686,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
   !$omp target enter data &
   !$omp   map(to: CS%barotropic_CSp, u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
-  !$omp   map(alloc: CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
+  !$omp   map(alloc: eta_pred, CS%uhbt, CS%vhbt)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
@@ -977,9 +977,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
   !$omp target exit data &
   !$omp   map(release: CS%barotropic_CSp, u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
-  !$omp   map(from: CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
+  !$omp   map(from: eta_pred, CS%uhbt, CS%vhbt)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif
@@ -1548,11 +1549,11 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   ALLOC_(CS%eta_PF(isd:ied,jsd:jed))          ; CS%eta_PF(:,:)       = 0.0
   ALLOC_(CS%pbce(isd:ied,jsd:jed,nz))         ; CS%pbce(:,:,:)       = 0.0
   !$omp target enter data map(alloc: CS%pbce, CS%eta_PF)
-
   ALLOC_(CS%u_accel_bt(IsdB:IedB,jsd:jed,nz)) ; CS%u_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%v_accel_bt(isd:ied,JsdB:JedB,nz)) ; CS%v_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%PFu_Stokes(IsdB:IedB,jsd:jed,nz)) ; CS%PFu_Stokes(:,:,:) = 0.0
   ALLOC_(CS%PFv_Stokes(isd:ied,JsdB:JedB,nz)) ; CS%PFv_Stokes(:,:,:) = 0.0
+  !$omp target enter data map(alloc: CS%u_accel_bt, CS%v_accel_bt)
 
   MIS%diffu      => CS%diffu
   MIS%diffv      => CS%diffv

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -499,9 +499,11 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 ! pbce = dM/deta
   if (CS%begw == 0.0) call enable_averages(dt, Time_local, CS%diag)
   call cpu_clock_begin(id_clock_pres)
+
   call PressureForce(h, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                      CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
   !$omp target update from(CS%PFu, CS%PFv)
+
   if (dyn_p_surf) then
     pres_to_eta = 1.0 / (GV%g_Earth * GV%H_to_RZ)
     !$OMP parallel do default(shared)
@@ -1202,7 +1204,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   endif
 
   if (showCallTree) call callTree_leave("step_MOM_dyn_split_RK2()")
-
 end subroutine step_MOM_dyn_split_RK2
 
 !> This subroutine sets up any auxiliary restart variables that are specific

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -658,6 +658,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call cpu_clock_begin(id_clock_continuity)
     call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                     visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, BT_cont=CS%BT_cont)
+    !$omp target update to(CS%BT_cont%h_u, CS%BT_cont%h_v)
     call cpu_clock_end(id_clock_continuity)
     if (BT_cont_BT_thick) then
       call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
@@ -802,6 +803,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av, BT_cont=CS%BT_cont)
   call cpu_clock_end(id_clock_continuity)
+  !$omp target update to(CS%BT_cont%h_u, CS%BT_cont%h_v)
   if (showCallTree) call callTree_wayPoint("done with continuity (step_MOM_dyn_split_RK2)")
 
   call do_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
@@ -908,7 +910,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   ! TODO: Cleanup BT_cont%h_[uv] handling
   !$omp target update to(u_av, v_av, h_av, uh, vh)
-  !$omp target enter data map(to: CS%BT_cont%h_u, CS%BT_cont%h_v)
 
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
@@ -920,7 +921,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call cpu_clock_end(id_clock_horvisc)
 
   !$omp target update from(CS%diffu, CS%diffv)
-  !$omp target exit data map(delete: CS%BT_cont%h_u, CS%BT_cont%h_v)
 
   if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2)")
 
@@ -1654,12 +1654,10 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
       .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
     ! TODO: Cleanup BT_cont%h_[uv] handling
     !$omp target update to(u, v, h, uh, vh)
-    !$omp target enter data map(to: CS%BT_cont%h_u, CS%BT_cont%h_v)
     call horizontal_viscosity(u, v, h, uh, vh, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
                               tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                               hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
     !$omp target update from(CS%diffu, CS%diffv)
-    !$omp target exit data map(delete: CS%BT_cont%h_u, CS%BT_cont%h_v)
     call set_initialized(CS%diffu, "diffu", restart_CS)
     call set_initialized(CS%diffv, "diffv", restart_CS)
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -685,7 +685,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
   !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
   !$omp target enter data &
-  !$omp   map(to: CS%barotropic_CSp, u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
+  !$omp   map(to: u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
   !$omp   map(alloc: eta_pred, CS%uhbt, CS%vhbt)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
@@ -979,7 +979,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
   !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
   !$omp target exit data &
-  !$omp   map(release: CS%barotropic_CSp, u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
+  !$omp   map(release: u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
   !$omp   map(from: eta_pred, CS%uhbt, CS%vhbt)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -503,7 +503,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(h)
   call PressureForce(h, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                      CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
-  !$omp target update from(CS%PFu, CS%PFv)
+  !$omp target update from(CS%PFu, CS%PFv, CS%pbce, CS%eta_PF)
 
   if (dyn_p_surf) then
     pres_to_eta = 1.0 / (GV%g_Earth * GV%H_to_RZ)
@@ -1501,6 +1501,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   ALLOC_(CS%visc_rem_v(isd:ied,JsdB:JedB,nz)) ; CS%visc_rem_v(:,:,:) = 0.0
   ALLOC_(CS%eta_PF(isd:ied,jsd:jed))          ; CS%eta_PF(:,:)       = 0.0
   ALLOC_(CS%pbce(isd:ied,jsd:jed,nz))         ; CS%pbce(:,:,:)       = 0.0
+  !$omp target enter data map(alloc: CS%pbce, CS%eta_PF)
 
   ALLOC_(CS%u_accel_bt(IsdB:IedB,jsd:jed,nz)) ; CS%u_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%v_accel_bt(isd:ied,JsdB:JedB,nz)) ; CS%v_accel_bt(:,:,:) = 0.0
@@ -1907,6 +1908,7 @@ subroutine end_dyn_split_RK2(CS)
 
   DEALLOC_(CS%eta) ; DEALLOC_(CS%eta_PF) ; DEALLOC_(CS%pbce)
   DEALLOC_(CS%h_av) ; DEALLOC_(CS%u_av) ; DEALLOC_(CS%v_av)
+  !$omp target exit data map(delete: CS%pbce, CS%eta_PF)
 
   call dealloc_BT_cont_type(CS%BT_cont)
   deallocate(CS%AD_pred)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -887,25 +887,32 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     endif
   endif
 
+  ! TODO: Cleanup BT_cont%h_[uv] handling
+  !$omp target update to(u_av, v_av, h_av, uh, vh)
+  !$omp target enter data map(to: CS%BT_cont%h_u, CS%BT_cont%h_v)
+
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
-  ! TODO: Am I doing this twice for no reason?
-  !$omp target update to(u_av, v_av, h_av, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
+
   call horizontal_viscosity(u_av, v_av, h_av, uh, vh, CS%diffu, CS%diffv, &
                             MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt, &
                             OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                             ADp=CS%ADp, hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v, STOCH=STOCH)
-  !$omp target update from(CS%diffu, CS%diffv)
   call cpu_clock_end(id_clock_horvisc)
+
+  !$omp target update from(CS%diffu, CS%diffv)
+  !$omp target exit data map(delete: CS%BT_cont%h_u, CS%BT_cont%h_v)
+
   if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2)")
 
 ! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
   call cpu_clock_begin(id_clock_Cor)
-  !$omp target update to(u_av, v_av, h_av, uh, vh)
   call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu, CS%CAv, CS%OBC, CS%ADp, &
                  G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
-  !$omp target update from(CS%CAu, CS%CAv)
   call cpu_clock_end(id_clock_Cor)
+
+  !$omp target update from(CS%CAu, CS%CAv)
+
   if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2)")
 
 ! Calculate the momentum forcing terms for the barotropic equations.
@@ -1612,11 +1619,14 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
 
   if (.not. query_initialized(CS%diffu, "diffu", restart_CS) .or. &
       .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
-    !!$omp target update to(u, v, h, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
+    ! TODO: Cleanup BT_cont%h_[uv] handling
+    !$omp target update to(u, v, h, uh, vh)
+    !$omp target enter data map(to: CS%BT_cont%h_u, CS%BT_cont%h_v)
     call horizontal_viscosity(u, v, h, uh, vh, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
                               tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                               hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
     !$omp target update from(CS%diffu, CS%diffv)
+    !$omp target exit data map(delete: CS%BT_cont%h_u, CS%BT_cont%h_v)
     call set_initialized(CS%diffu, "diffu", restart_CS)
     call set_initialized(CS%diffv, "diffv", restart_CS)
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1580,6 +1580,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   endif
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
+  !$omp target enter data map(to: CS%PressureForce_CSp)
 
   !$omp target enter data map(to: CS%hor_visc)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -683,9 +683,8 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
-  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
+  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel, CS%visc_rem_u, CS%visc_rem_v)
   !$omp target enter data &
-  !$omp   map(to: u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
   !$omp   map(alloc: eta_pred, CS%uhbt, CS%vhbt)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
@@ -979,7 +978,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
   !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
   !$omp target exit data &
-  !$omp   map(release: u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
   !$omp   map(from: eta_pred, CS%uhbt, CS%vhbt)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
@@ -1548,7 +1546,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   ALLOC_(CS%visc_rem_v(isd:ied,JsdB:JedB,nz)) ; CS%visc_rem_v(:,:,:) = 0.0
   ALLOC_(CS%eta_PF(isd:ied,jsd:jed))          ; CS%eta_PF(:,:)       = 0.0
   ALLOC_(CS%pbce(isd:ied,jsd:jed,nz))         ; CS%pbce(:,:,:)       = 0.0
-  !$omp target enter data map(alloc: CS%pbce, CS%eta_PF)
+  !$omp target enter data map(alloc: CS%visc_rem_u, CS%visc_rem_v, CS%pbce, CS%eta_PF)
   ALLOC_(CS%u_accel_bt(IsdB:IedB,jsd:jed,nz)) ; CS%u_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%v_accel_bt(isd:ied,JsdB:JedB,nz)) ; CS%v_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%PFu_Stokes(IsdB:IedB,jsd:jed,nz)) ; CS%PFu_Stokes(:,:,:) = 0.0

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -422,7 +422,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("step_MOM_dyn_split_RK2(), MOM_dynamics_split_RK2.F90")
 
   ! allocate internal variables on GPU
-  !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred)
+  !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
   !$omp target update to(eta)
 
   !$OMP parallel do default(shared)
@@ -669,6 +669,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (CS%BT_use_layer_fluxes) then
     uh_ptr => uh_in ; vh_ptr => vh_in; u_ptr => u_inst ; v_ptr => v_inst
+    !$omp target update to(uh_in, vh_in)
   endif
 
   call cpu_clock_begin(id_clock_btstep)
@@ -1127,7 +1128,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   enddo
 
   ! release internal variables
-  !$omp target exit data map(release: u_bc_accel, v_bc_accel, eta_pred)
+  !$omp target exit data map(release: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
 
   if (CS%store_CAu) then
     ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -421,6 +421,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   showCallTree = callTree_showQuery()
   if (showCallTree) call callTree_enter("step_MOM_dyn_split_RK2(), MOM_dynamics_split_RK2.F90")
 
+  ! allocate internal variables on GPU
+  !$omp target enter data map(alloc: u_bc_accel, v_bc_accel)
+
   !$OMP parallel do default(shared)
   do k=1,nz
     do j=G%jsd,G%jed   ; do i=G%isdB,G%iedB ;  up(i,j,k) = 0.0 ; enddo ; enddo
@@ -679,7 +682,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
-  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr)
+  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
   !$omp target enter data &
   !$omp   map(to: CS%barotropic_CSp, u_inst, v_inst, eta, forces, forces%taux, forces%tauy, &
   !$omp       CS%visc_rem_u, CS%visc_rem_v) &
@@ -969,6 +972,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the corrector step call to btstep.
   !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
+  !$omp target update to(u_bc_accel, v_bc_accel)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
@@ -1117,6 +1121,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
       vhtr(i,J,k) = vhtr(i,J,k) + vh(i,J,k)*dt
     enddo ; enddo
   enddo
+
+  ! release internal variables
+  !$omp target exit data map(release: u_bc_accel, v_bc_accel)
 
   if (CS%store_CAu) then
     ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -889,10 +889,13 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
+  ! TODO: Am I doing this twice for no reason?
+  !!$omp target update to(u_av, v_av, h_av, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
   call horizontal_viscosity(u_av, v_av, h_av, uh, vh, CS%diffu, CS%diffv, &
                             MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt, &
                             OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                             ADp=CS%ADp, hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v, STOCH=STOCH)
+  !$omp target update from(CS%diffu, CS%diffv)
   call cpu_clock_end(id_clock_horvisc)
   if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2)")
 
@@ -1249,6 +1252,7 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_C
   !   map(alloc:) rather than map(to:)
   ALLOC_(CS%diffu(IsdB:IedB,jsd:jed,nz)) ; CS%diffu(:,:,:) = 0.0
   ALLOC_(CS%diffv(isd:ied,JsdB:JedB,nz)) ; CS%diffv(:,:,:) = 0.0
+  !$omp target enter data map(to: CS%diffu, CS%diffv)
   ALLOC_(CS%CAu(IsdB:IedB,jsd:jed,nz))   ; CS%CAu(:,:,:)   = 0.0
   ALLOC_(CS%CAv(isd:ied,JsdB:JedB,nz))   ; CS%CAv(:,:,:)   = 0.0
   !$omp target enter data map(to: CS%CAu, CS%CAv)
@@ -1569,6 +1573,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   endif
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
+
   !$omp target enter data map(to: CS%hor_visc)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
@@ -1607,9 +1612,11 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
 
   if (.not. query_initialized(CS%diffu, "diffu", restart_CS) .or. &
       .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
+    !!$omp target update to(u, v, h, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
     call horizontal_viscosity(u, v, h, uh, vh, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
                               tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                               hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
+    !$omp target update from(CS%diffu, CS%diffv)
     call set_initialized(CS%diffu, "diffu", restart_CS)
     call set_initialized(CS%diffv, "diffv", restart_CS)
   endif
@@ -1909,6 +1916,7 @@ subroutine end_dyn_split_RK2(CS)
   call CoriolisAdv_end(CS%CoriolisAdv)
 
   DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
+  !$omp target exit data map(delete: CS%diffu, CS%diffv)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)
   !$omp target exit data map(delete: CS%CAu, CS%CAv)
   DEALLOC_(CS%CAu_pred) ; DEALLOC_(CS%CAv_pred)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1569,7 +1569,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   endif
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
-  !$omp target enter data map(to: CS%PressureForce_CSp)
+  !$omp target enter data map(to: CS%hor_visc)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp, CS%fpmix)
@@ -1902,6 +1902,8 @@ subroutine end_dyn_split_RK2(CS)
   deallocate(CS%vertvisc_CSp)
 
   call hor_visc_end(CS%hor_visc)
+  !$omp target exit data map(delete: CS%hor_visc)
+
   if (CS%calculate_SAL) call SAL_end(CS%SAL_CSp)
   if (CS%use_tides) call tidal_forcing_end(CS%tides_CSp)
   call CoriolisAdv_end(CS%CoriolisAdv)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -500,6 +500,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (CS%begw == 0.0) call enable_averages(dt, Time_local, CS%diag)
   call cpu_clock_begin(id_clock_pres)
 
+  !$omp target update to(h)
   call PressureForce(h, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                      CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
   !$omp target update from(CS%PFu, CS%PFv)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -679,6 +679,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
+  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -423,6 +423,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   ! allocate internal variables on GPU
   !$omp target enter data map(alloc: u_bc_accel, v_bc_accel)
+  !$omp target update to(eta)
 
   !$OMP parallel do default(shared)
   do k=1,nz
@@ -1297,7 +1298,7 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_C
   ALLOC_(CS%u_av(IsdB:IedB,jsd:jed,nz)) ; CS%u_av(:,:,:) = 0.0
   ALLOC_(CS%v_av(isd:ied,JsdB:JedB,nz)) ; CS%v_av(:,:,:) = 0.0
   ALLOC_(CS%h_av(isd:ied,jsd:jed,nz))   ; CS%h_av(:,:,:) = GV%Angstrom_H
-  !$omp target enter data map(to: CS%u_av, CS%v_av, CS%h_av)
+  !$omp target enter data map(to: CS%eta, CS%u_av, CS%v_av, CS%h_av)
 
   thickness_units = get_thickness_units(GV)
   flux_units = get_flux_units(GV)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -684,8 +684,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
   !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
   !$omp target enter data &
-  !$omp   map(to: CS%barotropic_CSp, u_inst, v_inst, eta, forces, forces%taux, forces%tauy, &
-  !$omp       CS%visc_rem_u, CS%visc_rem_v) &
+  !$omp   map(to: CS%barotropic_CSp, u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
   !$omp   map(alloc: CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
@@ -978,8 +977,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
   !$omp target exit data &
-  !$omp   map(release: CS%barotropic_CSp, u_inst, v_inst, eta, forces, forces%taux, forces%tauy, &
-  !$omp       CS%visc_rem_u, CS%visc_rem_v) &
+  !$omp   map(release: CS%barotropic_CSp, u_inst, v_inst, CS%visc_rem_u, CS%visc_rem_v) &
   !$omp   map(from: CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -422,7 +422,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("step_MOM_dyn_split_RK2(), MOM_dynamics_split_RK2.F90")
 
   ! allocate internal variables on GPU
-  !$omp target enter data map(alloc: u_bc_accel, v_bc_accel)
+  !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred)
   !$omp target update to(eta)
 
   !$OMP parallel do default(shared)
@@ -688,7 +688,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt)
   if (showCallTree) call callTree_leave("btstep()")
   call cpu_clock_end(id_clock_btstep)
 
@@ -974,7 +974,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt, eta_pred)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif
@@ -1117,7 +1117,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   enddo
 
   ! release internal variables
-  !$omp target exit data map(release: u_bc_accel, v_bc_accel)
+  !$omp target exit data map(release: u_bc_accel, v_bc_accel, eta_pred)
 
   if (CS%store_CAu) then
     ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -680,10 +680,15 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
   !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr)
+  !$omp target enter data &
+  !$omp   map(to: CS%barotropic_CSp, u_inst, v_inst, eta, forces, forces%taux, forces%tauy, &
+  !$omp       CS%visc_rem_u, CS%visc_rem_v) &
+  !$omp   map(alloc: CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
   if (showCallTree) call callTree_leave("btstep()")
   call cpu_clock_end(id_clock_btstep)
 
@@ -963,10 +968,15 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the corrector step call to btstep.
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
+  !$omp target exit data &
+  !$omp   map(release: CS%barotropic_CSp, u_inst, v_inst, eta, forces, forces%taux, forces%tauy, &
+  !$omp       CS%visc_rem_u, CS%visc_rem_v) &
+  !$omp   map(from: CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -448,6 +448,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   else
     p_surf => forces%p_surf
   endif
+  ! TODO: This should probably be resolved in step_MOM, if not higher.  But
+  !   p_surf setup is a bit complicated, and may even depend on the driver, so
+  !   for now we alloc/delete in the dynamic core step.
+  !$omp target enter data map(to: p_surf) if (associated(p_surf))
 
   if (associated(CS%OBC)) then
     if (CS%debug_OBC) call open_boundary_test_extern_h(G, GV, CS%OBC, h)
@@ -838,6 +842,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     ! PFu = d/dx M(hp,T,S)
     ! pbce = dM/deta
     call cpu_clock_begin(id_clock_pres)
+    ! XXX: GPU error?? why no hp upload?
     call PressureForce(hp, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                        CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
     !$omp target exit data map(from: CS%PFu, CS%PFv)
@@ -866,6 +871,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call cpu_clock_end(id_clock_pres)
     if (showCallTree) call callTree_wayPoint("done with PressureForce[hp=(1-b).h+b.h] (step_MOM_dyn_split_RK2)")
   endif
+
+  ! TODO: Move p_surf handling outside of this function
+  !$omp target exit data map(delete: p_surf) if (associated(p_surf))
 
   if (G%nonblocking_updates) &
     call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -684,8 +684,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
   !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel, CS%visc_rem_u, CS%visc_rem_v)
-  !$omp target enter data &
-  !$omp   map(alloc: eta_pred, CS%uhbt, CS%vhbt)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
@@ -976,9 +974,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
-  !$omp target exit data &
-  !$omp   map(from: eta_pred, CS%uhbt, CS%vhbt)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif
@@ -1542,11 +1538,13 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
 
   ALLOC_(CS%uhbt(IsdB:IedB,jsd:jed))          ; CS%uhbt(:,:)         = 0.0
   ALLOC_(CS%vhbt(isd:ied,JsdB:JedB))          ; CS%vhbt(:,:)         = 0.0
+  !$omp target enter data map(alloc: CS%uhbt, CS%vhbt)
   ALLOC_(CS%visc_rem_u(IsdB:IedB,jsd:jed,nz)) ; CS%visc_rem_u(:,:,:) = 0.0
   ALLOC_(CS%visc_rem_v(isd:ied,JsdB:JedB,nz)) ; CS%visc_rem_v(:,:,:) = 0.0
+  !$omp target enter data map(alloc: CS%visc_rem_u, CS%visc_rem_v)
   ALLOC_(CS%eta_PF(isd:ied,jsd:jed))          ; CS%eta_PF(:,:)       = 0.0
   ALLOC_(CS%pbce(isd:ied,jsd:jed,nz))         ; CS%pbce(:,:,:)       = 0.0
-  !$omp target enter data map(alloc: CS%visc_rem_u, CS%visc_rem_v, CS%pbce, CS%eta_PF)
+  !$omp target enter data map(alloc: CS%pbce, CS%eta_PF)
   ALLOC_(CS%u_accel_bt(IsdB:IedB,jsd:jed,nz)) ; CS%u_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%v_accel_bt(isd:ied,JsdB:JedB,nz)) ; CS%v_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%PFu_Stokes(IsdB:IedB,jsd:jed,nz)) ; CS%PFu_Stokes(:,:,:) = 0.0

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -890,7 +890,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
   ! TODO: Am I doing this twice for no reason?
-  !!$omp target update to(u_av, v_av, h_av, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
+  !$omp target update to(u_av, v_av, h_av, uh, vh, CS%BT_cont%h_u, CS%BT_cont%h_v)
   call horizontal_viscosity(u_av, v_av, h_av, uh, vh, CS%diffu, CS%diffv, &
                             MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt, &
                             OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -598,6 +598,7 @@ subroutine alloc_BT_cont_type(BT_cont, G, GV, alloc_faces)
   if (present(alloc_faces)) then ; if (alloc_faces) then
     allocate(BT_cont%h_u(IsdB:IedB,jsd:jed,1:nz), source=0.0)
     allocate(BT_cont%h_v(isd:ied,JsdB:JedB,1:nz), source=0.0)
+    !$omp target enter data map(to: BT_cont%h_u, BT_cont%h_v)
   endif ; endif
 
 end subroutine alloc_BT_cont_type
@@ -620,6 +621,7 @@ subroutine dealloc_BT_cont_type(BT_cont)
   deallocate(BT_cont%FA_v_N0) ; deallocate(BT_cont%FA_v_NN)
   deallocate(BT_cont%vBT_SS)  ; deallocate(BT_cont%vBT_NN)
 
+  !$omp target exit data map(release: BT_cont%h_u, BT_cont%h_v)
   if (allocated(BT_cont%h_u)) deallocate(BT_cont%h_u)
   if (allocated(BT_cont%h_v)) deallocate(BT_cont%h_v)
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -582,6 +582,9 @@ subroutine alloc_BT_cont_type(BT_cont, G, GV, alloc_faces)
   allocate(BT_cont%FA_u_EE(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%uBT_WW(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%uBT_EE(IsdB:IedB,jsd:jed), source=0.0)
+  !$omp target enter data map(alloc: BT_cont) ! map(to: BT_cont) results in cuda memory access errors elsewhere...
+  !$omp target enter data map(to: BT_cont%FA_u_WW, BT_cont%FA_u_W0, BT_cont%FA_u_E0, &
+  !$omp   BT_cont%FA_u_EE, BT_cont%uBT_WW, BT_cont%uBT_EE)
 
   allocate(BT_cont%FA_v_SS(isd:ied,JsdB:JedB), source=0.0)
   allocate(BT_cont%FA_v_S0(isd:ied,JsdB:JedB), source=0.0)
@@ -589,6 +592,8 @@ subroutine alloc_BT_cont_type(BT_cont, G, GV, alloc_faces)
   allocate(BT_cont%FA_v_NN(isd:ied,JsdB:JedB), source=0.0)
   allocate(BT_cont%vBT_SS(isd:ied,JsdB:JedB), source=0.0)
   allocate(BT_cont%vBT_NN(isd:ied,JsdB:JedB), source=0.0)
+  !$omp target enter data map(to: BT_cont%FA_v_SS, BT_cont%FA_v_S0, BT_cont%FA_v_N0, &
+  !$omp   BT_cont%FA_v_NN, BT_cont%vBT_SS, BT_cont%vBT_NN)
 
   if (present(alloc_faces)) then ; if (alloc_faces) then
     allocate(BT_cont%h_u(IsdB:IedB,jsd:jed,1:nz), source=0.0)
@@ -603,10 +608,14 @@ subroutine dealloc_BT_cont_type(BT_cont)
 
   if (.not.associated(BT_cont)) return
 
+  !$omp target exit data map(release: BT_cont, BT_cont%FA_u_WW, BT_cont%FA_u_W0, BT_cont%FA_u_E0, &
+  !$omp   BT_cont%FA_u_EE, BT_cont%uBT_WW, BT_cont%uBT_EE)
   deallocate(BT_cont%FA_u_WW) ; deallocate(BT_cont%FA_u_W0)
   deallocate(BT_cont%FA_u_E0) ; deallocate(BT_cont%FA_u_EE)
   deallocate(BT_cont%uBT_WW)  ; deallocate(BT_cont%uBT_EE)
 
+  !$omp target exit data map(release: BT_cont%FA_v_SS, BT_cont%FA_v_S0, BT_cont%FA_v_N0, &
+  !$omp   BT_cont%FA_v_NN, BT_cont%vBT_SS, BT_cont%vBT_NN)
   deallocate(BT_cont%FA_v_SS) ; deallocate(BT_cont%FA_v_S0)
   deallocate(BT_cont%FA_v_N0) ; deallocate(BT_cont%FA_v_NN)
   deallocate(BT_cont%vBT_SS)  ; deallocate(BT_cont%vBT_NN)

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -66,6 +66,7 @@ public get_EOS_name
 interface calculate_density
   module procedure calculate_density_scalar
   module procedure calculate_density_1d
+  module procedure calculate_density_2d
   module procedure calculate_stanley_density_scalar
   module procedure calculate_stanley_density_1d
 end interface calculate_density
@@ -344,6 +345,63 @@ subroutine calculate_density_1d(T, S, pressure, rho, EOS, dom, rho_ref, scale)
   enddo ; endif
 
 end subroutine calculate_density_1d
+
+
+!> 2D version...
+subroutine calculate_density_2d(T, S, pressure, rho, EOS, dom, rho_ref)
+  real, intent(in) :: T(:,:)
+    !< Potential temperature referenced to the surface [C ~> degC]
+  real, intent(in) :: S(:,:)
+    !< Salinity [S ~> ppt]
+  real, intent(in) :: pressure(:,:)
+    !< Pressure [R L2 T-2 ~> Pa]
+  real, intent(inout) :: rho(:,:)
+    !< Density (in-situ if pressure is local) [R ~> kg m-3]
+  type(EOS_type), intent(in) :: EOS
+    !< Equation of state structure
+  integer, optional, intent(in) :: dom(2,2)
+    !< The domain of indices to work on, taking into account that arrays start
+    !! at 1.
+  real, optional, intent(in) :: rho_ref
+    !< A reference density [R ~> kg m-3]
+
+  real, dimension(size(rho,1), size(rho,2)) :: pres
+    ! Pressure converted to [Pa]
+  real, dimension(size(rho,1), size(rho,2)) :: Ta
+    ! Temperature converted to [degC]
+  real, dimension(size(rho,1), size(rho,2)) :: Sa
+    ! Salinity converted to [ppt]
+  integer :: i, is, ie, js, je, npts
+  integer :: domain(2,2)
+
+  if (present(dom)) then
+    domain(:,:) = dom(:,:)
+  else
+    domain(1,:) = [1, size(rho,1)]
+    domain(2,:) = [1, size(rho,2)]
+  endif
+
+  if ((EOS%RL2_T2_to_Pa == 1.0) .and. (EOS%R_to_kg_m3 == 1.0) .and. &
+      (EOS%C_to_degC == 1.0) .and. (EOS%S_to_ppt == 1.0)) then
+    call EOS%type%calculate_density_array_2d(T, S, pressure, rho, domain, &
+        rho_ref=rho_ref)
+  else ! This is the same as above, but with some extra work to rescale variables.
+    is = domain(1,1) ; ie = domain(1,2)
+    js = domain(2,1) ; je = domain(2,2)
+
+    pres(is:ie, js:je) = EOS%RL2_T2_to_Pa * pressure(is:ie, js:je)
+    Ta(is:ie, js:je) = EOS%C_to_degC * T(is:ie, js:je)
+    Sa(is:ie, js:je) = EOS%S_to_ppt * S(is:ie, js:je)
+
+    if (present(rho_ref)) then
+      call EOS%type%calculate_density_array_2d(Ta, Sa, pres, rho, domain, &
+          rho_ref=EOS%R_to_kg_m3*rho_ref)
+    else
+      call EOS%type%calculate_density_array_2d(Ta, Sa, pres, rho, domain)
+    endif
+  endif
+end subroutine calculate_density_2d
+
 
 !> Calls the appropriate subroutine to calculate the density of sea water for 1-D array inputs
 !! including the variance of T, S and covariance of T-S,

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -81,6 +81,7 @@ end interface calculate_spec_vol
 interface calculate_density_derivs
   module procedure calculate_density_derivs_scalar, calculate_density_derivs_array
   module procedure calculate_density_derivs_1d
+  module procedure calculate_density_derivs_2d
 end interface calculate_density_derivs
 
 !> Calculate the derivatives of specific volume with temperature and salinity from T, S, and P
@@ -371,7 +372,7 @@ subroutine calculate_density_2d(T, S, pressure, rho, EOS, dom, rho_ref)
     ! Temperature converted to [degC]
   real, dimension(size(rho,1), size(rho,2)) :: Sa
     ! Salinity converted to [ppt]
-  integer :: i, is, ie, js, je, npts
+  integer :: is, ie, js, je, npts
   integer :: domain(2,2)
 
   if (present(dom)) then
@@ -400,6 +401,9 @@ subroutine calculate_density_2d(T, S, pressure, rho, EOS, dom, rho_ref)
       call EOS%type%calculate_density_array_2d(Ta, Sa, pres, rho, domain)
     endif
   endif
+
+  if (EOS%kg_m3_to_R /= 1.) &
+    rho(is:ie, js:je) = EOS%kg_m3_to_R * rho(is:ie, js:je)
 end subroutine calculate_density_2d
 
 
@@ -813,6 +817,64 @@ subroutine calculate_density_derivs_1d(T, S, pressure, drho_dT, drho_dS, EOS, do
   enddo ; endif
 
 end subroutine calculate_density_derivs_1d
+
+
+!> Calls the appropriate subroutine to calculate density derivatives for 1-D array inputs.
+subroutine calculate_density_derivs_2d(T, S, pressure, drho_dT, drho_dS, EOS, dom)
+  real, intent(in) :: T(:,:)
+    !< Potential temperature referenced to the surface [degC]
+  real, intent(in) :: S(:,:)
+    !< Salinity [ppt]
+  real, intent(in) :: pressure(:,:)
+    !< Pressure [Pa]
+  real, intent(inout) :: drho_dT(:,:)
+    !< The partial derivative of density with potential temperature
+    !! [kg m-3 degC-1] or other units determinedby the optional scale argument
+  real, intent(inout) :: drho_dS(:,:)
+    !< The partial derivative of density with salinity, in [kg m-3 ppt-1] or
+    !! other units determined by the optional scale argument
+  type(EOS_type), intent(in) :: EOS
+    !< Equation of state structure
+  integer, optional, intent(in) :: dom(2,2)
+    !< The domain of indices to work on, taking into account that arrays start
+
+  ! Local variables
+  real :: Ta(size(T,1), size(T,2))
+    ! Temperature converted to [degC]
+  real :: Sa(size(S,1), size(S,2))
+    ! Salinity converted to [ppt]
+  real :: press(size(pressure,1), size(pressure,2))
+    ! Pressure converted to [Pa]
+  integer :: is, ie, js, je, npts
+  integer :: domain(2,2)
+
+  if (present(dom)) then
+    domain(:,:) = dom(:,:)
+  else
+    domain(1,:) = [1, size(drho_dT, 1)]
+    domain(2,:) = [1, size(drho_dT, 2)]
+  endif
+  is = domain(1,1) ; ie = domain(1,2)
+  js = domain(2,1) ; je = domain(2,2)
+
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+      "calculate_density_derivs_array: EOS%form_of_EOS is not valid.")
+
+  if (all([EOS%RL2_T2_to_Pa, EOS%C_to_degC, EOS%S_to_ppt] == 1.)) then
+    call EOS%type%calculate_density_derivs_2d(T, S, pressure, drho_dT, drho_dS, domain)
+  else
+    press(is:ie, js:je) = EOS%RL2_T2_to_Pa * pressure(is:ie, js:je)
+    Ta(is:ie, js:je) = EOS%C_to_degC * T(is:ie, js:je)
+    Sa(is:ie, js:je) = EOS%S_to_ppt * S(is:ie, js:je)
+
+    call EOS%type%calculate_density_derivs_2d(Ta, Sa, press, drho_dT, drho_dS, domain)
+  endif
+
+  if (EOS%kg_m3_to_R * EOS%C_to_degC /= 1.) &
+    drho_dT(is:ie, js:je) = EOS%kg_m3_to_R * EOS%C_to_degC * drho_dT(is:ie, js:je)
+  if (EOS%kg_m3_to_R * EOS%S_to_ppt /= 1.) &
+    drho_dS(is:ie, js:je) = EOS%kg_m3_to_R * EOS%S_to_ppt * drho_dS(is:ie, js:je)
+end subroutine calculate_density_derivs_2d
 
 
 !> Calls the appropriate subroutines to calculate density derivatives by promoting a scalar

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -921,7 +921,6 @@ subroutine calculate_density_array_buggy_Wright(this, T, S, pressure, rho, start
   ! Local variables
   integer :: j
 
-  !!!$acc kernels
   if (present(rho_ref)) then
     do j = start, start+npts-1
       rho(j) = density_anomaly_elem_buggy_Wright(this, T(j), S(j), pressure(j), rho_ref)
@@ -931,7 +930,6 @@ subroutine calculate_density_array_buggy_Wright(this, T, S, pressure, rho, start
       rho(j) = density_elem_buggy_Wright(this, T(j), S(j), pressure(j))
     enddo
   endif
-  !!!$acc end kernels
 end subroutine calculate_density_array_buggy_Wright
 
 !> Calculate the in-situ density for 2D arraya inputs and outputs.
@@ -957,6 +955,9 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
 
   is = dom(1,1) ; ie = dom(1,2)
   js = dom(2,1) ; je = dom(2,2)
+
+  ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
+  !   Possibly because Nvidia cannot associate `this` with `EOS%type`.
 
   !$acc kernels present(T, S, pressure, rho_ref, rho)
   if (present(rho_ref)) then

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -961,7 +961,6 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
   !   Possibly because Nvidia cannot associate `this` with `EOS%type`.
 
-  !$acc kernels present(T, S, pressure, rho_ref, rho)
   !$omp target
   if (present(rho_ref)) then
     !$omp parallel loop
@@ -975,7 +974,6 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
       rho(i,j) = density_elem_buggy_Wright(this, T(i,j), S(i,j), pressure(i,j))
     enddo ; enddo
   endif
-  !$acc end kernels
   !$omp end target
 end subroutine calculate_density_array_2d_buggy_Wright
 
@@ -1032,14 +1030,12 @@ subroutine calculate_density_derivs_2d_buggy_Wright(this, T, S, pressure, &
 
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
 
-  !$acc kernels present(T, S, pressure, drho_dT, drho_dS)
   !$omp target
   !$omp parallel loop collapse(2)
   do j = js, je ; do i = is, ie
     call calculate_density_derivs_elem_buggy_Wright(this, T(i,j), S(i,j), &
         pressure(i,j), drho_dT(i,j), drho_dS(i,j))
   enddo ; enddo
-  !$acc end kernels
   !$omp end target
 end subroutine calculate_density_derivs_2d_buggy_Wright
 

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -962,17 +962,21 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
   !   Possibly because Nvidia cannot associate `this` with `EOS%type`.
 
   !$acc kernels present(T, S, pressure, rho_ref, rho)
+  !$omp target
   if (present(rho_ref)) then
+    !$omp parallel loop
     do j = js, je ; do i = is, ie
       rho(i,j) = density_anomaly_elem_buggy_Wright(this, T(i,j), S(i,j), &
           pressure(i,j), rho_ref)
     enddo ; enddo
   else
+    !$omp parallel loop
     do j = js, je ; do i = is, ie
       rho(i,j) = density_elem_buggy_Wright(this, T(i,j), S(i,j), pressure(i,j))
     enddo ; enddo
   endif
   !$acc end kernels
+  !$omp end target
 end subroutine calculate_density_array_2d_buggy_Wright
 
 !> Calculate the in-situ specific volume for 1D array inputs and outputs.

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -961,20 +961,16 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
   !   Possibly because Nvidia cannot associate `this` with `EOS%type`.
 
-  !$omp target
   if (present(rho_ref)) then
-    !$omp parallel loop
-    do j = js, je ; do i = is, ie
+    do concurrent (i=is:ie, j=js:je)
       rho(i,j) = density_anomaly_elem_buggy_Wright(this, T(i,j), S(i,j), &
           pressure(i,j), rho_ref)
-    enddo ; enddo
+    enddo
   else
-    !$omp parallel loop
-    do j = js, je ; do i = is, ie
+    do concurrent (i=is:ie, j=js:je)
       rho(i,j) = density_elem_buggy_Wright(this, T(i,j), S(i,j), pressure(i,j))
-    enddo ; enddo
+    enddo
   endif
-  !$omp end target
 end subroutine calculate_density_array_2d_buggy_Wright
 
 !> Calculate the in-situ specific volume for 1D array inputs and outputs.
@@ -1030,13 +1026,10 @@ subroutine calculate_density_derivs_2d_buggy_Wright(this, T, S, pressure, &
 
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
 
-  !$omp target
-  !$omp parallel loop collapse(2)
-  do j = js, je ; do i = is, ie
+  do concurrent (i=is:ie, j=js:je)
     call calculate_density_derivs_elem_buggy_Wright(this, T(i,j), S(i,j), &
         pressure(i,j), drho_dT(i,j), drho_dS(i,j))
-  enddo ; enddo
-  !$omp end target
+  enddo
 end subroutine calculate_density_derivs_2d_buggy_Wright
 
 !> Set coefficients that can correct bugs un the buggy Wright equation of state.

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -1033,11 +1033,14 @@ subroutine calculate_density_derivs_2d_buggy_Wright(this, T, S, pressure, &
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
 
   !$acc kernels present(T, S, pressure, drho_dT, drho_dS)
+  !$omp target
+  !$omp parallel loop collapse(2)
   do j = js, je ; do i = is, ie
     call calculate_density_derivs_elem_buggy_Wright(this, T(i,j), S(i,j), &
         pressure(i,j), drho_dT(i,j), drho_dS(i,j))
   enddo ; enddo
   !$acc end kernels
+  !$omp end target
 end subroutine calculate_density_derivs_2d_buggy_Wright
 
 !> Set coefficients that can correct bugs un the buggy Wright equation of state.

--- a/src/equation_of_state/MOM_EOS_base_type.F90
+++ b/src/equation_of_state/MOM_EOS_base_type.F90
@@ -42,6 +42,8 @@ contains
   procedure :: calculate_density_scalar => a_calculate_density_scalar
   !> Calculates the in-situ density or density anomaly for array inputs [m3 kg-1]
   procedure :: calculate_density_array => a_calculate_density_array
+  !> Calculates the in-situ density or density anomaly for 2d array inputs [m3 kg-1]
+  procedure :: calculate_density_array_2d => a_calculate_density_array_2d
   !> Calculates the in-situ specific volume or specific volume anomaly for scalar inputs [m3 kg-1]
   procedure :: calculate_spec_vol_scalar => a_calculate_spec_vol_scalar
   !> Calculates the in-situ specific volume or specific volume anomaly for array inputs [m3 kg-1]
@@ -251,6 +253,36 @@ contains
     endif
 
   end subroutine a_calculate_density_array
+
+  !> Calculate the in-situ density for 2D array inputs and outputs.
+  subroutine a_calculate_density_array_2d(this, T, S, pressure, rho, dom, rho_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real, intent(in) :: T(:,:)
+      !< Potential temperature relative to the surface [degC]
+    real, intent(in) :: S(:,:)
+      !< Salinity [PSU]
+    real, intent(in) :: pressure(:,:)
+      !< Pressure [Pa]
+    real, intent(out) :: rho(:,:)
+      !< In situ density [kg m-3]
+    integer, intent(in) :: dom(2,2)
+      !< Index bounds of domain.  dom(::) = [[is, ie], [js, je]]
+    real, optional, intent(in) :: rho_ref
+      !< A reference density [kg m-3]
+
+    integer :: is, ie, js, je
+
+    is = dom(1,1) ; ie = dom(1,2)
+    js = dom(2,1) ; je = dom(2,2)
+
+    if (present(rho_ref)) then
+      rho(is:ie, js:je) = this%density_anomaly_elem(T(is:ie, js:je), &
+          S(is:ie, js:je), pressure(is:ie, js:je), rho_ref)
+    else
+      rho(is:ie, js:je) = this%density_elem(T(is:ie, js:je), S(is:ie, js:je), &
+          pressure(is:ie, js:je))
+    endif
+  end subroutine a_calculate_density_array_2d
 
   !> In situ specific volume [m3 kg-1]
   real function a_spec_vol_fn(this, T, S, pressure, spv_ref)

--- a/src/equation_of_state/MOM_EOS_base_type.F90
+++ b/src/equation_of_state/MOM_EOS_base_type.F90
@@ -52,6 +52,8 @@ contains
   procedure :: calculate_density_derivs_scalar => a_calculate_density_derivs_scalar
   !> Calculates the derivatives of density for array inputs
   procedure :: calculate_density_derivs_array => a_calculate_density_derivs_array
+  !> Calculates the derivatives of density for array inputs
+  procedure :: calculate_density_derivs_2d => a_calculate_density_derivs_2d
   !> Calculates the second derivatives of density for scalar inputs
   procedure :: calculate_density_second_derivs_scalar => a_calculate_density_second_derivs_scalar
   !> Calculates the second derivatives of density for array inputs
@@ -381,6 +383,34 @@ contains
     call this%calculate_density_derivs_elem(T(js:je), S(js:je), pressure(js:je), drho_dt(js:je), drho_ds(js:je))
 
   end subroutine a_calculate_density_derivs_array
+
+  !> Calculate the derivatives of density with respect to temperature, salinity and pressure
+  !! for array inputs
+  subroutine a_calculate_density_derivs_2d(this, T, S, pressure, drho_dT, drho_dS, dom)
+    class(EOS_base), intent(in) :: this
+      !< This EOS
+    real, intent(in) :: T(:,:)
+      !< Potential temperature relative to the surface [degC]
+    real, intent(in)  :: S(:,:)
+      !< Salinity [PSU]
+    real, intent(in)  :: pressure(:,:)
+      !< Pressure [Pa]
+    real, intent(out) :: drho_dT(:,:)
+      !< The partial derivative of density with potential temperature
+      !! [kg m-3 degC-1]
+    real, intent(out) :: drho_dS(:,:)
+      !< The partial derivative of density with salinity, in [kg m-3 PSU-1]
+    integer, intent(in) :: dom(2,2)
+      !< Index bounds of domain.  First index is rank, second is bounds
+
+    integer :: is, ie, js, je
+
+    is = dom(1,1) ; ie = dom(1,2)
+    js = dom(2,1) ; je = dom(2,2)
+
+    call this%calculate_density_derivs_elem(T(is:ie, js:je), S(is:ie, js:je), &
+        pressure(is:ie, js:je), drho_dt(is:ie, js:je), drho_ds(is:ie, js:je))
+  end subroutine a_calculate_density_derivs_2d
 
   !> Calculate the second derivatives of density with respect to temperature, salinity and pressure
   !! for scalar inputs

--- a/src/equation_of_state/MOM_EOS_base_type.F90
+++ b/src/equation_of_state/MOM_EOS_base_type.F90
@@ -266,7 +266,7 @@ contains
     real, intent(out) :: rho(:,:)
       !< In situ density [kg m-3]
     integer, intent(in) :: dom(2,2)
-      !< Index bounds of domain.  dom(::) = [[is, ie], [js, je]]
+      !< Index bounds of domain.  First index is rank, second is bounds
     real, optional, intent(in) :: rho_ref
       !< A reference density [kg m-3]
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -686,7 +686,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
   !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
-  !$omp target enter data map(alloc: bhstr_xy) if (CS%biharmonic)
+  ! TODO: Only needed if FrictWork_bh is true, and currently only used on CPU,
+  !   but I do not yet see any benefit to breaking up the calculation.
+  !$omp target enter data map(alloc: bhstr_xx, bhstr_xy) if (CS%biharmonic)
 
   !$omp target enter data map(alloc: hrat_min) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
@@ -2161,6 +2163,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     if (find_FrictWork_bh) then
+      !$omp target update from(bhstr_xx, bhstr_xy)
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc
@@ -2359,7 +2362,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: Shear_mag) if (use_Smag)
   !$omp target exit data map(delete: Kh) if (CS%Laplacian)
   !$omp target exit data map(delete: Ah) if (CS%biharmonic)
-  !$omp target exit data map(delete: bhstr_xy) if (CS%biharmonic)
+  !$omp target exit data map(delete: bhstr_xx, bhstr_xy) if (CS%biharmonic)
 
   !$omp target exit data map(delete: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -704,8 +704,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
-  !!!$omp target enter data map(to: CS%Kh_max_xy) &
-  !!!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
+  !$omp target enter data map(to: CS%Kh_max_xy) &
+  !$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
   !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
@@ -1740,8 +1740,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp target update from(Shear_mag) if (use_Smag)
     !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
     !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
-    !$omp target update from(visc_bound_rem, hrat_min) &
-    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then
@@ -1873,6 +1871,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update from(Kh)
       endif
 
+      !$omp target
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         ! Newer method of bounding for stability
         if ((CS%better_bound_Kh) .and. (CS%better_bound_Ah)) then
@@ -1888,6 +1888,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           Kh(I,J) = min(Kh(I,J), hrat_min(I,J) * CS%Kh_Max_xy(I,J))
         endif
       enddo ; enddo
+      !$omp end target
 
       if (CS%use_Leithy) then
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
@@ -1930,6 +1931,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     !$omp target update from(Kh)
+    !$omp target update from(visc_bound_rem, hrat_min) &
+    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     if (CS%anisotropic) then
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -2450,8 +2453,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
-  !!!$omp target exit data map(delete: CS%Kh_max_xy) &
-  !!!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
+  !$omp target exit data map(delete: CS%Kh_max_xy) &
+  !$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
   !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1952,10 +1952,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update to(str_xy)
     endif
 
-    !$omp target update from(h_u, h_v, hq)
-    !$omp target update from(sh_xx, sh_xy)
-    !$omp target update from(str_xx, str_xy)
-
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
@@ -2188,7 +2184,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
       !$omp end target
     endif ! use_GME
-    !$omp target update from(str_xx, str_xy)
 
     !$omp target
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
@@ -2239,6 +2234,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
       !$omp target update to(diffv)
     endif
+
+    !$omp target update from(h_u, h_v, hq)
+    !$omp target update from(sh_xx, sh_xy)
+    !$omp target update from(str_xx, str_xy)
 
     if (find_FrictWork) then
       if (CS%FrictWork_bug) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -708,9 +708,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! shearing strain advocated by Smagorinsky (1993) and discussed in
     ! Griffies and Hallberg (2000).
 
-    ! XXX: **I don't understand why I need this**
-    !$omp target update to(u(:,:,k), v(:,:,k), h(:,:,k))
-
     ! Calculate horizontal tension
     do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
       dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
@@ -918,12 +915,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%no_slip) then
       do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
         sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
       enddo
     else
       do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
         sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
+      enddo
+    endif
+
+    if (CS%id_shearstress > 0) then
+      do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
+        ShSt(I,J,k) = sh_xy(I,J)
       enddo
     endif
 
@@ -1172,21 +1173,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         Kh(i,j) = CS%Kh_bg_xx(i,j)
       enddo
 
-      ! NOTE: The following do-block can be decomposed and vectorized after the
-      !   stack size has been reduced.
-      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
-        if (CS%add_LES_viscosity) then
-          if (CS%Smagorinsky_Kh) &
+      if (CS%add_LES_viscosity) then
+        if (CS%Smagorinsky_Kh) then
+          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
             Kh(i,j) = Kh(i,j) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j)
-          if (CS%Leith_Kh) &
-            Kh(i,j) = Kh(i,j) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3
-        else
-          if (CS%Smagorinsky_Kh) &
-            Kh(i,j) = max(Kh(i,j), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j))
-          if (CS%Leith_Kh) &
-            Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
+          enddo
         endif
-      enddo
+
+        if (CS%Leith_Kh) then
+          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+            Kh(i,j) = Kh(i,j) &
+                + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3
+          enddo
+        endif
+      else
+        if (CS%Smagorinsky_Kh) then
+          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+            Kh(i,j) = max(Kh(i,j), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j))
+          enddo
+        endif
+
+        if (CS%Leith_Kh) then
+          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+            Kh(i,j) = max(Kh(i,j), &
+                CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
+          enddo
+        endif
+      endif
 
       ! All viscosity contributions above are subject to resolution scaling
 
@@ -1496,8 +1509,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
-      !$omp target update to(sh_xx_smooth) if (CS%use_Leithy)
-
       do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j)) - (G%IdyCu(I-1,j) * Del2u(I-1,j))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J)) - (G%IdxCv(i,J-1) * Del2v(i,J-1))
@@ -1505,11 +1516,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         str_xx(i,j) = str_xx(i,j) + d_str
 
-        if (CS%use_Leithy) str_xx(i,j) = str_xx(i,j) - Kh(i,j) * sh_xx_smooth(i,j)
-
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
+        ! XXX: Need to get out of the loop somehow
+        if (find_FrictWork_bh) &
+          bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo
+
+      if (CS%use_Leithy) then
+        !$omp target update from(Kh)
+        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+          str_xx(i,j) = str_xx(i,j) - Kh(i,j) * sh_xx_smooth(i,j)
+        enddo ; enddo
+      endif
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
     ! Backscatter using MEKE

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -677,6 +677,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
   !$omp target enter data map(alloc: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
 
   ! TODO: NoSt, ShSt, ...?
 
@@ -689,6 +690,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
   !$omp target enter data map(to: CS%dx2q, CS%dy2q) if (CS%biharmonic)
   !$omp target enter data map(to: CS%dx2h, CS%dy2h) if (CS%biharmonic)
+
+  !$omp target enter data map(to: CS%Kh_bg_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
@@ -1207,13 +1212,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       endif
 
+      !$omp target
+
       ! Static (pre-computed) background viscosity
+      !$omp parallel loop collapse(2)
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Kh(i,j) = CS%Kh_bg_xx(i,j)
       enddo ; enddo
 
       ! NOTE: The following do-block can be decomposed and vectorized after the
       !   stack size has been reduced.
+      !$omp parallel loop collapse(2)
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         if (CS%add_LES_viscosity) then
           if (CS%Smagorinsky_Kh) &
@@ -1227,6 +1236,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
         endif
       enddo ; enddo
+      !$omp end target
+
+      !$omp target update from(Kh)
 
       ! All viscosity contributions above are subject to resolution scaling
 
@@ -2284,11 +2296,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: Shear_mag) if (use_Smag_visc)
   !$omp target exit data map(delete: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp target exit data map(delete: Kh) if (CS%Laplacian)
 
   ! TODO: This should should be permanently on the GPU
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
   !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
   !$omp target exit data map(delete: CS)
+
+  !$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%dx2q, CS%dy2q) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%dx2h, CS%dy2h) if (CS%biharmonic)
+
+  !$omp target exit data map(delete: CS%Kh_bg_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -715,6 +715,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
   !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
+  !$omp target enter data map(to: MEKE%Au) if (use_MEKE_Au)
 
   do k=1,nz
 
@@ -1204,8 +1205,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp target update from(h_u, h_v)
     !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
     !$omp target update from(Shear_mag) if (use_Smag)
-    !$omp target update from(hrat_min) &
-    !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     if (CS%Laplacian) then
       ! Determine the Laplacian viscosity at h points, using the
@@ -1343,9 +1342,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp end target
 
       !$omp target update from(Kh)
-
-      !$omp target update from(visc_bound_rem) &
-      !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
       ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
       ! The harmonic component of str_xx is added in the biharmonic loop.
@@ -1519,6 +1515,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       !$omp target update from(Ah)
 
+      ! TODO: GPU
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1526,6 +1523,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
+      ! TODO: GPU
       if (CS%Re_Ah > 0.0) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
@@ -1533,27 +1531,32 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
+      !$omp target
       if (CS%better_bound_Ah) then
         if (CS%better_bound_Kh) then
+          !$omp parallel loop collapse(2)
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Ah(i,j) = min(Ah(i,j), visc_bound_rem(i,j) * hrat_min(i,j) * CS%Ah_Max_xx(i,j))
           enddo ; enddo
         else
+          !$omp parallel loop collapse(2)
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Ah(i,j) = min(Ah(i,j), hrat_min(i,j) * CS%Ah_Max_xx(i,j))
           enddo ; enddo
         endif
       endif
+      !$omp end target
 
+      ! TODO: GPU
       if (CS%EY24_EBT_BS) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            tmp = CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j)
-            visc_limit_h(i,j,k) = tmp
-            visc_limit_h_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j))
-            if (Ah(i,j) >= tmp) then
-              visc_limit_h_flag(i,j,k) = 1.
-            endif
-          enddo ; enddo
+        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          tmp = CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j)
+          visc_limit_h(i,j,k) = tmp
+          visc_limit_h_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j))
+          if (Ah(i,j) >= tmp) then
+            visc_limit_h_flag(i,j,k) = 1.
+          endif
+        enddo ; enddo
       endif
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
@@ -1592,6 +1595,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
+
+    !$omp target update from(hrat_min) &
+    !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+    !$omp target update from(visc_bound_rem) &
+    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -444,6 +444,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   logical :: rescale_Kh, legacy_bound
   logical :: find_FrictWork
+  logical :: find_FrictWork_bh
   logical :: apply_OBC = .false.
   logical :: use_MEKE_Ku
   logical :: use_MEKE_Au
@@ -516,10 +517,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   if (.not.(CS%Laplacian .or. CS%biharmonic)) return
 
-  find_FrictWork = (CS%id_FrictWork > 0)
-  if (CS%id_FrictWorkIntz > 0) find_FrictWork = .true.
+  find_FrictWork = CS%id_FrictWork > 0 .or. CS%id_FrictWorkIntz > 0 &
+      .or. allocated(MEKE%mom_src)
+  find_FrictWork_bh = CS%id_FrictWork_bh > 0 .or. CS%id_FrictWorkIntz_bh > 0 &
+      .or. allocated(MEKE%mom_src_bh)
 
-  if (allocated(MEKE%mom_src)) find_FrictWork = .true.
   use_kh_struct = allocated(VarMix%BS_struct)
   backscat_subround = 0.0
   if (find_FrictWork .and. allocated(MEKE%mom_src) .and. (MEKE%backscatter_Ro_c > 0.0) .and. &
@@ -2235,11 +2237,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update to(diffv)
     endif
 
-    !$omp target update from(h_u, h_v, hq)
-    !$omp target update from(sh_xx, sh_xy)
-    !$omp target update from(str_xx, str_xy)
+    !$omp target update from(h_u, h_v) &
+    !$omp   if ((find_Frictwork .or. find_FrictWork_bh) .and. .not. CS%FrictWork_bug)
 
     if (find_FrictWork) then
+      !$omp target update from(str_xx, str_Xy)
+
       if (CS%FrictWork_bug) then
         ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion
@@ -2300,7 +2303,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
     endif
 
-    if (CS%id_FrictWork_bh>0 .or. CS%id_FrictWorkIntz_bh > 0 .or. allocated(MEKE%mom_src_bh)) then
+    if (find_FrictWork_bh) then
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc
@@ -2440,6 +2443,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       endif
       if (MEKE%backscatter_Ro_c /= 0.) then
+        !$omp target update from(sh_xx, sh_xy)
         do j=js,je ; do i=is,ie
           FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
                         (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -721,8 +721,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     enddo ; enddo
     !$omp end target
 
-    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx)
-
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -784,11 +782,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
     !$omp end target
 
-    !$omp target update from(h_u, h_v)
-
     ! Adjust contributions to shearing strain and interpolated values of
     ! thicknesses on open boundaries.
-    if (apply_OBC) then ; do n=1,OBC%number_of_segments
+    if (apply_OBC) then
+      !$omp target update from(dvdx, dudy, h_u, h_v)
+      ! TODO: Reindent this later
+      do n=1,OBC%number_of_segments
+
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (OBC%zero_strain .or. OBC%freeslip_strain .or. OBC%computed_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
@@ -904,7 +904,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
         endif
       endif
-    enddo ; endif
+    enddo
+    ! TODO: Fix indentation
+    !$omp target update from(dvdx, dudy, h_u, h_v)
+    endif
+
+    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx)
+    !$omp target update from(h_u, h_v)
 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -684,6 +684,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
   !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
+  !$omp target enter data map(alloc: bhstr_xy) if (CS%biharmonic)
 
   !$omp target enter data map(alloc: hrat_min) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
@@ -715,7 +716,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
   !$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%reduction_xx) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy) &
+  !$omp   if (CS%biharmonic)
   !$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Biharm_const_xy) &
@@ -1975,7 +1977,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp target update from(h_u, h_v, hq)
     !$omp target update from(sh_xx, sh_xy)
     !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
-    !!$omp target update from(Shear_mag) if (use_Smag)
     !$omp target update from(visc_bound_rem, hrat_min) &
     !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
     !$omp target update from(str_xx, str_xy)
@@ -2098,6 +2099,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update from(Ah)
 
       ! Again, need to initialize str_xy as if its biharmonic
+      !$omp target
+      ! NOTE: computing bhstr_xy ought to be conditional!  But depends on d_str
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
 
@@ -2106,10 +2110,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
       enddo ; enddo
+      !$omp end target
+
+      !$omp target update from(str_xy, bhstr_xy)
     endif ! Get Ah at q points and biharmonic part of str_xy
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
+      !$omp target update from(sh_xy, str_xy)
       do J=js-1,Jeq ; do I=is-1,Ieq
         if (visc_limit_q_flag(I,J,k) > 0) then
           Kh_BS(I,J) = 0.
@@ -2139,6 +2147,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do J=js-1,Jeq ; do I=is-1,Ieq
         str_xy(I,J) = str_xy(I,J) + str_xy_BS(I,J)
       enddo ; enddo
+      !$omp target update to(str_xy)
     endif ! Backscatter
 
     if (CS%use_GME) then
@@ -2493,23 +2502,23 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target exit data map(delete: h_u, h_v, hq)
-  !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
+  !$omp target exit data map(delete: str_xx, str_xy)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
   !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)
-  !$omp target exit data map(delete: str_xx, str_xy)
-
+  !$omp target exit data map(delete: Shear_mag) if (use_Smag)
   !$omp target exit data map(delete: Kh) if (CS%Laplacian)
   !$omp target exit data map(delete: Ah) if (CS%biharmonic)
-  !$omp target exit data map(delete: Shear_mag) if (use_Smag)
+  !$omp target exit data map(delete: bhstr_xy) if (CS%biharmonic)
+
   !$omp target exit data map(delete: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target exit data map(delete: visc_bound_rem) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
   ! TODO: Should static CS arrays be permanently on the GPU?
+  !$omp target exit data map(delete: CS)
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
   !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
-  !$omp target exit data map(delete: CS)
 
   !$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
   !$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
@@ -2525,7 +2534,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
   !$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%reduction_xx) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy) &
+  !$omp   if (CS%biharmonic)
   !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Ah_max_xx) &
@@ -2533,6 +2543,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)
+  !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1036,16 +1036,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! straightforward.
 
     if (use_vort_xy) then
-      ! TODO: Remove this after moving Leith to GPU
       !$omp target update from(dvdx, dudy)
-
       if (CS%no_slip) then
-        !!$omp parallel loop collapse(2)
         do J=js_vort,je_vort ; do I=is_vort,ie_vort
           vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
         enddo ; enddo
       else
-        !!$omp parallel loop collapse(2)
         do J=js_vort,je_vort ; do I=is_vort,ie_vort
           vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
         enddo ; enddo
@@ -1104,7 +1100,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! endif
 
       if (CS%modified_Leith) then
-        ! TODO: GPU
         !$omp target update from(dudx, dvdy)
 
         ! Divergence
@@ -1221,7 +1216,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! largest value from several parameterizations. Also get
       ! the Laplacian component of str_xx.
 
-      ! TODO: GPU
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%use_QG_Leith_visc) then
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1265,7 +1259,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! All viscosity contributions above are subject to resolution scaling
 
-      ! TODO: GPU
       if (rescale_Kh) then
         !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1273,7 +1266,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
-      ! TODO: GPU
       if (legacy_bound) then
         ! Older method of bounding for stability
         !$omp target update from(Kh)
@@ -1291,7 +1283,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       !$omp end target
 
-      ! TODO: GPU of MEKE and anisotropic Kh tweaks
       !$omp target update from(Kh) &
       !$omp   if ((use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) .or. CS%anisotropic)
 
@@ -1404,7 +1395,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp end target
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
-    ! TODO: GPU
     if (CS%anisotropic) then
       !$omp target update from(str_xx)
       !$omp target update from(sh_xx, sh_xy)
@@ -1527,7 +1517,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp end target
       endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
 
-      ! TODO: GPU
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
         !$omp target update from(Ah)
@@ -1537,7 +1526,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Ah)
       endif
 
-      ! TODO: GPU
       if (CS%Re_Ah > 0.0) then
         !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1563,7 +1551,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
       !$omp end target
 
-      ! TODO: GPU
       if (CS%EY24_EBT_BS) then
         !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1624,7 +1611,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      ! TODO: GPU
       !$omp target update from(sh_xx)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         if (visc_limit_h_flag(i,j,k) > 0) then
@@ -1766,7 +1752,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! largest value from several parameterizations. Also get the
       ! Laplacian component of str_xy.
 
-      ! TODO: GPU
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
           do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1805,7 +1790,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       !$omp end target
 
-      ! TODO: GPU
       if (CS%Leith_Kh) then
         !$omp target update from(Kh)
         if (CS%add_LES_viscosity) then
@@ -1822,7 +1806,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! All viscosity contributions above are subject to resolution scaling
 
-      ! TODO: GPU
       if (rescale_Kh) then
         !$omp target update from(Kh)
         do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1831,7 +1814,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Kh)
       endif
 
-      ! TODO: GPU
       if (legacy_bound) then
         !$omp target update from(Kh)
         ! Older method of bounding for stability
@@ -1849,7 +1831,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
       !$omp end target
 
-      ! TODO: GPU
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         !$omp target update from(Kh)
         if (use_kh_struct) then
@@ -1876,7 +1857,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Kh)
       endif
 
-      ! TODO: GPU
       if (CS%anisotropic) then
         !$omp target update from(Kh)
         ! *Add* the shear component of anisotropic viscosity
@@ -1905,7 +1885,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
       !$omp end target
 
-      ! TODO: GPU
       if (CS%use_Leithy) then
         !$omp target update from(Kh)
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
@@ -1973,12 +1952,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update to(str_xy)
     endif
 
-    !$omp target update from(Kh)
     !$omp target update from(h_u, h_v, hq)
     !$omp target update from(sh_xx, sh_xy)
-    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
-    !$omp target update from(visc_bound_rem, hrat_min) &
-    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
     !$omp target update from(str_xx, str_xy)
 
     if (CS%biharmonic) then
@@ -2011,8 +1986,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         endif
         !$omp end target
-
-        !$omp target update from(Ah)
 
         if (CS%Leith_Ah) then
           !$omp target update from(Ah)
@@ -2070,7 +2043,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (CS%EY24_EBT_BS) then
         ! TODO: Fix indent!
-        !$omp target update from(Ah)
+        !$omp target update from(Ah, hrat_min)
           do J=js-1,Jeq ; do I=is-1,Ieq
             tmp = CS%KS_coef *hrat_min(I,J) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
@@ -2100,7 +2073,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! Again, need to initialize str_xy as if its biharmonic
       !$omp target
-      ! NOTE: computing bhstr_xy ought to be conditional!  But depends on d_str
       !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
@@ -2108,11 +2080,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         str_xy(I,J) = str_xy(I,J) + d_str
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
+        ! NOTE: computing this ought to be conditional!  But it uses d_str...
         bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
       enddo ; enddo
       !$omp end target
 
-      !$omp target update from(str_xy, bhstr_xy)
+      !$omp target update from(Ah, str_xy, bhstr_xy)
     endif ! Get Ah at q points and biharmonic part of str_xy
 
     ! Backscatter using MEKE

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -679,6 +679,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target enter data map(alloc: h_u, h_v)
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
   !$omp target enter data map(alloc: str_xx)
@@ -1596,17 +1597,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp end target
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
-    !$omp target update from(dudx, dudy, dvdx, dvdy)
-    !$omp target update from(sh_xx, sh_xy)
-    !$omp target update from(h_u, h_v)
-    !$omp target update from(str_xx)
-    !$omp target update from(Shear_mag) if (use_Smag)
-    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
-    !$omp target update from(visc_bound_rem, hrat_min) &
-    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
+      ! TODO: GPU
+      !$omp target update from(sh_xx)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         if (visc_limit_h_flag(i,j,k) > 0) then
           Kh_BS(i,j) = 0.
@@ -1632,16 +1626,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = str_xx(i,j) + str_xx_BS(i,j)
       enddo ; enddo
+      !$omp target update to(str_xx)
     endif ! Backscatter
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
+      !$omp target
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J)*G%IdyCv(i+1,J)) - (Del2v(i,J)*G%IdyCv(i,J)))
         dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1)*G%IdxCu(I,j+1)) - (Del2u(I,j)*G%IdxCu(I,j)))
       enddo ; enddo
+      !$omp end target
+
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if (OBC%zero_strain .or. OBC%freeslip_strain) then
+        !$omp target update from(dDel2vdx, dDel2udy)
         do n=1,OBC%number_of_segments
           J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
@@ -1662,8 +1662,19 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo
           endif
         enddo
+        !$omp target update to(dDel2vdx, dDel2udy)
       endif ; endif
     endif
+
+    !$omp target update from(dudx, dudy, dvdx, dvdy)
+    !$omp target update from(sh_xx, sh_xy)
+    !$omp target update from(h_u, h_v)
+    !$omp target update from(str_xx)
+    !$omp target update from(Shear_mag) if (use_Smag)
+    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
+    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
+    !$omp target update from(visc_bound_rem, hrat_min) &
+    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -2368,6 +2379,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: h_u, h_v)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target exit data map(delete: str_xx)
 
   !$omp target exit data map(delete: Kh) if (CS%Laplacian)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1825,32 +1825,25 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         Ah(I,J) = CS%Ah_bg_xy(I,J)
-      enddo ; enddo
-      !$omp end target
+      enddo
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
-        !$omp target
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            !$omp parallel loop collapse(2)
-            do J=js-1,Jeq ; do I=is-1,Ieq
+            do concurrent (I=is-1:Ieq, J=js-1:Jeq)
               AhSm = Shear_mag(I,J) * (CS%Biharm_const_xy(I,J) &
                   + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J))
               Ah(I,J) = max(Ah(I,J), AhSm)
-            enddo ; enddo
+            enddo
           else
-            !$omp parallel loop collapse(2)
-            do J=js-1,Jeq ; do I=is-1,Ieq
+            do concurrent (I=is-1:Ieq, J=js-1:Jeq)
               AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J)
               Ah(I,J) = max(Ah(I,J), AhSm)
-            enddo ; enddo
+            enddo
           endif
         endif
-        !$omp end target
 
         if (CS%Leith_Ah) then
           !$omp target update from(Ah)
@@ -1861,14 +1854,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           !$omp target update to(Ah)
         endif
 
-        !$omp target
         if (CS%bound_Ah .and. .not.CS%better_bound_Ah) then
-          !$omp parallel loop collapse(2)
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
             Ah(I,J) = min(Ah(I,J), CS%Ah_Max_xy(I,J))
-          enddo ; enddo
+          enddo
         endif
-        !$omp end target
       endif ! Smagorinsky_Ah or Leith_Ah
 
       if (use_MEKE_Au) then
@@ -1890,21 +1880,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Ah)
       endif
 
-      !$omp target
       if (CS%better_bound_Ah) then
         if (CS%better_bound_Kh) then
-          !$omp parallel loop collapse(2)
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
             Ah(I,J) = min(Ah(I,J), visc_bound_rem(I,J) * hrat_min(I,J) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo
+          enddo
         else
-          !$omp parallel loop collapse(2)
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
             Ah(I,J) = min(Ah(I,J), hrat_min(I,J) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo
+          enddo
         endif
       endif
-      !$omp end target
 
       if (CS%EY24_EBT_BS) then
         ! TODO: Fix indent!
@@ -2068,15 +2054,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update to(diffu)
     endif
 
-    !$omp target
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
-    !$omp parallel loop collapse(2)
-    do J=Jsq,Jeq ; do i=is,ie
+    do concurrent (i=is:ie, J=Jsq:Jeq)
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j)) - (CS%dx2h(i,j+1)*str_xx(i,j+1)))) * &
                      G%IareaCv(i,J)) / (h_v(i,J) + h_neglect)
-    enddo ; enddo
-    !$omp end target
+    enddo
 
     if (apply_OBC) then
       !$omp target update from(diffv)
@@ -2988,12 +2971,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
     endif
   endif
 
-  !$omp target
-
-  !$omp parallel loop collapse(2)
-  do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+  do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
     CS%dx2q(I,J) = G%dxBu(I,J)*G%dxBu(I,J) ; CS%dy2q(I,J) = G%dyBu(I,J)*G%dyBu(I,J)
-  enddo ; enddo
+  enddo
 
   if (((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) .and. &
       ((G%isc-G%isd < 3) .or. (G%isc-G%isd < 3))) call MOM_error(FATAL, &
@@ -3013,13 +2993,10 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   endif
   !$omp target enter data map(to: CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)
 
-  !$omp parallel loop collapse(2)
-  do j=js-2,Jeq+2 ; do i=is-2,Ieq+2
+  do concurrent (i=is-2:Ieq+2, j=js-2:Jeq+2)
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)
     CS%DX_dyT(i,j) = G%dxT(i,j)*G%IdyT(i,j) ; CS%DY_dxT(i,j) = G%dyT(i,j)*G%IdxT(i,j)
-  enddo ; enddo
-
-  !$omp end target
+  enddo
 
   ! TODO: Remove this after every instance has been moved to GPU
   !$omp target update from(CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -3073,6 +3073,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   ALLOC_(CS%dy_dxT(isd:ied,jsd:jed))      ; CS%dy_dxT(:,:)  = 0.0
   ALLOC_(CS%dx_dyBu(IsdB:IedB,JsdB:JedB)) ; CS%dx_dyBu(:,:) = 0.0
   ALLOC_(CS%dy_dxBu(IsdB:IedB,JsdB:JedB)) ; CS%dy_dxBu(:,:) = 0.0
+  !$omp target enter data map(alloc: CS%dx2h, CS%dy2h, CS%dx2q, CS%dy2q)
+  !$omp target enter data map(alloc: CS%dx_dyT, CS%dy_dxT, CS%dx_dyBu, CS%dy_dxBu)
+
   if (CS%Laplacian) then
     ALLOC_(CS%grid_sp_h2(isd:ied,jsd:jed))   ; CS%grid_sp_h2(:,:) = 0.0
     ALLOC_(CS%Kh_bg_xx(isd:ied,jsd:jed))     ; CS%Kh_bg_xx(:,:) = 0.0
@@ -3165,6 +3168,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
     endif
   endif
 
+  !$omp target
+
+  !$omp parallel loop collapse(2)
   do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
     CS%dx2q(I,J) = G%dxBu(I,J)*G%dxBu(I,J) ; CS%dy2q(I,J) = G%dyBu(I,J)*G%dyBu(I,J)
   enddo ; enddo
@@ -3187,11 +3193,17 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   endif
   !$omp target enter data map(to: CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)
 
+  !$omp parallel loop collapse(2)
   do j=js-2,Jeq+2 ; do i=is-2,Ieq+2
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)
     CS%DX_dyT(i,j) = G%dxT(i,j)*G%IdyT(i,j) ; CS%DY_dxT(i,j) = G%dyT(i,j)*G%IdxT(i,j)
   enddo ; enddo
-  !$omp target enter data map(to: CS%dx2h, CS%dy2h, CS%dx_dyT, CS%dy_dxT)
+
+  !$omp end target
+
+  ! TODO: Remove this after every instance has been moved to GPU
+  !$omp target update from(CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)
+  !$omp target update from(CS%dx2h, CS%dy2h, CS%dx_dyT, CS%dy_dxT)
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     CS%reduction_xx(i,j) = 1.0
@@ -3208,6 +3220,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
         (G%dx_Cv(i,J-1) < G%dxCv(i,J-1) * CS%reduction_xx(i,j))) &
       CS%reduction_xx(i,j) = G%dx_Cv(i,J-1) / (G%dxCv(i,J-1))
   enddo ; enddo
+
   do J=js-1,Jeq ; do I=is-1,Ieq
     CS%reduction_xy(I,J) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -706,6 +706,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
   !$omp target enter data map(to: CS%Ah_bg_xx) if (CS%biharmonic)
   !$omp target enter data map(to: CS%reduction_xx) if (CS%biharmonic)
@@ -1772,21 +1773,23 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do J=js-1,Jeq ; do I=is-1,Ieq
         Kh(I,J) = CS%Kh_bg_xy(I,J)
       enddo ; enddo
-      !$omp target update from(Kh)
-
-      !$omp end target
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
+          !$omp parallel loop collapse(2)
           do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = Kh(I,J) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J)
           enddo ; enddo
         else
+          !$omp parallel loop collapse(2)
           do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = max(Kh(I,J), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J) )
           enddo ; enddo
         endif
       endif
+      !$omp end target
+
+      !$omp target update from(Kh)
 
       if (CS%Leith_Kh) then
         if (CS%add_LES_viscosity) then
@@ -2427,6 +2430,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
   !$omp target exit data map(delete: CS%Ah_bg_xx) if (CS%biharmonic)
   !$omp target exit data map(delete: CS%reduction_xx) if (CS%biharmonic)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -751,6 +751,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp target update to(u(:,:,k), v(:,:,k), h(:,:,k))
 
     !$omp target
+
     ! Calculate horizontal tension
     !$omp parallel loop collapse(2)
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
@@ -775,6 +776,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
     enddo ; enddo
+
     !$omp end target
 
     if (CS%use_Leithy) then
@@ -797,6 +799,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! use Leith+E
 
     if (CS%id_normstress > 0) then
+      !$omp target update from(sh_xx)
       do j=js,je ; do i=is,ie
         NoSt(i,j,k) = sh_xx(i,j)
       enddo ; enddo
@@ -1285,10 +1288,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       !$omp end target
 
-      !$omp target update from(Kh) &
-      !$omp   if ((use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) .or. CS%anisotropic)
-
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
+        !$omp target update from(Kh)
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
@@ -1311,13 +1312,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo ; enddo
           endif
         endif
+        !$omp target update to(Kh)
       endif
 
       if (CS%anisotropic) then
+        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           ! *Add* the tension component of anisotropic viscosity
           Kh(i,j) = Kh(i,j) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
         enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
       !$omp target update to(Kh) &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -474,9 +474,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     visc_bound_rem  ! fraction of overall viscous bounds that remain to be applied (h or q) [nondim]
 
   ! New variables: move these up once ready
-  logical :: use_Leith    ! True if any Leith-based parameterizations are enabled
+  logical :: use_Leith    ! True if any Leith parameterizations are enabled
   logical :: use_vort_xy  ! True if vort_xy must be computed
-  logical :: use_Smag_visc  ! True if a Smagorinsky viscosity is enabled
+  logical :: use_Smag     ! True if a Smagorinsky viscosity is enabled
+
+  use_Leith = CS%Leith_Kh .or. CS%Leith_Ah .or. CS%use_Leithy
+  use_vort_xy = use_Leith .or. CS%id_vort_xy_q > 0 .or. CS%use_ZB2020
+  use_Smag = CS%Smagorinsky_Kh .or. CS%Smagorinsky_Ah
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -675,6 +679,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target enter data map(alloc: h_u, h_v)
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
   !$omp target enter data map(alloc: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
@@ -997,8 +1002,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     ! Vorticity
-    use_Leith = CS%Leith_Kh .or. CS%Leith_Ah .or. CS%use_Leithy
-    use_vort_xy = use_Leith .or. CS%id_vort_xy_q > 0 .or. CS%use_ZB2020
 
     ! NOTE: Keep Leith code on CPU for now, but moving it should be
     ! straightforward.
@@ -1165,8 +1168,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     endif ! CS%Leith_Kh
 
-    !$omp target enter data map(alloc: Shear_mag) if (use_Smag_visc)
-
     !$omp target
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
       !$omp parallel loop collapse(2)
@@ -1190,6 +1191,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
     !$omp target update from(h_u, h_v)
     !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
+    !$omp target update from(Shear_mag) if (use_Smag)
     !$omp target update from(hrat_min) &
     !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
@@ -2296,12 +2298,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: h_u, h_v)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
-  !$omp target exit data map(delete: Shear_mag) if (use_Smag_visc)
+  !$omp target exit data map(delete: Shear_mag) if (use_Smag)
   !$omp target exit data map(delete: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target exit data map(delete: Kh) if (CS%Laplacian)
 
-  ! TODO: This should should be permanently on the GPU
+  ! TODO: Should static CS arrays be permanently on the GPU?
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
   !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
   !$omp target exit data map(delete: CS)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -677,7 +677,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   endif
 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-  !$omp target enter data map(alloc: h_u, h_v)
+  !$omp target enter data map(alloc: h_u, h_v, hq)
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
   !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
@@ -1666,17 +1666,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif ; endif
     endif
 
-    !$omp target update from(dudx, dudy, dvdx, dvdy)
-    !$omp target update from(sh_xx, sh_xy)
-    !$omp target update from(h_u, h_v)
-    !$omp target update from(str_xx)
-    !$omp target update from(Shear_mag) if (use_Smag)
-    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
-    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
-    !$omp target update from(visc_bound_rem, hrat_min) &
-    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+    !$omp target
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         sh_xy_sq = sh_xy(I,J)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j)**2) + (sh_xx(i+1,j+1)**2)) &
@@ -1685,6 +1678,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
     endif
 
+    !$omp parallel loop collapse(2)
     do J=js-1,Jeq ; do I=is-1,Ieq
       h2uq = 4.0 * (h_u(I,j) * h_u(I,j+1))
       h2vq = 4.0 * (h_v(i,J) * h_v(i+1,J))
@@ -1693,11 +1687,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     enddo ; enddo
 
     if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         h_min = min(h_u(I,j), h_u(I,j+1), h_v(i,J), h_v(i+1,J))
         hrat_min(I,J) = min(1.0, h_min / (hq(I,J) + h_neglect))
       enddo ; enddo
-
     endif
 
     if (CS%no_slip) then
@@ -1723,6 +1717,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       enddo ; enddo
     endif
+
+    !$omp end target
+
+    !$omp target update from(dudx, dudy, dvdx, dvdy)
+    !$omp target update from(sh_xx, sh_xy)
+    !$omp target update from(h_u, h_v, hq)
+    !$omp target update from(str_xx)
+    !$omp target update from(Shear_mag) if (use_Smag)
+    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
+    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
+    !$omp target update from(visc_bound_rem, hrat_min) &
+    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then
@@ -2376,7 +2382,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   enddo ! end of k loop
 
   !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-  !$omp target exit data map(delete: h_u, h_v)
+  !$omp target exit data map(delete: h_u, h_v, hq)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
   !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -699,12 +699,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: sh_xy_q) &
   !$omp   if (CS%id_sh_xy_q > 0)
 
-  ! TODO: NoSt, ShSt, ...?
-
-  ! TODO: Do this outside the function
-  !$omp target enter data map(to: u, v, h)
-  !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
-
   do k=1,nz
     ! The following are the forms of the horizontal tension and horizontal
     ! shearing strain advocated by Smagorinsky (1993) and discussed in
@@ -2362,10 +2356,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target exit data map(delete: visc_bound_rem) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-
-  ! TODO: Do this outside of the function
-  !$omp target exit data map(delete: u, v, h)
-  !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -915,21 +915,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
-    !$omp target
     if (CS%no_slip) then
-      !$omp parallel loop collapse(2)
-      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+      do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
         sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
-      enddo ; enddo
+      enddo
     else
-      !$omp parallel loop collapse(2)
-      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+      do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
         sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
-      enddo ; enddo
+      enddo
     endif
-    !$omp end target
 
     if (CS%use_Leithy) then
       ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
@@ -947,20 +943,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
-      !$omp target
-
-      !$omp parallel loop collapse(2)
-      do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, j=js-1:Jeq+1)
         Del2u(I,j) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
                      CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j)) - (CS%dy2h(i,j)*sh_xx(i,j)))
-      enddo ; enddo
+      enddo
 
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
+      do concurrent (i=is-1:Ieq+1, J=Jsq-1:Jeq+1)
         Del2v(i,J) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
                      CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1)) - (CS%dx2h(i,j)*sh_xx(i,j)))
-      enddo ; enddo
-      !$omp end target
+      enddo
 
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
         !$omp target update from(Del2u, Del2v)
@@ -1141,25 +1132,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     endif ! CS%Leith_Kh
 
-    !$omp target
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      !$omp parallel loop collapse(2)
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
         sh_xx_sq = sh_xx(i,j)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1)**2) + (sh_xy(I,J)**2)) &
                           + ((sh_xy(I-1,J)**2) + (sh_xy(I,J-1)**2)) )
         Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
-      enddo ; enddo
+      enddo
     endif
 
     if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
-      !$omp parallel loop collapse(2)
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
         h_min = min(h_u(I,j), h_u(I-1,j), h_v(i,J), h_v(i,J-1))
         hrat_min(i,j) = min(1.0, h_min / (h(i,j,k) + h_neglect))
-      enddo ; enddo
+      enddo
     endif
-    !$omp end target
 
     if (CS%Laplacian) then
       ! Determine the Laplacian viscosity at h points, using the
@@ -1180,18 +1167,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       endif
 
-      !$omp target
-
       ! Static (pre-computed) background viscosity
-      !$omp parallel loop collapse(2)
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
         Kh(i,j) = CS%Kh_bg_xx(i,j)
-      enddo ; enddo
+      enddo
 
       ! NOTE: The following do-block can be decomposed and vectorized after the
       !   stack size has been reduced.
-      !$omp parallel loop collapse(2)
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
         if (CS%add_LES_viscosity) then
           if (CS%Smagorinsky_Kh) &
             Kh(i,j) = Kh(i,j) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j)
@@ -1203,9 +1186,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           if (CS%Leith_Kh) &
             Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
         endif
-      enddo ; enddo
-
-      !$omp end target
+      enddo
 
       ! All viscosity contributions above are subject to resolution scaling
 
@@ -1225,13 +1206,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Place a floor on the viscosity, if desired.
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
         Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
-      enddo ; enddo
-
-      !$omp end target
+      enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         !$omp target update from(Kh)
@@ -1273,10 +1250,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp   if ((use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) .or. CS%anisotropic)
 
       ! Newer method of bounding for stability
-      !$omp target
       if ((CS%better_bound_Kh) .and. (CS%better_bound_Ah)) then
-        !$omp parallel loop collapse(2)
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
           visc_bound_rem(i,j) = 1.0
           Kh_max_here = hrat_min(i,j) * CS%Kh_Max_xx(i,j)
           if (Kh(i,j) >= Kh_max_here) then
@@ -1285,32 +1260,34 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           elseif ((Kh(i,j) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
             visc_bound_rem(i,j) = 1.0 - Kh(i,j) / Kh_max_here
           endif
-        enddo ; enddo
+        enddo
       elseif (CS%better_bound_Kh) then
-        !$omp parallel loop collapse(2)
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
           Kh(i,j) = min(Kh(i,j), hrat_min(i,j) * CS%Kh_Max_xx(i,j))
-        enddo ; enddo
+        enddo
       endif
-      !$omp end target
 
-      !$omp target update from(Kh)
+      !!$omp target update from(Kh)
 
       ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
       ! The harmonic component of str_xx is added in the biharmonic loop.
       if (CS%use_Leithy) then
+        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = 0.
         enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
       if (CS%id_Kh_h>0 .or. CS%debug) then
+        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh_h(i,j,k) = Kh(i,j)
         enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Kh>0) then
+        !$omp target update from(Kh)
         do j=js,je ; do i=is,ie
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           grid_Kh = max(Kh(i,j), CS%min_grid_Kh)
@@ -1331,19 +1308,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         str_xx(i,j) = -Kh(i,j) * sh_xx(i,j)
-      enddo ; enddo
-      !$omp end target
+      enddo
     else
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         str_xx(i,j) = 0.0
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then
@@ -1362,13 +1333,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Determine the biharmonic viscosity at h points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
         Ah(i,j) = CS%Ah_bg_xx(i,j)
-      enddo ; enddo
-      !$omp end target
-      !$omp target update from(Ah)
+      enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         !$omp target

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1363,7 +1363,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo ; enddo
           !$omp target update to(Ah)
         endif
-        !!$omp target update from(Ah)
 
         if (CS%use_Leithy) then
           ! TODO: !$omp target update from(...?)
@@ -1938,9 +1937,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update from(Ah)
 
       ! Again, need to initialize str_xy as if its biharmonic
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
 
         str_xy(I,J) = str_xy(I,J) + d_str
@@ -1948,8 +1945,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         ! NOTE: computing this ought to be conditional!  But it uses d_str...
         bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-      enddo ; enddo
-      !$omp end target
+      enddo
 
       !$omp target update from(Ah, str_xy, bhstr_xy)
     endif ! Get Ah at q points and biharmonic part of str_xy
@@ -2033,37 +2029,29 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
       !$omp target update to(str_xx, str_xy)
     else ! .not. use_GME
-      !$omp target
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
+      enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        !$omp parallel loop collapse(2)
-        do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        enddo
       else
-        !$omp parallel loop collapse(2)
-        do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        enddo
       endif
-      !$omp end target
     endif ! use_GME
 
-    !$omp target
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
-    !$omp parallel loop collapse(2)
-    do j=js,je ; do I=Isq,Ieq
+    do concurrent (I=Isq:Ieq, j=js:je)
       diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1)) - (CS%dx2q(I,J)*str_xy(I,J))) + &
                        G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j)) - (CS%dy2h(i+1,j)*str_xx(i+1,j)))) * &
                      G%IareaCu(I,j)) / (h_u(I,j) + h_neglect)
-    enddo ; enddo
-    !$omp end target
+    enddo
 
     if (apply_OBC) then
       !$omp target update from(diffu)
@@ -2376,37 +2364,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target exit data map(delete: visc_bound_rem) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-
-  ! TODO: Should static CS arrays be permanently on the GPU?
-  !!$omp target exit data map(delete: CS)
-  !!$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
-  !!$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
-
-  !!$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
-  !!$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-  !!$omp target exit data map(delete: CS%dx2q, CS%dy2q)
-  !!$omp target exit data map(delete: CS%dx2h, CS%dy2h)
-
-  !!$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
-  !!$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
-  !!$omp target exit data map(delete: CS%Kh_max_xy) &
-  !!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
-  !!$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
-  !!$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
-  !!$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
-
-  !!$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !!$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy)
-  !!$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
-  !!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
-  !!$omp target exit data map(delete: CS%Biharm_const_xy) &
-  !!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
-  !!$omp target exit data map(delete: CS%Biharm_const2_xy) &
-  !!$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
-  !!$omp target exit data map(delete: CS%Ah_max_xx) &
-  !!$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-  !!$omp target exit data map(delete: CS%Ah_max_xy) &
-  !!$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -678,11 +678,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target enter data map(alloc: h_u, h_v, hq)
+  !$omp target enter data map(alloc: str_xx, str_xy)
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
   !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
-  !$omp target enter data map(alloc: str_xx, str_xy)
   !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
 
   !$omp target enter data map(alloc: hrat_min) &
@@ -714,10 +714,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
-  !$omp target enter data map(to: CS%Ah_bg_xx) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
   !$omp target enter data map(to: CS%reduction_xx) if (CS%biharmonic)
-  !$omp target enter data map(alloc: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
+  !$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !$omp target enter data map(to: CS%Biharm_const_xy) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
+  !$omp target enter data map(to: CS%Biharm_const2_xy) &
+  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
   !$omp target enter data map(to: CS%Ah_max_xx) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
@@ -1419,6 +1423,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         Ah(i,j) = CS%Ah_bg_xx(i,j)
       enddo ; enddo
       !$omp end target
+      !$omp target update from(Ah)
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         !$omp target
@@ -1439,7 +1444,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         endif
         !$omp end target
-        !$omp target update from(Ah)
 
         if (CS%Leith_Ah) then
           !$omp target update from(Ah)
@@ -1449,7 +1453,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
             Ah(i,j) = max(Ah(i,j), AhLth)
           enddo ; enddo
+          !$omp target update to(Ah)
         endif
+        !$omp target update from(Ah)
 
         if (CS%use_Leithy) then
           ! TODO: !$omp target update from(...?)
@@ -1517,22 +1523,24 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp end target
       endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
 
-      !$omp target update from(Ah)
-
       ! TODO: GPU
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
+        !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Ah(i,j) = Ah(i,j) + MEKE%Au(i,j)
         enddo ; enddo
+        !$omp target update to(Ah)
       endif
 
       ! TODO: GPU
       if (CS%Re_Ah > 0.0) then
+        !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           Ah(i,j) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
         enddo ; enddo
+        !$omp target update to(Ah)
       endif
 
       !$omp target
@@ -1553,6 +1561,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! TODO: GPU
       if (CS%EY24_EBT_BS) then
+        !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           tmp = CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j)
           visc_limit_h(i,j,k) = tmp
@@ -1564,6 +1573,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
+        !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Ah_h(i,j,k) = Ah(i,j)
         enddo ; enddo
@@ -1572,13 +1582,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%use_Leithy) then
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
+        !$omp target update from(Ah, Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = -m_leithy(i,j) * Ah(i,j)
           Kh_h(i,j,k) = Kh(i,j)
         enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
       if (CS%id_grid_Re_Ah > 0) then
+        !$omp target update from(Ah)
         do j=js,je ; do i=is,ie
           KE = 0.125 * (((u(I,j,k) + u(I-1,j,k))**2) + ((v(i,J,k) + v(i,J-1,k))**2))
           grid_Ah = max(Ah(i,j), CS%min_grid_Ah)
@@ -1945,47 +1958,61 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp end target
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
-    !$omp target update from(Kh)
-    !$omp target update from(h_u, h_v, hq)
-    !$omp target update from(sh_xx, sh_xy)
-    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
-    !$omp target update from(Shear_mag) if (use_Smag)
-    !$omp target update from(visc_bound_rem, hrat_min) &
-    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-    !$omp target update from(str_xx, str_xy)
-
     if (CS%anisotropic) then
+      !$omp target update from(sh_xx, str_xy)
       do J=js-1,Jeq ; do I=is-1,Ieq
         ! Horizontal-tension averaged to q-points
         local_strain = 0.25 * ( (sh_xx(i,j) + sh_xx(i+1,j+1)) + (sh_xx(i+1,j) + sh_xx(i,j+1)) )
         ! *Add* the tension contribution to the xy-component of stress
         str_xy(I,J) = str_xy(I,J) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
       enddo ; enddo
+      !$omp target update to(str_xy)
     endif
+
+    !$omp target update from(Kh)
+    !$omp target update from(h_u, h_v, hq)
+    !$omp target update from(sh_xx, sh_xy)
+    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
+    !!$omp target update from(Shear_mag) if (use_Smag)
+    !$omp target update from(visc_bound_rem, hrat_min) &
+    !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+    !$omp target update from(str_xx, str_xy)
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
+      !$omp target
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         Ah(I,J) = CS%Ah_bg_xy(I,J)
       enddo ; enddo
+      !$omp end target
+
+      ! TODO: Remove after next block is done
+      !$omp target update from(Ah)
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
+        !$omp target
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
+            !$omp parallel loop collapse(2)
             do J=js-1,Jeq ; do I=is-1,Ieq
               AhSm = Shear_mag(I,J) * (CS%Biharm_const_xy(I,J) &
                   + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J))
               Ah(I,J) = max(Ah(I,J), AhSm)
             enddo ; enddo
           else
+            !$omp parallel loop collapse(2)
             do J=js-1,Jeq ; do I=is-1,Ieq
               AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J)
               Ah(I,J) = max(Ah(I,J), AhSm)
             enddo ; enddo
           endif
         endif
+        !$omp end target
+
+        !$omp target update from(Ah)
 
         if (CS%Leith_Ah) then
           do J=js-1,Jeq ; do I=is-1,Ieq
@@ -2479,7 +2506,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
-  !$omp target exit data map(delete: CS%Ah_bg_xx) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
   !$omp target exit data map(delete: CS%reduction_xx) if (CS%biharmonic)
   !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1744,11 +1744,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
     !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
 
-    ! Pass the velocity gradients and thickness to ZB2020
-    if (CS%use_ZB2020) then
-      call ZB2020_copy_gradient_and_thickness(sh_xx, sh_xy, vort_xy, hq, G, GV, CS%ZB2020, k)
-    endif
-
     if (CS%Laplacian) then
       ! Determine the Laplacian viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
@@ -1951,9 +1946,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     !$omp target update from(Kh)
+    !$omp target update from(h_u, h_v, hq)
+    !$omp target update from(sh_xx, sh_xy)
+    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
+    !$omp target update from(Shear_mag) if (use_Smag)
     !$omp target update from(visc_bound_rem, hrat_min) &
     !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-    !$omp target update from(str_xy)
+    !$omp target update from(str_xx, str_xy)
 
     if (CS%anisotropic) then
       do J=js-1,Jeq ; do I=is-1,Ieq

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1338,24 +1338,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
-        !$omp target
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            !$omp parallel loop collapse(2)
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
               AhSm = Shear_mag(i,j) * (CS%Biharm_const_xx(i,j) &
                   + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j))
               Ah(i,j) = max(Ah(i,j), AhSm)
-            enddo ; enddo
+            enddo
           else
-            !$omp parallel loop collapse(2)
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
               AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j)
               Ah(i,j) = max(Ah(i,j), AhSm)
-            enddo ; enddo
+            enddo
           endif
         endif
-        !$omp end target
 
         if (CS%Leith_Ah) then
           !$omp target update from(Ah)
@@ -1367,7 +1363,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo ; enddo
           !$omp target update to(Ah)
         endif
-        !$omp target update from(Ah)
+        !!$omp target update from(Ah)
 
         if (CS%use_Leithy) then
           ! TODO: !$omp target update from(...?)
@@ -1425,14 +1421,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         endif
 
-        !$omp target
         if (CS%bound_Ah .and. .not. CS%better_bound_Ah) then
-          !$omp parallel loop collapse(2)
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
             Ah(i,j) = min(Ah(i,j), CS%Ah_Max_xx(i,j))
-          enddo ; enddo
+          enddo
         endif
-        !$omp end target
       endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
 
       if (use_MEKE_Au) then
@@ -1453,21 +1446,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Ah)
       endif
 
-      !$omp target
       if (CS%better_bound_Ah) then
         if (CS%better_bound_Kh) then
-          !$omp parallel loop collapse(2)
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
             Ah(i,j) = min(Ah(i,j), visc_bound_rem(i,j) * hrat_min(i,j) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo
+          enddo
         else
-          !$omp parallel loop collapse(2)
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
             Ah(i,j) = min(Ah(i,j), hrat_min(i,j) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo
+          enddo
         endif
       endif
-      !$omp end target
 
       if (CS%EY24_EBT_BS) then
         !$omp target update from(Ah)
@@ -1510,9 +1499,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       !$omp target update to(sh_xx_smooth) if (CS%use_Leithy)
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j)) - (G%IdyCu(I-1,j) * Del2u(I-1,j))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J)) - (G%IdxCv(i,J-1) * Del2v(i,J-1))
         d_str = Ah(i,j) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
@@ -1523,8 +1510,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
     ! Backscatter using MEKE
@@ -1560,13 +1546,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J)*G%IdyCv(i+1,J)) - (Del2v(i,J)*G%IdyCv(i,J)))
         dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1)*G%IdxCu(I,j+1)) - (Del2u(I,j)*G%IdxCu(I,j)))
-      enddo ; enddo
-      !$omp end target
+      enddo
 
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if (OBC%zero_strain .or. OBC%freeslip_strain) then
@@ -1595,34 +1578,30 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif ; endif
     endif
 
-    !$omp target
-
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         sh_xy_sq = sh_xy(I,J)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j)**2) + (sh_xx(i+1,j+1)**2)) &
                           + ((sh_xx(i,j+1)**2) + (sh_xx(i+1,j)**2)) )
         Shear_mag(I,J) = sqrt(sh_xy_sq + sh_xx_sq)
-      enddo ; enddo
+      enddo
     endif
 
-    !$omp parallel loop collapse(2)
-    do J=js-1,Jeq ; do I=is-1,Ieq
+    do concurrent (I=is-1:Ieq, J=js-1:Jeq)
       h2uq = 4.0 * (h_u(I,j) * h_u(I,j+1))
       h2vq = 4.0 * (h_v(i,J) * h_v(i+1,J))
       hq(I,J) = (2.0 * (h2uq * h2vq)) &
           / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j) + h_u(I,j+1)) + (h_v(i,J) + h_v(i+1,J))))
-    enddo ; enddo
+    enddo
 
     if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         h_min = min(h_u(I,j), h_u(I,j+1), h_v(i,J), h_v(i+1,J))
         hrat_min(I,J) = min(1.0, h_min / (hq(I,J) + h_neglect))
-      enddo ; enddo
+      enddo
     endif
 
+    ! TODO: GPU??  Are h_[uv] on CPU?  update to hrat_min?
     if (CS%no_slip) then
       do J=js-1,Jeq ; do I=is-1,Ieq
         if (CS%no_slip .and. (G%mask2dBu(I,J) < 0.5)) then
@@ -1646,8 +1625,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       enddo ; enddo
     endif
-
-    !$omp end target
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1282,8 +1282,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo
       endif
 
-      !!$omp target update from(Kh)
-
       ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
       ! The harmonic component of str_xx is added in the biharmonic loop.
       if (CS%use_Leithy) then
@@ -1940,8 +1938,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
-      !$omp target update from(Ah)
-
       ! Again, need to initialize str_xy as if its biharmonic
       do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
@@ -1952,8 +1948,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! NOTE: computing this ought to be conditional!  But it uses d_str...
         bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
       enddo
-
-      !$omp target update from(Ah, str_xy, bhstr_xy)
     endif ! Get Ah at q points and biharmonic part of str_xy
 
     ! Backscatter using MEKE
@@ -2100,7 +2094,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp   if ((find_Frictwork .or. find_FrictWork_bh) .and. .not. CS%FrictWork_bug)
 
     if (find_FrictWork) then
-      !$omp target update from(str_xx, str_Xy)
+      !$omp target update from(str_xx, str_xy)
 
       if (CS%FrictWork_bug) then
         ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -669,13 +669,19 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target enter data map(alloc: h_u, h_v)
+  !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
 
   ! TODO: NoSt, ShSt, ...?
 
-  ! TODO: This should be computed (and stored?) on the GPU
+  ! TODO: These are static and should be computed (and stored?) on the GPU
   !$omp target enter data map(to: CS)
   !$omp target enter data map(to: CS%dx_dyT, CS%dy_dxT)
   !$omp target enter data map(to: CS%dx_dyBu, CS%dy_dxBu)
+
+  !$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%dx2q, CS%dy2q) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%dx2h, CS%dy2h) if (CS%biharmonic)
 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
@@ -929,9 +935,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
     !$omp end target
 
-    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-    !$omp target update from(h_u, h_v)
-
     if (CS%use_Leithy) then
       ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
       ! dudy_smooth and dvdx_smooth do not (yet) include modifications at OBCs from above.
@@ -948,15 +951,23 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
+      !$omp target
+
+      !$omp parallel loop collapse(2)
       do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
         Del2u(I,j) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
                      CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j)) - (CS%dy2h(i,j)*sh_xx(i,j)))
       enddo ; enddo
+
+      !$omp parallel loop collapse(2)
       do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
         Del2v(i,J) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
                      CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1)) - (CS%dx2h(i,j)*sh_xx(i,j)))
       enddo ; enddo
+      !$omp end target
+
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
+        !$omp target update from(Del2u, Del2v)
         do n=1,OBC%number_of_segments
           I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
@@ -969,8 +980,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo
           endif
         enddo
+        !$omp target update to(Del2u, Del2v)
       endif ; endif
     endif
+
+    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
+    !$omp target update from(h_u, h_v)
+    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
 
     ! Vorticity
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
@@ -2234,6 +2250,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target exit data map(delete: h_u, h_v)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
+  !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
 
   ! TODO: This should should be permanently on the GPU
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -703,7 +703,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%dx2h, CS%dy2h) if (CS%biharmonic)
 
   !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Kh_Max_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
+  !!!$omp target enter data map(to: CS%Kh_max_xy) &
+  !!!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
   !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
@@ -1787,11 +1789,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo ; enddo
         endif
       endif
+
       !$omp end target
 
-      !$omp target update from(Kh)
-
+      ! TODO: GPU
       if (CS%Leith_Kh) then
+        !$omp target update from(Kh)
         if (CS%add_LES_viscosity) then
           do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = Kh(I,J) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3 ! Is this right? -AJA
@@ -1801,28 +1804,41 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Kh(I,J) = max(Kh(I,J), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3)
           enddo ; enddo
         endif
+        !$omp target update to(Kh)
       endif
 
       ! All viscosity contributions above are subject to resolution scaling
 
+      ! TODO: GPU
       if (rescale_Kh) then
+        !$omp target update from(Kh)
         do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J) = VarMix%Res_fn_q(I,J) * Kh(I,J)
         enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
+      ! TODO: GPU
       if (legacy_bound) then
+        !$omp target update from(Kh)
         ! Older method of bounding for stability
         do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J) = min(Kh(I,J), CS%Kh_Max_xy(I,J))
         enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
+      !$omp target
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
-        Kh(I,J) = max(Kh(I,J), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
+        ! Place a floor on the viscosity, if desired.
+        Kh(I,J) = max(Kh(I,J), CS%Kh_bg_min)
       enddo ; enddo
+      !$omp end target
 
+      ! TODO: GPU
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
+        !$omp target update from(Kh)
         if (use_kh_struct) then
           do J=js-1,Jeq ; do I=is-1,Ieq
             meke_res_fn = 1.
@@ -1844,13 +1860,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                         MEKE%Ku(i,j+1)) ) * meke_res_fn
           enddo ; enddo
         endif
+        !$omp target update to(Kh)
       endif
 
+      ! TODO: GPU
       if (CS%anisotropic) then
+        !$omp target update from(Kh)
         ! *Add* the shear component of anisotropic viscosity
         do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = Kh(I,J) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
         enddo ; enddo
+        !$omp target update from(Kh)
       endif
 
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1908,6 +1928,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         str_xy(I,J) = 0.
       enddo ; enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
+
+    !$omp target update from(Kh)
 
     if (CS%anisotropic) then
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -2428,6 +2450,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
+  !!!$omp target exit data map(delete: CS%Kh_max_xy) &
+  !!!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
   !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -667,44 +667,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! call pass_vector(slope_x, slope_y, G%Domain, halo=2)
   endif
 
-  !$OMP parallel do default(none) if (.not. CS%smooth_AH) &
-  !$OMP shared( &
-  !$OMP   CS, G, GV, US, OBC, VarMix, MEKE, u, v, h, uh, vh, &
-  !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
-  !$OMP   is_vort, ie_vort, js_vort, je_vort, &
-  !$OMP   is_Kh, ie_Kh, js_Kh, je_Kh, &
-  !$OMP   apply_OBC, rescale_Kh, legacy_bound, find_FrictWork, use_kh_struct, skeb_use_frict, &
-  !$OMP   use_MEKE_Ku, use_MEKE_Au, u_smooth, v_smooth, use_cont_huv, slope_x, slope_y, dz, &
-  !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
-  !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
-  !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_bh, FrictWork_GME, &
-  !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
-  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont, STOCH &
-  !$OMP ) &
-  !$OMP private( &
-  !$OMP   i, j, k, n, tmp, &
-  !$OMP   dudx, dudy, dvdx, dvdy, sh_xx, sh_xy, h_u, h_v, &
-  !$OMP   Del2u, Del2v, DY_dxBu, DX_dyBu, sh_xx_bt, sh_xy_bt, &
-  !$OMP   str_xx, str_xy, bhstr_xx, bhstr_xy, str_xx_GME, str_xy_GME, &
-  !$OMP   vort_xy, vort_xy_dx, vort_xy_dy, div_xx, div_xx_dx, div_xx_dy, &
-  !$OMP   grad_div_mag_h, grad_div_mag_q, grad_vort_mag_h, grad_vort_mag_q, &
-  !$OMP   grad_vort, grad_vort_qg, grad_vort_mag_h_2d, grad_vort_mag_q_2d, &
-  !$OMP   sh_xx_sq, sh_xy_sq, meke_res_fn, Shear_mag, Shear_mag_bc, vert_vort_mag, &
-  !$OMP   h_min, hrat_min, visc_bound_rem, Kh_max_here, &
-  !$OMP   grid_Ah, grid_Kh, d_Del2u, d_Del2v, d_str, &
-  !$OMP   Kh, Ah, AhSm, AhLth, local_strain, Sh_F_pow, &
-  !$OMP   dDel2vdx, dDel2udy, Del2vort_q, Del2vort_h, KE, &
-  !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff, &
-  !$OMP   dudx_smooth, dudy_smooth, dvdx_smooth, dvdy_smooth, &
-  !$OMP   vort_xy_smooth, vort_xy_dx_smooth, vort_xy_dy_smooth, &
-  !$OMP   sh_xx_smooth, sh_xy_smooth, &
-  !$OMP   vert_vort_mag_smooth, m_leithy, Ah_sq, AhLthy, &
-  !$OMP   Kh_BS, str_xx_bs, str_xy_bs, bs_coeff_h, bs_coeff_q &
-  !$OMP ) &
-  !$OMP firstprivate( &
-  !$OMP   visc_limit_h, visc_limit_h_frac, visc_limit_h_flag, &
-  !$OMP   visc_limit_q, visc_limit_q_frac, visc_limit_q_flag &
-  !$OMP )
+  !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx)
+
+  ! TODO: This should be computed (and stored?) on the GPU
+  !$omp target enter data map(to: CS)
+  !$omp target enter data map(to: CS%dx_dyT, CS%dy_dxT)
+  !$omp target enter data map(to: CS%dx_dyBu, CS%dy_dxBu)
+
+  ! TODO: Do this outside the function
+  !$omp target enter data map(to: u, v)
+
   do k=1,nz
 
     ! The following are the forms of the horizontal tension and horizontal
@@ -717,12 +689,27 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !   the dudx and dvdy terms beyond their valid bounds.
     ! TODO: Explore methods for retaining both the syntax and speedup.
 
+    ! XXX: **I don't understand why I need this**
+    !$omp target update to(u(:,:,k), v(:,:,k))
+
+    !$omp target
     ! Calculate horizontal tension
+    !$omp parallel loop collapse(2)
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                   (G%IdyCu(I-1,j) * u(I-1,j,k)))
+    enddo ; enddo
+
+    !$omp parallel loop collapse(2)
+    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       dvdy(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
                                   (G%IdxCv(i,J-1) * v(i,J-1,k)))
+    enddo ; enddo
+
+    !$omp end target
+    !$omp target update from(dudx, dvdy)
+
+    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
     enddo ; enddo
 
@@ -731,6 +718,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
     enddo ; enddo
+
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
@@ -2217,6 +2205,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
     endif ! find_FrictWork and associated(mom_src)
   enddo ! end of k loop
+
+  !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx)
+
+  ! TODO: This should should be permanently on the GPU
+  !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
+  !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
+  !$omp target exit data map(delete: CS)
+
+  ! TODO: Do this outside of the function
+  !$omp target exit data map(delete: u, v)
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -706,19 +706,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                   (G%IdxCv(i,J-1) * v(i,J-1,k)))
     enddo ; enddo
 
-    !$omp end target
-    !$omp target update from(dudx, dvdy)
-
+    !$omp parallel loop collapse(2)
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
     enddo ; enddo
 
     ! Components for the shearing strain
+    !$omp parallel loop collapse(2)
     do J=js_vort,je_vort ; do I=is_vort,ie_vort
       dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
     enddo ; enddo
+    !$omp end target
 
+    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx)
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -724,6 +724,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
   !$omp target enter data map(to: CS%Ah_max_xx) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp target enter data map(to: CS%Ah_max_xy) &
+  !$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
@@ -1989,9 +1991,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
       !$omp end target
 
-      ! TODO: Remove after next block is done
-      !$omp target update from(Ah)
-
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         !$omp target
         if (CS%Smagorinsky_Ah) then
@@ -2015,47 +2014,62 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update from(Ah)
 
         if (CS%Leith_Ah) then
+          !$omp target update from(Ah)
           do J=js-1,Jeq ; do I=is-1,Ieq
             AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J)) * inv_PI6
             Ah(I,J) = max(Ah(I,J), AhLth)
           enddo ; enddo
+          !$omp target update to(Ah)
         endif
 
+        !$omp target
         if (CS%bound_Ah .and. .not.CS%better_bound_Ah) then
+          !$omp parallel loop collapse(2)
           do J=js-1,Jeq ; do I=is-1,Ieq
             Ah(I,J) = min(Ah(I,J), CS%Ah_Max_xy(I,J))
           enddo ; enddo
         endif
+        !$omp end target
       endif ! Smagorinsky_Ah or Leith_Ah
 
       if (use_MEKE_Au) then
+        !$omp target update from(Ah)
         ! *Add* the MEKE contribution
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah(I,J) = Ah(I,J) + 0.25 * ( &
               (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) + (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
         enddo ; enddo
+        !$omp target update to(Ah)
       endif
 
+      ! XXX: It is just overwrites the values!
       if (CS%Re_Ah > 0.0) then
         do J=js-1,Jeq ; do I=is-1,Ieq
           KE = 0.125 * (((u(I,j,k) + u(I,j+1,k))**2) + ((v(i,J,k) + v(i+1,J,k))**2))
           Ah(I,J) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
         enddo ; enddo
+        !$omp target update to(Ah)
       endif
 
+      !$omp target
       if (CS%better_bound_Ah) then
         if (CS%better_bound_Kh) then
+          !$omp parallel loop collapse(2)
           do J=js-1,Jeq ; do I=is-1,Ieq
             Ah(I,J) = min(Ah(I,J), visc_bound_rem(I,J) * hrat_min(I,J) * CS%Ah_Max_xy(I,J))
           enddo ; enddo
         else
+          !$omp parallel loop collapse(2)
           do J=js-1,Jeq ; do I=is-1,Ieq
             Ah(I,J) = min(Ah(I,J), hrat_min(I,J) * CS%Ah_Max_xy(I,J))
           enddo ; enddo
         endif
       endif
+      !$omp end target
 
       if (CS%EY24_EBT_BS) then
+        ! TODO: Fix indent!
+        !$omp target update from(Ah)
           do J=js-1,Jeq ; do I=is-1,Ieq
             tmp = CS%KS_coef *hrat_min(I,J) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
@@ -2071,13 +2085,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah(I,J) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
         enddo ; enddo
+        !$omp target update to(Ah)
       end if
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
+        !$omp target update from(Ah)
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah_q(I,J,k) = Ah(I,J)
         enddo ; enddo
       endif
+
+      !$omp target update from(Ah)
 
       ! Again, need to initialize str_xy as if its biharmonic
       do J=js-1,Jeq ; do I=is-1,Ieq

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -682,13 +682,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
-  !$omp target enter data map(alloc: str_xx)
+  !$omp target enter data map(alloc: str_xx, str_xy)
   !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
 
   !$omp target enter data map(alloc: hrat_min) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target enter data map(alloc: visc_bound_rem) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp target enter data map(alloc: Kh_q) &
+  !$omp   if (CS%Laplacian .and. (CS%id_Kh_q > 0 .or. CS%debug))
+  !$omp target enter data map(alloc: sh_xy_q) &
+  !$omp   if (CS%id_sh_xy_q > 0)
 
   ! TODO: NoSt, ShSt, ...?
 
@@ -1733,7 +1737,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
            G, GV, CS%ZB2020, k)
     endif
 
-    !$omp target update from(dudx, dudy, dvdx, dvdy)
     !$omp target update from(sh_xx, sh_xy)
     !$omp target update from(h_u, h_v, hq)
     !$omp target update from(str_xx)
@@ -1868,7 +1871,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = Kh(I,J) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
         enddo ; enddo
-        !$omp target update from(Kh)
+        !$omp target update to(Kh)
       endif
 
       !$omp target
@@ -1890,17 +1893,23 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
       !$omp end target
 
+      ! TODO: GPU
       if (CS%use_Leithy) then
+        !$omp target update from(Kh)
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
         do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
         enddo ; enddo
+        !$omp target update to(Kh)
       end if
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
+        !$omp target
+        !$omp parallel loop collapse(2)
         do J=js-1,Jeq ; do I=is-1,Ieq
           Kh_q(I,J,k) = Kh(I,J)
         enddo ; enddo
+        !$omp end target
       endif
 
       if (CS%id_vort_xy_q > 0) then
@@ -1910,29 +1919,41 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_sh_xy_q > 0) then
+        !$omp target
+        !$omp parallel loop collapse(2)
         do J=js-1,Jeq ; do I=is-1,Ieq
           sh_xy_q(I,J,k) = sh_xy(I,J)
         enddo ; enddo
+        !$omp end target
       endif
 
       if (.not. CS%use_Leithy) then
+        !$omp target
+        !$omp parallel loop collapse(2)
         do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
         enddo ; enddo
+        !$omp end target
       else
+        !$omp target update from(Kh)
         do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = -Kh(I,J) * sh_xy_smooth(I,J)
         enddo ; enddo
+        !$omp target update to(str_xy)
       endif
     else
+      !$omp target
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         str_xy(I,J) = 0.
       enddo ; enddo
+      !$omp end target
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     !$omp target update from(Kh)
     !$omp target update from(visc_bound_rem, hrat_min) &
     !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+    !$omp target update from(str_xy)
 
     if (CS%anisotropic) then
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -2431,7 +2452,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
   !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)
-  !$omp target exit data map(delete: str_xx)
+  !$omp target exit data map(delete: str_xx, str_xy)
 
   !$omp target exit data map(delete: Kh) if (CS%Laplacian)
   !$omp target exit data map(delete: Ah) if (CS%biharmonic)
@@ -2516,6 +2537,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       call Bchksum(Ah_q, "Ah_q", G%HI, haloshift=0, symmetric=.true., unscale=US%L_to_m**4*US%s_to_T)
     endif
   endif
+
+  !$omp target exit data map(delete: Kh_q) &
+  !$omp   if (CS%Laplacian .and. (CS%id_Kh_q > 0 .or. CS%debug))
+  !$omp target exit data map(delete: sh_xy_q) &
+  !$omp   if (CS%id_sh_xy_q > 0)
 
   if (CS%id_FrictWorkIntz > 0) then
     do j=js,je

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1204,6 +1204,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = VarMix%Res_fn_h(i,j) * Kh(i,j)
         enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
       if (legacy_bound) then
@@ -1212,6 +1213,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = min(Kh(i,j), CS%Kh_Max_xx(i,j))
         enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
       ! Place a floor on the viscosity, if desired.
@@ -1310,6 +1312,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_sh_xx_h>0) then
+        !$omp target update from(sh_xx)
         do j=js,je ; do i=is,ie
           sh_xx_h(i,j,k) = sh_xx(i,j)
         enddo ; enddo
@@ -1325,8 +1328,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then
-      !$omp target update from(str_xx)
-      !$omp target update from(sh_xx, sh_xy)
+      !$omp target update from(str_xx, sh_xy)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         ! Shearing-strain averaged to h-points
         local_strain = 0.25 * ( (sh_xy(I,J) + sh_xy(I-1,J-1)) + (sh_xy(I-1,J) + sh_xy(I,J-1)) )
@@ -1646,12 +1648,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
            G, GV, CS%ZB2020, k)
     endif
 
-    !$omp target update from(sh_xx, sh_xy)
-    !$omp target update from(h_u, h_v, hq)
-    !$omp target update from(str_xx)
-    !$omp target update from(Shear_mag) if (use_Smag)
-    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
-    !$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
+    !!$omp target update from(sh_xx, sh_xy)
+    !!$omp target update from(h_u, h_v, hq)
+    !!$omp target update from(str_xx)
+    !!$omp target update from(Shear_mag) if (use_Smag)
+    !!$omp target update from(Del2u, Del2v) if (CS%biharmonic)
+    !!$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
 
     if (CS%Laplacian) then
       ! Determine the Laplacian viscosity at q points, using the
@@ -1981,6 +1983,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if (CS%use_GME) then
       !$omp target update from(str_xx, str_xy)
+      !$omp target update from(hq) if (CS%no_slip)
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
       do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -702,7 +702,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%dx2q, CS%dy2q) if (CS%biharmonic)
   !$omp target enter data map(to: CS%dx2h, CS%dy2h) if (CS%biharmonic)
 
-  !$omp target enter data map(to: CS%Kh_bg_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
@@ -1245,6 +1245,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
         endif
       enddo ; enddo
+
       !$omp end target
 
       ! All viscosity contributions above are subject to resolution scaling
@@ -1720,6 +1721,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     !$omp end target
 
+    ! Pass the velocity gradients and thickness to ZB2020
+    if (CS%use_ZB2020) then
+      !$omp target update to(sh_xx, sh_xy, vort_xy, hq)
+      call ZB2020_copy_gradient_and_thickness( &
+           sh_xx, sh_xy, vort_xy,              &
+           hq,                                 &
+           G, GV, CS%ZB2020, k)
+    endif
+
     !$omp target update from(dudx, dudy, dvdx, dvdy)
     !$omp target update from(sh_xx, sh_xy)
     !$omp target update from(h_u, h_v, hq)
@@ -1740,6 +1750,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! largest value from several parameterizations. Also get the
       ! Laplacian component of str_xy.
 
+      ! TODO: GPU
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
           do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1754,10 +1765,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       endif
 
+      !$omp target
+
       ! Static (pre-computed) background viscosity
+      !$omp parallel loop collapse(2)
       do J=js-1,Jeq ; do I=is-1,Ieq
         Kh(I,J) = CS%Kh_bg_xy(I,J)
       enddo ; enddo
+      !$omp target update from(Kh)
+
+      !$omp end target
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
@@ -2406,7 +2423,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%dx2q, CS%dy2q) if (CS%biharmonic)
   !$omp target exit data map(delete: CS%dx2h, CS%dy2h) if (CS%biharmonic)
 
-  !$omp target exit data map(delete: CS%Kh_bg_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -707,6 +707,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
 
   !$omp target enter data map(to: CS%Ah_bg_xx) if (CS%biharmonic)
+  !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
@@ -1247,11 +1249,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
         endif
       enddo ; enddo
+      !$omp end target
 
       ! All viscosity contributions above are subject to resolution scaling
 
       ! TODO: GPU
       if (rescale_Kh) then
+        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = VarMix%Res_fn_h(i,j) * Kh(i,j)
         enddo ; enddo
@@ -1260,12 +1264,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! TODO: GPU
       if (legacy_bound) then
         ! Older method of bounding for stability
+        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = min(Kh(i,j), CS%Kh_Max_xx(i,j))
         enddo ; enddo
       endif
 
       ! Place a floor on the viscosity, if desired.
+      !$omp target
       !$omp parallel loop collapse(2)
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
@@ -1274,7 +1280,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp end target
 
       ! TODO: GPU of MEKE and anisotropic Kh tweaks
-
       !$omp target update from(Kh) &
       !$omp   if ((use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) .or. CS%anisotropic)
 
@@ -1416,20 +1421,25 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update from(Ah)
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
+        !$omp target
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
+            !$omp parallel loop collapse(2)
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               AhSm = Shear_mag(i,j) * (CS%Biharm_const_xx(i,j) &
                   + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j))
               Ah(i,j) = max(Ah(i,j), AhSm)
             enddo ; enddo
           else
+            !$omp parallel loop collapse(2)
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j)
               Ah(i,j) = max(Ah(i,j), AhSm)
             enddo ; enddo
           endif
         endif
+        !$omp end target
+        !$omp target update from(Ah)
 
         if (CS%Leith_Ah) then
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -2364,6 +2374,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
 
   !$omp target exit data map(delete: CS%Ah_bg_xx) if (CS%biharmonic)
+
+  !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -681,8 +681,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
   !$omp target enter data map(alloc: hrat_min) &
-  !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
+  !$omp target enter data map(alloc: visc_bound_rem) &
+  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+
 
   ! TODO: NoSt, ShSt, ...?
 
@@ -697,6 +700,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%dx2h, CS%dy2h) if (CS%biharmonic)
 
   !$omp target enter data map(to: CS%Kh_bg_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
 
@@ -1200,6 +1204,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! largest value from several parameterizations. Also get
       ! the Laplacian component of str_xx.
 
+      ! TODO: GPU
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%use_QG_Leith_visc) then
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1261,9 +1266,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
       enddo ; enddo
+
       !$omp end target
 
-      !$omp target update from(Kh)
+      ! TODO: GPU of MEKE and anisotropic Kh tweaks
+
+      !$omp target update from(Kh) &
+      !$omp   if ((use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) .or. CS%anisotropic)
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         ! *Add* the MEKE contribution (which might be negative)
@@ -1297,8 +1306,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
+      !$omp target update to(Kh) &
+      !$omp   if ((use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) .or. CS%anisotropic)
+
       ! Newer method of bounding for stability
+      !$omp target
       if ((CS%better_bound_Kh) .and. (CS%better_bound_Ah)) then
+        !$omp parallel loop collapse(2)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           visc_bound_rem(i,j) = 1.0
           Kh_max_here = hrat_min(i,j) * CS%Kh_Max_xx(i,j)
@@ -1310,10 +1324,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         enddo ; enddo
       elseif (CS%better_bound_Kh) then
+        !$omp parallel loop collapse(2)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = min(Kh(i,j), hrat_min(i,j) * CS%Kh_Max_xx(i,j))
         enddo ; enddo
       endif
+      !$omp end target
+
+      !$omp target update from(Kh)
+
+      !$omp target update from(visc_bound_rem) &
+      !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
       ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
       ! The harmonic component of str_xx is added in the biharmonic loop.
@@ -2302,6 +2323,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
   !$omp target exit data map(delete: Kh) if (CS%Laplacian)
+  !$omp target exit data map(delete: visc_bound_rem) &
+  !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
   ! TODO: Should static CS arrays be permanently on the GPU?
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
@@ -2314,6 +2337,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%dx2h, CS%dy2h) if (CS%biharmonic)
 
   !$omp target exit data map(delete: CS%Kh_bg_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1661,29 +1661,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       endif
 
-      !$omp target
-
       ! Static (pre-computed) background viscosity
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         Kh(I,J) = CS%Kh_bg_xy(I,J)
-      enddo ; enddo
+      enddo
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
-          !$omp parallel loop collapse(2)
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
             Kh(I,J) = Kh(I,J) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J)
-          enddo ; enddo
+          enddo
         else
-          !$omp parallel loop collapse(2)
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
             Kh(I,J) = max(Kh(I,J), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J) )
-          enddo ; enddo
+          enddo
         endif
       endif
-
-      !$omp end target
 
       if (CS%Leith_Kh) then
         !$omp target update from(Kh)
@@ -1718,13 +1711,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Kh)
       endif
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         ! Place a floor on the viscosity, if desired.
         Kh(I,J) = max(Kh(I,J), CS%Kh_bg_min)
-      enddo ; enddo
-      !$omp end target
+      enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         !$omp target update from(Kh)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -699,41 +699,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   ! TODO: NoSt, ShSt, ...?
 
-  ! TODO: These are static and should be computed (and stored?) on the GPU
-  !!!$omp target enter data map(to: CS)
-  !!!$omp target enter data map(to: CS%dx_dyT, CS%dy_dxT)
-  !!!$omp target enter data map(to: CS%dx_dyBu, CS%dy_dxBu)
-
-  !!!$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
-  !!!$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-  !!!$omp target enter data map(to: CS%dx2q, CS%dy2q)
-  !!!$omp target enter data map(to: CS%dx2h, CS%dy2h)
-
-  !!!$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
-  !!!$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
-  !!!$omp target enter data map(to: CS%Kh_max_xy) &
-  !!!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
-  !!!$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
-  !!!$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
-  !!!$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
-
-  !!!$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !!!$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy)
-  !!!$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
-  !!!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
-  !!!$omp target enter data map(to: CS%Biharm_const_xy) &
-  !!!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
-  !!!$omp target enter data map(to: CS%Biharm_const2_xy) &
-  !!!$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
-  !!!$omp target enter data map(to: CS%Ah_max_xx) &
-  !!!$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-  !!!$omp target enter data map(to: CS%Ah_max_xy) &
-  !!!$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
-
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
   !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
-  !$omp target enter data map(alloc: diffu, diffv)
 
   do k=1,nz
 
@@ -2547,7 +2515,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
-  !$omp target exit data map(from: diffu, diffv)
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -685,7 +685,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
   !$omp target enter data map(alloc: visc_bound_rem) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-
+  !$omp target enter data map(alloc: str_xx)
 
   ! TODO: NoSt, ShSt, ...?
 
@@ -1370,14 +1370,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
+      !$omp target
+      !$omp parallel loop collapse(2)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = -Kh(i,j) * sh_xx(i,j)
       enddo ; enddo
+      !$omp end target
     else
+      !$omp target
+      !$omp parallel loop collapse(2)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = 0.0
       enddo ; enddo
+      !$omp end target
     endif ! Get Kh at h points and get Laplacian component of str_xx
+
+    !$omp target update from(str_xx)
 
     if (CS%anisotropic) then
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -2325,6 +2333,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: Kh) if (CS%Laplacian)
   !$omp target exit data map(delete: visc_bound_rem) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp target exit data map(delete: str_xx)
 
   ! TODO: Should static CS arrays be permanently on the GPU?
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -763,36 +763,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! in OBCs, which are not ordinarily be necessary, and might not be necessary
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
-    !$omp target
     if (use_cont_huv) then
-      !$omp parallel loop collapse(2)
-      do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+      do concurrent (I=Isq-1:Ieq+1, j=js-2:je+2)
         h_u(I,j) = hu_cont(I,j,k)
-      enddo ; enddo
-      !$omp parallel loop collapse(2)
-      do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
+      enddo
+      do concurrent (i=is-2:ie+2, J=Jsq-1:Jeq+1)
         h_v(i,J) = hv_cont(i,J,k)
-      enddo ; enddo
+      enddo
     elseif (CS%use_land_mask) then
-      !$omp parallel loop collapse(2)
-      do j=js-2,je+2 ; do I=is-2,Ieq+1
+      do concurrent (I=is-2:Ieq+1, j=js-2:je+2)
         h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
-      enddo ; enddo
-      !$omp parallel loop collapse(2)
-      do J=js-2,Jeq+1 ; do i=is-2,ie+2
+      enddo
+      do concurrent (i=is-2:ie+2, J=js-2:Jeq+1)
         h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
-      enddo ; enddo
+      enddo
     else
-      !$omp parallel loop collapse(2)
-      do j=js-2,je+2 ; do I=is-2,Ieq+1
+      do concurrent (I=is-2:Ieq+1, j=js-2:je+2)
         h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
-      enddo ; enddo
-      !$omp parallel loop collapse(2)
-      do J=js-2,Jeq+1 ; do i=is-2,ie+2
+      enddo
+      do concurrent (i=is-2:ie+2, J=js-2:Jeq+1)
         h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
-      enddo ; enddo
+      enddo
     endif
-    !$omp end target
 
     ! Adjust contributions to shearing strain and interpolated values of
     ! thicknesses on open boundaries.

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -710,7 +710,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target enter data map(to: CS%Ah_bg_xx) if (CS%biharmonic)
   !$omp target enter data map(to: CS%reduction_xx) if (CS%biharmonic)
-  !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
+  !$omp target enter data map(alloc: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Ah_max_xx) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
@@ -2434,7 +2434,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target exit data map(delete: CS%Ah_bg_xx) if (CS%biharmonic)
   !$omp target exit data map(delete: CS%reduction_xx) if (CS%biharmonic)
-  !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
+  !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Ah_max_xx) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -700,35 +700,35 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! TODO: NoSt, ShSt, ...?
 
   ! TODO: These are static and should be computed (and stored?) on the GPU
-  !$omp target enter data map(to: CS)
-  !$omp target enter data map(to: CS%dx_dyT, CS%dy_dxT)
-  !$omp target enter data map(to: CS%dx_dyBu, CS%dy_dxBu)
+  !!!$omp target enter data map(to: CS)
+  !!!$omp target enter data map(to: CS%dx_dyT, CS%dy_dxT)
+  !!!$omp target enter data map(to: CS%dx_dyBu, CS%dy_dxBu)
 
-  !$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%dx2q, CS%dy2q)
-  !$omp target enter data map(to: CS%dx2h, CS%dy2h)
+  !!!$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !!!$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+  !!!$omp target enter data map(to: CS%dx2q, CS%dy2q)
+  !!!$omp target enter data map(to: CS%dx2h, CS%dy2h)
 
-  !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Kh_max_xy) &
-  !$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
-  !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
+  !!!$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
+  !!!$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
+  !!!$omp target enter data map(to: CS%Kh_max_xy) &
+  !!!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
+  !!!$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !!!$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !!!$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
-  !$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy)
-  !$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
-  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
-  !$omp target enter data map(to: CS%Biharm_const_xy) &
-  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
-  !$omp target enter data map(to: CS%Biharm_const2_xy) &
-  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
-  !$omp target enter data map(to: CS%Ah_max_xx) &
-  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-  !$omp target enter data map(to: CS%Ah_max_xy) &
-  !$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
+  !!!$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
+  !!!$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy)
+  !!!$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
+  !!!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !!!$omp target enter data map(to: CS%Biharm_const_xy) &
+  !!!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
+  !!!$omp target enter data map(to: CS%Biharm_const2_xy) &
+  !!!$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
+  !!!$omp target enter data map(to: CS%Ah_max_xx) &
+  !!!$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !!!$omp target enter data map(to: CS%Ah_max_xy) &
+  !!!$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
@@ -2514,29 +2514,35 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
   ! TODO: Should static CS arrays be permanently on the GPU?
-  !$omp target exit data map(delete: CS)
-  !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
-  !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
+  !!$omp target exit data map(delete: CS)
+  !!$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
+  !!$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
 
-  !$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%dx2q, CS%dy2q)
-  !$omp target exit data map(delete: CS%dx2h, CS%dy2h)
+  !!$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !!$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+  !!$omp target exit data map(delete: CS%dx2q, CS%dy2q)
+  !!$omp target exit data map(delete: CS%dx2h, CS%dy2h)
 
-  !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Kh_max_xy) &
-  !$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
-  !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
+  !!$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
+  !!$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
+  !!$omp target exit data map(delete: CS%Kh_max_xy) &
+  !!$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
+  !!$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !!$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !!$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
-  !$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy)
-  !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
-  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
-  !$omp target enter data map(to: CS%Ah_max_xx) &
-  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !!$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
+  !!$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy)
+  !!$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
+  !!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !!$omp target exit data map(delete: CS%Biharm_const_xy) &
+  !!$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
+  !!$omp target exit data map(delete: CS%Biharm_const2_xy) &
+  !!$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
+  !!$omp target exit data map(delete: CS%Ah_max_xx) &
+  !!$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !!$omp target exit data map(delete: CS%Ah_max_xy) &
+  !!$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)
@@ -3158,6 +3164,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       ALLOC_(CS%Re_Ah_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Re_Ah_const_xy(:,:) = 0.0
     endif
   endif
+
   do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
     CS%dx2q(I,J) = G%dxBu(I,J)*G%dxBu(I,J) ; CS%dy2q(I,J) = G%dyBu(I,J)*G%dyBu(I,J)
   enddo ; enddo
@@ -3178,11 +3185,14 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
     enddo ; enddo
   endif
+  !$omp target enter data map(to: CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)
 
   do j=js-2,Jeq+2 ; do i=is-2,Ieq+2
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)
     CS%DX_dyT(i,j) = G%dxT(i,j)*G%IdyT(i,j) ; CS%DY_dxT(i,j) = G%dyT(i,j)*G%IdxT(i,j)
   enddo ; enddo
+  !$omp target enter data map(to: CS%dx2h, CS%dy2h, CS%dx_dyT, CS%dy_dxT)
+
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     CS%reduction_xx(i,j) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &
@@ -3626,6 +3636,32 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       'Depth integrated work done by the biharmonic lateral friction', &
       'W m-2', conversion=US%RZ3_T3_to_W_m2*US%L_to_Z**2)
 
+
+  ! TODO: Position these after their respective loops (and run loops on device)
+  !$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+
+  !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Kh_max_xy) &
+  !$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
+  !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
+
+  !$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy)
+  !$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !$omp target enter data map(to: CS%Biharm_const_xy) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
+  !$omp target enter data map(to: CS%Biharm_const2_xy) &
+  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
+  !$omp target enter data map(to: CS%Ah_max_xx) &
+  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp target enter data map(to: CS%Ah_max_xy) &
+  !$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
+
 end subroutine hor_visc_init
 
 !> hor_visc_vel_stencil returns the horizontal viscosity input velocity stencil size
@@ -3841,6 +3877,36 @@ end subroutine smooth_x9_uv
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
   type(hor_visc_CS), intent(inout) :: CS !< Horizontal viscosity control structure
+
+  !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
+  !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
+
+  !$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%dx2q, CS%dy2q)
+  !$omp target exit data map(delete: CS%dx2h, CS%dy2h)
+
+  !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Kh_max_xy) &
+  !$omp   if (CS%Laplacian .and. (CS%bound_Kh .or. CS%better_bound_Kh))
+  !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
+
+  !$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy)
+  !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !$omp target exit data map(delete: CS%Biharm_const_xy) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
+  !$omp target exit data map(delete: CS%Biharm_const2_xy) &
+  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
+  !$omp target exit data map(delete: CS%Ah_max_xx) &
+  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
+  !$omp target exit data map(delete: CS%Ah_max_xy) &
+  !$omp   if (CS%bound_Ah .or. CS%better_bound_Ah)
+
   if (CS%Laplacian .or. CS%biharmonic) then
     DEALLOC_(CS%dx2h) ; DEALLOC_(CS%dx2q) ; DEALLOC_(CS%dy2h) ; DEALLOC_(CS%dy2q)
     DEALLOC_(CS%dx_dyT) ; DEALLOC_(CS%dy_dxT) ; DEALLOC_(CS%dx_dyBu) ; DEALLOC_(CS%dy_dxBu)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -675,6 +675,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target enter data map(alloc: h_u, h_v)
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target enter data map(alloc: hrat_min) &
+  !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
   ! TODO: NoSt, ShSt, ...?
 
@@ -1170,18 +1172,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
       enddo ; enddo
     endif
-    !$omp end target
-
-    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-    !$omp target update from(h_u, h_v)
-    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
 
     if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
+      !$omp parallel loop collapse(2)
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         h_min = min(h_u(I,j), h_u(I-1,j), h_v(i,J), h_v(i,J-1))
         hrat_min(i,j) = min(1.0, h_min / (h(i,j,k) + h_neglect))
       enddo ; enddo
     endif
+    !$omp end target
+
+    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
+    !$omp target update from(h_u, h_v)
+    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
+    !$omp target update from(hrat_min) &
+    !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     if (CS%Laplacian) then
       ! Determine the Laplacian viscosity at h points, using the
@@ -2277,6 +2282,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
   !$omp target exit data map(delete: Shear_mag) if (use_Smag_visc)
+  !$omp target exit data map(delete: hrat_min) &
+  !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
   ! TODO: This should should be permanently on the GPU
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -704,48 +704,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
 
   do k=1,nz
-
     ! The following are the forms of the horizontal tension and horizontal
     ! shearing strain advocated by Smagorinsky (1993) and discussed in
     ! Griffies and Hallberg (2000).
 
-    ! NOTE: There is a ~1% speedup when the tension and shearing loops below
-    !   are fused (presumably due to shared access of Id[xy]C[uv]).  However,
-    !   this breaks the center/vertex index case convention, and also evaluates
-    !   the dudx and dvdy terms beyond their valid bounds.
-    ! TODO: Explore methods for retaining both the syntax and speedup.
-
     ! XXX: **I don't understand why I need this**
     !$omp target update to(u(:,:,k), v(:,:,k), h(:,:,k))
 
-    !$omp target
-
     ! Calculate horizontal tension
-    !$omp parallel loop collapse(2)
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
       dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                   (G%IdyCu(I-1,j) * u(I-1,j,k)))
-    enddo ; enddo
+    enddo
 
-    !$omp parallel loop collapse(2)
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
       dvdy(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
                                   (G%IdxCv(i,J-1) * v(i,J-1,k)))
-    enddo ; enddo
+    enddo
 
-    !$omp parallel loop collapse(2)
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
       sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
-    enddo ; enddo
+    enddo
 
     ! Components for the shearing strain
-    !$omp parallel loop collapse(2)
-    do J=js_vort,je_vort ; do I=is_vort,ie_vort
+    do concurrent (I=is_vort:ie_vort, J=js_vort:je_vort)
       dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
-    enddo ; enddo
-
-    !$omp end target
+    enddo
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -707,6 +707,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
 
   !$omp target enter data map(to: CS%Ah_bg_xx) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%reduction_xx) if (CS%biharmonic)
   !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Ah_max_xx) &
@@ -715,7 +716,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
   !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
-  !$omp target enter data map(to: MEKE%Au) if (use_MEKE_Au)
 
   do k=1,nz
 
@@ -1088,8 +1088,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! endif
 
       if (CS%modified_Leith) then
-
-        ! TODO: Remove after moving Leith to GPU
+        ! TODO: GPU
         !$omp target update from(dudx, dvdy)
 
         ! Divergence
@@ -1200,11 +1199,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
     endif
     !$omp end target
-
-    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-    !$omp target update from(h_u, h_v)
-    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
-    !$omp target update from(Shear_mag) if (use_Smag)
 
     if (CS%Laplacian) then
       ! Determine the Laplacian viscosity at h points, using the
@@ -1366,6 +1360,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_div_xx_h>0) then
+        !$omp target update from(dudx, dvdy)
         do j=js,je ; do i=is,ie
           div_xx_h(i,j,k) = dudx(i,j) + dvdy(i,j)
         enddo ; enddo
@@ -1392,10 +1387,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp end target
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
-    !$omp target update from(str_xx)
-
     ! TODO: GPU
     if (CS%anisotropic) then
+      !$omp target update from(str_xx)
+      !$omp target update from(sh_xx, sh_xy)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         ! Shearing-strain averaged to h-points
         local_strain = 0.25 * ( (sh_xy(I,J) + sh_xy(I-1,J-1)) + (sh_xy(I-1,J) + sh_xy(I,J-1)) )
@@ -1582,6 +1577,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
+      !$omp target update to(sh_xx_smooth) if (CS%use_Leithy)
+
+      !$omp target
+      !$omp parallel loop collapse(2)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j)) - (G%IdyCu(I-1,j) * Del2u(I-1,j))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J)) - (G%IdxCv(i,J-1) * Del2v(i,J-1))
@@ -1594,11 +1593,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
+      !$omp end target
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
-    !$omp target update from(hrat_min) &
-    !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-    !$omp target update from(visc_bound_rem) &
+    !$omp target update from(dudx, dudy, dvdx, dvdy)
+    !$omp target update from(sh_xx, sh_xy)
+    !$omp target update from(h_u, h_v)
+    !$omp target update from(str_xx)
+    !$omp target update from(Shear_mag) if (use_Smag)
+    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
+    !$omp target update from(visc_bound_rem, hrat_min) &
     !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
     ! Backscatter using MEKE
@@ -2390,6 +2394,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
 
   !$omp target exit data map(delete: CS%Ah_bg_xx) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%reduction_xx) if (CS%biharmonic)
   !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Ah_max_xx) &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1236,18 +1236,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
         endif
       enddo ; enddo
-      !$omp end target
-
-      !$omp target update from(Kh)
 
       ! All viscosity contributions above are subject to resolution scaling
 
+      ! TODO: GPU
       if (rescale_Kh) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = VarMix%Res_fn_h(i,j) * Kh(i,j)
         enddo ; enddo
       endif
 
+      ! TODO: GPU
       if (legacy_bound) then
         ! Older method of bounding for stability
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1256,9 +1255,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Place a floor on the viscosity, if desired.
+      !$omp parallel loop collapse(2)
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
       enddo ; enddo
+      !$omp end target
+
+      !$omp target update from(Kh)
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         ! *Add* the MEKE contribution (which might be negative)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1751,9 +1751,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Kh)
       endif
 
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         ! Newer method of bounding for stability
         if ((CS%better_bound_Kh) .and. (CS%better_bound_Ah)) then
           visc_bound_rem(I,J) = 1.0
@@ -1767,8 +1765,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         elseif (CS%better_bound_Kh) then
           Kh(I,J) = min(Kh(I,J), hrat_min(I,J) * CS%Kh_Max_xy(I,J))
         endif
-      enddo ; enddo
-      !$omp end target
+      enddo
 
       if (CS%use_Leithy) then
         !$omp target update from(Kh)
@@ -1780,12 +1777,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       end if
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
           Kh_q(I,J,k) = Kh(I,J)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
 
       if (CS%id_vort_xy_q > 0) then
@@ -1795,21 +1789,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_sh_xy_q > 0) then
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
           sh_xy_q(I,J,k) = sh_xy(I,J)
-        enddo ; enddo
-        !$omp end target
+        enddo
       endif
 
       if (.not. CS%use_Leithy) then
-        !$omp target
-        !$omp parallel loop collapse(2)
-        do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
           str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
-        enddo ; enddo
-        !$omp end target
+        enddo
       else
         !$omp target update from(Kh)
         do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1818,12 +1806,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(str_xy)
       endif
     else
-      !$omp target
-      !$omp parallel loop collapse(2)
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
         str_xy(I,J) = 0.
-      enddo ; enddo
-      !$omp end target
+      enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -709,6 +709,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Ah_bg_xx) if (CS%biharmonic)
   !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !$omp target enter data map(to: CS%Ah_max_xx) &
+  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
@@ -1418,8 +1420,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
       !$omp end target
 
-      !$omp target update from(Ah)
-
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         !$omp target
         if (CS%Smagorinsky_Ah) then
@@ -1442,6 +1442,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update from(Ah)
 
         if (CS%Leith_Ah) then
+          !$omp target update from(Ah)
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
                                  (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
@@ -1451,6 +1452,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
 
         if (CS%use_Leithy) then
+          ! TODO: !$omp target update from(...?)
+
           ! Get m_leithy
           if (CS%smooth_Ah) m_leithy(:,:) = 0.0 ! This is here to initialize domain edge halo values.
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1504,12 +1507,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         endif
 
+        !$omp target
         if (CS%bound_Ah .and. .not. CS%better_bound_Ah) then
+          !$omp parallel loop collapse(2)
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Ah(i,j) = min(Ah(i,j), CS%Ah_Max_xx(i,j))
           enddo ; enddo
         endif
+        !$omp end target
       endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
+
+      !$omp target update from(Ah)
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
@@ -2374,9 +2382,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
 
   !$omp target exit data map(delete: CS%Ah_bg_xx) if (CS%biharmonic)
-
   !$omp target enter data map(alloc: CS%Biharm_const_xx(i,j)) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !$omp target enter data map(to: CS%Ah_max_xx) &
+  !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -680,12 +680,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: h_u, h_v)
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
+  !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
+  !$omp target enter data map(alloc: str_xx)
+  !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
+
   !$omp target enter data map(alloc: hrat_min) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-  !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
   !$omp target enter data map(alloc: visc_bound_rem) &
   !$omp   if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-  !$omp target enter data map(alloc: str_xx)
 
   ! TODO: NoSt, ShSt, ...?
 
@@ -703,6 +705,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
+
+  !$omp target enter data map(to: CS%Ah_bg_xx) if (CS%biharmonic)
 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
@@ -1387,6 +1391,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     !$omp target update from(str_xx)
 
+    ! TODO: GPU
     if (CS%anisotropic) then
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         ! Shearing-strain averaged to h-points
@@ -1394,15 +1399,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! *Add* the shear-strain contribution to the xx-component of stress
         str_xx(i,j) = str_xx(i,j) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
       enddo ; enddo
+      !$omp target update to(str_xx)
     endif
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at h points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
+      !$omp target
+      !$omp parallel loop collapse(2)
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Ah(i,j) = CS%Ah_bg_xx(i,j)
       enddo ; enddo
+      !$omp end target
+
+      !$omp target update from(Ah)
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
@@ -2327,13 +2338,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: h_u, h_v)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target exit data map(delete: str_xx)
+
+  !$omp target exit data map(delete: Kh) if (CS%Laplacian)
+  !$omp target exit data map(delete: Ah) if (CS%biharmonic)
   !$omp target exit data map(delete: Shear_mag) if (use_Smag)
   !$omp target exit data map(delete: hrat_min) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-  !$omp target exit data map(delete: Kh) if (CS%Laplacian)
   !$omp target exit data map(delete: visc_bound_rem) &
   !$omp     if (CS%better_bound_Kh .or. CS%better_bound_Ah)
-  !$omp target exit data map(delete: str_xx)
 
   ! TODO: Should static CS arrays be permanently on the GPU?
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
@@ -2349,6 +2362,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
+
+  !$omp target exit data map(delete: CS%Ah_bg_xx) if (CS%biharmonic)
 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -704,8 +704,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
   !$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%dx2q, CS%dy2q) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%dx2h, CS%dy2h) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%dx2q, CS%dy2q)
+  !$omp target enter data map(to: CS%dx2h, CS%dy2h)
 
   !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
   !$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
@@ -716,8 +716,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
   !$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy) &
-  !$omp   if (CS%biharmonic)
+  !$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy)
   !$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Biharm_const_xy) &
@@ -732,6 +731,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! TODO: Do this outside the function
   !$omp target enter data map(to: u, v, h)
   !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
+  !$omp target enter data map(alloc: diffu, diffv)
 
   do k=1,nz
 
@@ -2124,6 +2124,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! Backscatter
 
     if (CS%use_GME) then
+      !$omp target update from(str_xx, str_xy)
+
       ! The wider halo here is to permit one pass of smoothing without a halo update.
       do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
         GME_coeff = GME_effic_h(i,j) * 0.25 * &
@@ -2163,33 +2165,43 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
-
+      !$omp target update to(str_xx, str_xy)
     else ! .not. use_GME
+      !$omp target
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
+      !$omp parallel loop collapse(2)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
+        !$omp parallel loop collapse(2)
         do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       else
+        !$omp parallel loop collapse(2)
         do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
+      !$omp end target
     endif ! use_GME
+    !$omp target update from(str_xx, str_xy)
 
+    !$omp target
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
+    !$omp parallel loop collapse(2)
     do j=js,je ; do I=Isq,Ieq
       diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1)) - (CS%dx2q(I,J)*str_xy(I,J))) + &
                        G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j)) - (CS%dy2h(i+1,j)*str_xx(i+1,j)))) * &
                      G%IareaCu(I,j)) / (h_u(I,j) + h_neglect)
     enddo ; enddo
+    !$omp end target
 
     if (apply_OBC) then
+      !$omp target update from(diffu)
       ! This is not the right boundary condition. If all the masking of tendencies are done
       ! correctly later then eliminating this block should not change answers.
       do n=1,OBC%number_of_segments
@@ -2200,16 +2212,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
         endif
       enddo
+      !$omp target update to(diffu)
     endif
 
+    !$omp target
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
+    !$omp parallel loop collapse(2)
     do J=Jsq,Jeq ; do i=is,ie
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j)) - (CS%dx2h(i,j+1)*str_xx(i,j+1)))) * &
                      G%IareaCv(i,J)) / (h_v(i,J) + h_neglect)
     enddo ; enddo
+    !$omp end target
 
     if (apply_OBC) then
+      !$omp target update from(diffv)
       ! This is not the right boundary condition. If all the masking of tendencies are done
       ! correctly later then eliminating this block should not change answers.
       do n=1,OBC%number_of_segments
@@ -2220,6 +2237,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
         endif
       enddo
+      !$omp target update to(diffv)
     endif
 
     if (find_FrictWork) then
@@ -2495,8 +2513,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
   !$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%dx2q, CS%dy2q) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%dx2h, CS%dy2h) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%dx2q, CS%dy2q)
+  !$omp target exit data map(delete: CS%dx2h, CS%dy2h)
 
   !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
   !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
@@ -2507,8 +2525,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
 
   !$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy) &
-  !$omp   if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy)
   !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
   !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
   !$omp target enter data map(to: CS%Ah_max_xx) &
@@ -2517,6 +2534,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! TODO: Do this outside of the function
   !$omp target exit data map(delete: u, v, h)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
+  !$omp target exit data map(from: diffu, diffv)
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -473,6 +473,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     hrat_min, &     ! h_min divided by the thickness at the stress point (h or q) [nondim]
     visc_bound_rem  ! fraction of overall viscous bounds that remain to be applied (h or q) [nondim]
 
+  ! New variables: move these up once ready
+  logical :: use_Leith    ! True if any Leith-based parameterizations are enabled
+  logical :: use_vort_xy  ! True if vort_xy must be computed
+  logical :: use_Smag_visc  ! True if a Smagorinsky viscosity is enabled
+
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
@@ -984,17 +989,24 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif ; endif
     endif
 
-    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-    !$omp target update from(h_u, h_v)
-    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
-
     ! Vorticity
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
+    use_Leith = CS%Leith_Kh .or. CS%Leith_Ah .or. CS%use_Leithy
+    use_vort_xy = use_Leith .or. CS%id_vort_xy_q > 0 .or. CS%use_ZB2020
+
+    ! NOTE: Keep Leith code on CPU for now, but moving it should be
+    ! straightforward.
+
+    if (use_vort_xy) then
+      ! TODO: Remove this after moving Leith to GPU
+      !$omp target update from(dvdx, dudy)
+
       if (CS%no_slip) then
+        !!$omp parallel loop collapse(2)
         do J=js_vort,je_vort ; do I=is_vort,ie_vort
           vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
         enddo ; enddo
       else
+        !!$omp parallel loop collapse(2)
         do J=js_vort,je_vort ; do I=is_vort,ie_vort
           vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
         enddo ; enddo
@@ -1013,8 +1025,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
     endif
 
-
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
+    if (use_Leith) then
 
       ! Vorticity gradient
       do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
@@ -1054,6 +1065,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! endif
 
       if (CS%modified_Leith) then
+
+        ! TODO: Remove after moving Leith to GPU
+        !$omp target update from(dudx, dvdy)
 
         ! Divergence
         do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
@@ -1096,6 +1110,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif ! CS%modified_Leith
 
       ! Add in beta for the Leith viscosity
+      ! TODO: Move G%dF_dx, G%dF_dy to GPU
+
       if (CS%use_beta_in_Leith) then
         do J=js-2,Jeq+1 ; do i=is-1,ie+1
           vort_xy_dx(i,J) = vort_xy_dx(i,J) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
@@ -1142,7 +1158,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     endif ! CS%Leith_Kh
 
+    !$omp target enter data map(alloc: Shear_mag) if (use_Smag_visc)
+
+    !$omp target
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
+      !$omp parallel loop collapse(2)
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         sh_xx_sq = sh_xx(i,j)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1)**2) + (sh_xy(I,J)**2)) &
@@ -1150,6 +1170,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
       enddo ; enddo
     endif
+    !$omp end target
+
+    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
+    !$omp target update from(h_u, h_v)
+    !$omp target update from(Del2u, Del2v) if (CS%biharmonic)
 
     if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -2251,6 +2276,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: h_u, h_v)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target exit data map(delete: Shear_mag) if (use_Smag_visc)
 
   ! TODO: This should should be permanently on the GPU
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -668,6 +668,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   endif
 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx)
+  !$omp target enter data map(alloc: h_u, h_v)
 
   ! TODO: This should be computed (and stored?) on the GPU
   !$omp target enter data map(to: CS)
@@ -675,7 +676,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(to: CS%dx_dyBu, CS%dy_dxBu)
 
   ! TODO: Do this outside the function
-  !$omp target enter data map(to: u, v)
+  !$omp target enter data map(to: u, v, h)
+  !$omp target enter data map(to: hu_cont, hv_cont) if (use_cont_huv)
 
   do k=1,nz
 
@@ -690,7 +692,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! TODO: Explore methods for retaining both the syntax and speedup.
 
     ! XXX: **I don't understand why I need this**
-    !$omp target update to(u(:,:,k), v(:,:,k))
+    !$omp target update to(u(:,:,k), v(:,:,k), h(:,:,k))
 
     !$omp target
     ! Calculate horizontal tension
@@ -751,28 +753,38 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! in OBCs, which are not ordinarily be necessary, and might not be necessary
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
+    !$omp target
     if (use_cont_huv) then
+      !$omp parallel loop collapse(2)
       do j=js-2,je+2 ; do I=Isq-1,Ieq+1
         h_u(I,j) = hu_cont(I,j,k)
       enddo ; enddo
+      !$omp parallel loop collapse(2)
       do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
         h_v(i,J) = hv_cont(i,J,k)
       enddo ; enddo
     elseif (CS%use_land_mask) then
+      !$omp parallel loop collapse(2)
       do j=js-2,je+2 ; do I=is-2,Ieq+1
         h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
       enddo ; enddo
+      !$omp parallel loop collapse(2)
       do J=js-2,Jeq+1 ; do i=is-2,ie+2
         h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
       enddo ; enddo
     else
+      !$omp parallel loop collapse(2)
       do j=js-2,je+2 ; do I=is-2,Ieq+1
         h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
       enddo ; enddo
+      !$omp parallel loop collapse(2)
       do J=js-2,Jeq+1 ; do i=is-2,ie+2
         h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
       enddo ; enddo
     endif
+    !$omp end target
+
+    !$omp target update from(h_u, h_v)
 
     ! Adjust contributions to shearing strain and interpolated values of
     ! thicknesses on open boundaries.
@@ -2208,6 +2220,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   enddo ! end of k loop
 
   !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx)
+  !$omp target exit data map(delete: h_u, h_v)
+  !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
 
   ! TODO: This should should be permanently on the GPU
   !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
@@ -2215,7 +2229,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: CS)
 
   ! TODO: Do this outside of the function
-  !$omp target exit data map(delete: u, v)
+  !$omp target exit data map(delete: u, v, h)
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2984,19 +2984,18 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       ((G%isc-G%isd < 3) .or. (G%isc-G%isd < 3))) call MOM_error(FATAL, &
           "The minimum halo size is 3 when a Leith viscosity is being used.")
   if (CS%use_Leithy) then
-    do J=js-3,Jeq+2 ; do I=is-3,Ieq+2
+    do concurrent (I=is-3:Ieq+2, J=js-3:Jeq+2)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo ; enddo
+    enddo
   elseif ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
-    do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+    do concurrent (I=Isq-2:Ieq+2, J=Jsq-2:Jeq+2)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo ; enddo
+    enddo
   else
-    do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+    do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo ; enddo
+    enddo
   endif
-  !$omp target enter data map(to: CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)
 
   do concurrent (i=is-2:Ieq+2, j=js-2:Jeq+2)
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -667,8 +667,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! call pass_vector(slope_x, slope_y, G%Domain, halo=2)
   endif
 
-  !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx)
+  !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target enter data map(alloc: h_u, h_v)
+
+  ! TODO: NoSt, ShSt, ...?
 
   ! TODO: This should be computed (and stored?) on the GPU
   !$omp target enter data map(to: CS)
@@ -909,22 +911,26 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !$omp target update from(dvdx, dudy, h_u, h_v)
     endif
 
-    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx)
-    !$omp target update from(h_u, h_v)
-
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
+    !$omp target
     if (CS%no_slip) then
+      !$omp parallel loop collapse(2)
       do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
         sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
       enddo ; enddo
     else
+      !$omp parallel loop collapse(2)
       do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
         sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
       enddo ; enddo
     endif
+    !$omp end target
+
+    !$omp target update from(dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
+    !$omp target update from(h_u, h_v)
 
     if (CS%use_Leithy) then
       ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
@@ -2225,7 +2231,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! find_FrictWork and associated(mom_src)
   enddo ! end of k loop
 
-  !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx)
+  !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target exit data map(delete: h_u, h_v)
   !$omp target exit data map(delete: hu_cont, hv_cont) if (use_cont_huv)
 


### PR DESCRIPTION
Hi Marshall,

This is pull request to merge my gpu port of btstep, btcalc, bt_mass_source into dev/gpu.

* CPU perf is similar.
* data mapping occurs close to data initialization, with updates to/from GPU added as needed in `step_MOM_dyn_split_RK2`. 
* btcalc ports my `btcalc-gpufriendly` version.
* bt_mass_source also converts `jki` to seperated `kji` loop ordering. CPU performance is similar - probably because I commented out a couple statements that don't contribute to the result.