### PR TITLE
Barotropic: CS mem cleanup; remove btcalc copies 

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1549,6 +1549,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       CS%eta_cor(i,j) = sign(dt*CS%eta_cor_bound(i,j), CS%eta_cor(i,j))
     enddo
   endif ; endif
+
   do concurrent (j=js:je, i=is:ie)
     eta_src(i,j) = G%mask2dT(i,j) * (Instep * CS%eta_cor(i,j))
   enddo
@@ -1662,6 +1663,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     call uvchksum("BT Initial [uv]bt", ubt, vbt, CS%debug_BT_HI, haloshift=0, unscale=US%L_T_to_m_s)
     !$omp target update from(eta)
     call hchksum(eta, "BT Initial eta", CS%debug_BT_HI, haloshift=0, unscale=GV%H_to_MKS)
+    !$omp target update from(BT_force_u, BT_force_v)
     call uvchksum("BT BT_force_[uv]", BT_force_u, BT_force_v, &
                   CS%debug_BT_HI, haloshift=0, unscale=US%L_T2_to_m_s2)
     if (interp_eta_PF) then
@@ -4389,8 +4391,7 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   h_neglect = GV%H_subroundoff
 
-  !$omp target enter data map(alloc: hatutot, hatvtot, Ihatutot, Ihatvtot, CS, CS%frhatu, CS%frhatv) &
-  !$omp   map(to: h_u, h_v)
+  !$omp target enter data map(alloc: hatutot, hatvtot, Ihatutot, Ihatvtot)
 
   do concurrent (j=js:je, I=is-1:ie) ; hatutot(I,j) = 0.0 ; enddo
 
@@ -4572,10 +4573,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     CS%frhatv(i,J,k) = CS%frhatv(i,J,k) * Ihatvtot(i,J)
   enddo
 
-  !$omp target exit data map(release: hatutot, hatvtot, Ihatutot, Ihatvtot, h_u, h_v, CS) &
-  !$omp   map(from: CS%frhatu, CS%frhatv)
+  !$omp target exit data map(delete: hatutot, hatvtot, Ihatutot, Ihatvtot)
 
   if (CS%debug) then
+    !$omp target update from(CS%frhatu, CS%frhatv)
     call uvchksum("btcalc frhat[uv]", CS%frhatu, CS%frhatv, G%HI, &
                   haloshift=0, symmetric=.true., omit_corners=.true., &
                   scalar_pair=.true.)
@@ -4585,7 +4586,6 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
                     scalar_pair=.true.)
     call hchksum(h, "btcalc h", G%HI, haloshift=1, unscale=GV%H_to_MKS)
   endif
-
 end subroutine btcalc
 
 !> The function find_uhbt determines the zonal transport for a given velocity, or with
@@ -5243,7 +5243,7 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  !$omp target enter data map(alloc: eta_h)
+  !$omp target data map(alloc: eta_h)
 
   if (GV%Boussinesq) then
     do concurrent (j=js:je, i=is:ie)
@@ -5271,7 +5271,7 @@ subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
     enddo
   endif
 
-  !$omp target exit data map(release: eta_h)
+  !$omp end target data
 
 end subroutine bt_mass_source
 
@@ -5709,6 +5709,8 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   CS%frhatu(:,:,:) = 0.0 ; CS%frhatv(:,:,:) = 0.0
   CS%eta_cor(:,:) = 0.0
   CS%IDatu(:,:) = 0.0 ; CS%IDatv(:,:) = 0.0
+  !$omp target enter data map(to: CS%frhatu, CS%frhatv)
+  !$omp target enter data map(to: CS%eta_cor)
 
   CS%ua_polarity(:,:) = 1.0 ; CS%va_polarity(:,:) = 1.0
   call create_group_pass(pass_a_polarity, CS%ua_polarity, CS%va_polarity, CS%BT_domain, To_All, AGRID)
@@ -6072,6 +6074,7 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
 
   if (.NOT.query_initialized(CS%ubtav,"ubtav",restart_CS) .or. &
       .NOT.query_initialized(CS%vbtav,"vbtav",restart_CS)) then
+    !$omp target update to(CS, h)
     call btcalc(h, G, GV, CS, may_use_default=.true.)
     CS%ubtav(:,:) = 0.0 ; CS%vbtav(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do I=is-1,ie
@@ -6119,6 +6122,7 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
          ((Datu(I-1,j) + Datu(I,j)) + (Datv(i,J) + Datv(i,J-1)))
     enddo ; enddo
   endif
+  !$omp target enter data map(to: CS%eta_cor_bound)
 
   if (CS%gradual_BT_ICs) &
     call create_group_pass(pass_bt_hbt_btav, CS%ubt_IC, CS%vbt_IC, G%Domain)
@@ -6136,12 +6140,9 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
     id_clock_sync = cpu_clock_id('(Ocean BT global synch)', grain=CLOCK_ROUTINE)
 
   ! send initialized data to GPU
-  !$omp target enter data map(to: CS)
   !$omp target enter data map(to: CS%bathyT)
   !$omp target enter data map(to: CS%D_u_Cor, CS%D_v_Cor)
   !$omp target enter data map(to: CS%dx_Cv, CS%dy_Cu)
-  !$omp target enter data map(to: CS%eta_cor)
-  !$omp target enter data map(to: CS%frhatu, CS%frhatv)
   !$omp target enter data map(to: CS%IareaT, CS%IareaT_OBCmask)
   !$omp target enter data map(to: CS%IDatu, CS%IDatv)
   !$omp target enter data map(to: CS%IdxCu, CS%IdyCv)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1514,7 +1514,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   ! Set the mass source, after first initializing the halos to 0.
   do concurrent (j=jsvf-1:jevf+1, i=isvf-1:ievf+1) ; eta_src(i,j) = 0.0 ; enddo
   if (CS%bound_BT_corr) then ; if ((use_BT_Cont.or.integral_BT_cont) .and. CS%BT_cont_bounds) then
-    do concurrent (j=js:je, i=is:ie, G%mask2dT(i,j) > 0.0)
+    do concurrent (j=js:je, i=is:ie, G%mask2dT(i,j) > 0.0) local(u_max_cor, v_max_cor)
       if (CS%eta_cor(i,j) > 0.0) then
         !   Limit the source (outward) correction to be a fraction the mass that
         ! can be transported out of the cell by velocities with a CFL number of CFL_cor.
@@ -4889,6 +4889,7 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
   real :: dt ! The baroclinic timestep [T ~> s] or 1.0 [nondim]
   real, parameter :: C1_3 = 1.0/3.0  ! [nondim]
   integer :: i, j, is, ie, js, je, hs
+  real :: tmp
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   hs = max(halo,0)
@@ -4949,9 +4950,17 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
     BTCL_u(I,j)%uBT_EE = dt*uBT_EE(I,j)   ; BTCL_u(I,j)%uBT_WW = dt*uBT_WW(I,j)
     ! Check for reversed polarity in the tripolar halo regions.
     if (u_polarity(I,j) < 0.0) then
-      call swap(BTCL_u(I,j)%FA_u_EE, BTCL_u(I,j)%FA_u_WW)
-      call swap(BTCL_u(I,j)%FA_u_E0, BTCL_u(I,j)%FA_u_W0)
-      call swap(BTCL_u(I,j)%uBT_EE,  BTCL_u(I,j)%uBT_WW)
+      tmp = BTCL_u(I,j)%FA_u_EE
+      BTCL_u(I,j)%FA_u_EE = BTCL_u(I,j)%FA_u_WW
+      BTCL_u(I,j)%FA_u_WW = tmp
+
+      tmp = BTCL_u(I,j)%FA_u_E0
+      BTCL_u(I,j)%FA_u_E0 = BTCL_u(I,j)%FA_u_W0
+      BTCL_u(I,j)%FA_u_W0 = tmp
+
+      tmp = BTCL_u(I,j)%uBT_EE
+      BTCL_u(I,j)%uBT_EE = BTCL_u(I,j)%uBT_WW
+      BTCL_u(I,j)%uBT_WW = tmp
     endif
 
     BTCL_u(I,j)%uh_EE = BTCL_u(I,j)%uBT_EE * &
@@ -4965,15 +4974,24 @@ subroutine set_local_BT_cont_types(BT_cont, BTCL_u, BTCL_v, G, US, MS, BT_Domain
     if (abs(BTCL_u(I,j)%uBT_EE) > 0.0) BTCL_u(I,j)%uh_crvE = &
       (C1_3 * (BTCL_u(I,j)%FA_u_EE - BTCL_u(I,j)%FA_u_E0)) / BTCL_u(I,j)%uBT_EE**2
   enddo
+
   do concurrent (J=js-hs-1:je+hs, i=is-hs:ie+hs)
     BTCL_v(i,J)%FA_v_NN = FA_v_NN(i,J) ; BTCL_v(i,J)%FA_v_N0 = FA_v_N0(i,J)
     BTCL_v(i,J)%FA_v_S0 = FA_v_S0(i,J) ; BTCL_v(i,J)%FA_v_SS = FA_v_SS(i,J)
     BTCL_v(i,J)%vBT_NN = dt*vBT_NN(i,J)   ; BTCL_v(i,J)%vBT_SS = dt*vBT_SS(i,J)
     ! Check for reversed polarity in the tripolar halo regions.
     if (v_polarity(i,J) < 0.0) then
-      call swap(BTCL_v(i,J)%FA_v_NN, BTCL_v(i,J)%FA_v_SS)
-      call swap(BTCL_v(i,J)%FA_v_N0, BTCL_v(i,J)%FA_v_S0)
-      call swap(BTCL_v(i,J)%vBT_NN,  BTCL_v(i,J)%vBT_SS)
+      tmp = BTCL_v(i,J)%FA_v_NN
+      BTCL_v(i,J)%FA_v_NN = BTCL_v(i,J)%FA_v_SS
+      BTCL_v(i,J)%FA_v_SS = tmp
+
+      tmp = BTCL_v(i,J)%FA_v_N0
+      BTCL_v(i,J)%FA_v_N0 = BTCL_v(i,J)%FA_v_S0
+      BTCL_v(i,J)%FA_v_S0 = tmp
+
+      tmp = BTCL_v(i,J)%vBT_NN
+      BTCL_v(i,J)%vBT_NN = BTCL_v(i,J)%vBT_SS
+      BTCL_v(i,J)%vBT_SS = tmp
     endif
 
     BTCL_v(i,J)%vh_NN = BTCL_v(i,J)%vBT_NN * &

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3560,6 +3560,7 @@ subroutine set_dtbt(G, GV, US, CS, pbce, gtot_est, BT_cont, eta, SSH_add)
       gtot_E(i,j) = 0.0 ; gtot_W(i,j) = 0.0
       gtot_N(i,j) = 0.0 ; gtot_S(i,j) = 0.0
     enddo ; enddo
+    !$omp target update from(CS%frhatu, CS%frhatv)
     do k=1,nz ; do j=js,je ; do i=is,ie
       gtot_E(i,j) = gtot_E(i,j) + pbce(i,j,k) * CS%frhatu(I,j,k)
       gtot_W(i,j) = gtot_W(i,j) + pbce(i,j,k) * CS%frhatu(I-1,j,k)
@@ -5731,8 +5732,6 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   CS%frhatu(:,:,:) = 0.0 ; CS%frhatv(:,:,:) = 0.0
   CS%eta_cor(:,:) = 0.0
   CS%IDatu(:,:) = 0.0 ; CS%IDatv(:,:) = 0.0
-  !$omp target enter data map(to: CS%frhatu, CS%frhatv)
-  !$omp target enter data map(to: CS%eta_cor)
 
   CS%ua_polarity(:,:) = 1.0 ; CS%va_polarity(:,:) = 1.0
   call create_group_pass(pass_a_polarity, CS%ua_polarity, CS%va_polarity, CS%BT_domain, To_All, AGRID)
@@ -6091,12 +6090,16 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
     endif
   endif
 
+  !$omp target enter data map(to: CS)
+  !$omp target enter data map(to: CS%frhatu, CS%frhatv)
+  !$omp target enter data map(to: CS%eta_cor)
+
   if (CS%id_frhatu1 > 0) allocate(CS%frhatu1(IsdB:IedB,jsd:jed,nz), source=0.)
   if (CS%id_frhatv1 > 0) allocate(CS%frhatv1(isd:ied,JsdB:JedB,nz), source=0.)
 
   if (.NOT.query_initialized(CS%ubtav,"ubtav",restart_CS) .or. &
       .NOT.query_initialized(CS%vbtav,"vbtav",restart_CS)) then
-    !$omp target update to(CS, h)
+    !$omp target update to(h)
     call btcalc(h, G, GV, CS, may_use_default=.true.)
     CS%ubtav(:,:) = 0.0 ; CS%vbtav(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do I=is-1,ie

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4416,20 +4416,22 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       e_u(I,j,nz+1) = -0.5 * Z_to_H * (G%bathyT(i+1,j) + G%bathyT(i,j))
       D_shallow_u(I,j) = -Z_to_H * min(G%bathyT(i+1,j), G%bathyT(i,j))
     enddo
-    do concurrent (k=1:nz, j=js:je, I=is-1:ie)
-      e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
-      h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
-      if (e_u(I,j,K+1) >= D_shallow_u(I,j)) then
-        CS%frhatu(I,j,k) = h_arith
-      else
-        h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
-        if (e_u(I,j,K) <= D_shallow_u(I,j)) then
-          CS%frhatu(I,j,k) = h_harm
+    do k=nz,1,-1
+      do concurrent (j=js:je, I=is-1:ie)
+        e_u(I,j,K) = e_u(I,j,K+1) + 0.5 * (h(i+1,j,k) + h(i,j,k))
+        h_arith = 0.5 * (h(i+1,j,k) + h(i,j,k))
+        if (e_u(I,j,K+1) >= D_shallow_u(I,j)) then
+          CS%frhatu(I,j,k) = h_arith
         else
-          wt_arith = (e_u(I,j,K) - D_shallow_u(I,j)) / (h_arith + h_neglect)
-          CS%frhatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+          h_harm = (h(i+1,j,k) * h(i,j,k)) / (h_arith + h_neglect)
+          if (e_u(I,j,K) <= D_shallow_u(I,j)) then
+            CS%frhatu(I,j,k) = h_harm
+          else
+            wt_arith = (e_u(I,j,K) - D_shallow_u(I,j)) / (h_arith + h_neglect)
+            CS%frhatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+          endif
         endif
-      endif
+      enddo
     enddo
     !$omp end target data
     do concurrent (j=js:je, I=is-1:ie) ; do k=1,nz
@@ -4507,20 +4509,22 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
       e_v(i,J,nz+1) = -0.5 * Z_to_H * (G%bathyT(i,j+1) + G%bathyT(i,j))
       D_shallow_v(i,J) = -Z_to_H * min(G%bathyT(i,j+1), G%bathyT(i,j))
     enddo
-    do concurrent (k=1:nz, J=js-1:je, i=is:ie)
-      e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
-      h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
-      if (e_v(i,J,K+1) >= D_shallow_v(i,J)) then
-        CS%frhatv(i,J,k) = h_arith
-      else
-        h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
-        if (e_v(i,J,K) <= D_shallow_v(i,J)) then
-          CS%frhatv(i,J,k) = h_harm
+    do k=nz,1,-1
+      do concurrent (J=js-1:je, i=is:ie)
+        e_v(i,J,K) = e_v(i,J,K+1) + 0.5 * (h(i,j+1,k) + h(i,j,k))
+        h_arith = 0.5 * (h(i,j+1,k) + h(i,j,k))
+        if (e_v(i,J,K+1) >= D_shallow_v(i,J)) then
+          CS%frhatv(i,J,k) = h_arith
         else
-          wt_arith = (e_v(i,J,K) - D_shallow_v(i,J)) / (h_arith + h_neglect)
-          CS%frhatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+          h_harm = (h(i,j+1,k) * h(i,j,k)) / (h_arith + h_neglect)
+          if (e_v(i,J,K) <= D_shallow_v(i,J)) then
+            CS%frhatv(i,J,k) = h_harm
+          else
+            wt_arith = (e_v(i,J,K) - D_shallow_v(i,J)) / (h_arith + h_neglect)
+            CS%frhatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
+          endif
         endif
-      endif
+      enddo
     enddo
     !$omp end target data
     do concurrent (J=js-1:je, i=is:ie) ; do k=1,nz

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -689,17 +689,25 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
-  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel, CS%visc_rem_u, CS%visc_rem_v)
-  !$omp target update to(CS%BT_cont%FA_u_E0, CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, &
-  !$omp   CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, &
-  !$omp   CS%BT_cont%uBT_EE, CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
+  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
+  !$omp target update to(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
+  !$omp target update to(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
+  !$omp target update to(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
+  !$omp target update to(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
+  !$omp target update to(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
+  !$omp target update to(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt, CS%BT_cont%FA_u_E0, CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, &
-  !$omp   CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, &
-  !$omp   CS%BT_cont%uBT_EE, CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt)
+  !$omp target update from(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
+  !$omp target update from(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
+  !$omp target update from(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
+  !$omp target update from(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
+  !$omp target update from(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
+  !$omp target update from(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
   if (showCallTree) call callTree_leave("btstep()")
   call cpu_clock_end(id_clock_btstep)
 
@@ -979,18 +987,26 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the corrector step call to btstep.
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, u_bc_accel, v_bc_accel, CS%BT_cont%FA_u_E0, &
-  !$omp   CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, &
-  !$omp   CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, CS%BT_cont%uBT_EE, &
-  !$omp   CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
+  !$omp target update to(u_bc_accel, v_bc_accel)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
+  !$omp target update to(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
+  !$omp target update to(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
+  !$omp target update to(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
+  !$omp target update to(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
+  !$omp target update to(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
+  !$omp target update to(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt, eta_pred)
-  !$omp target update from(CS%BT_cont%FA_u_E0, CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_W0, &
-  !$omp   CS%BT_cont%FA_u_WW, CS%BT_cont%FA_v_N0, CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS, &
-  !$omp   CS%BT_cont%uBT_EE, CS%BT_cont%uBT_WW, CS%BT_cont%vBT_NN, CS%BT_cont%vBT_SS)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
+  !$omp target update from(CS%uhbt, CS%vhbt, eta_pred)
+  !$omp target update from(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
+  !$omp target update from(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
+  !$omp target update from(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
+  !$omp target update from(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
+  !$omp target update from(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
+  !$omp target update from(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -638,8 +638,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   call cpu_clock_begin(id_clock_btcalc)
   ! Calculate the relative layer weights for determining barotropic quantities.
-  if (.not.BT_cont_BT_thick) &
+  if (.not.BT_cont_BT_thick) then
+    !$omp target update to(h)
     call btcalc(h, G, GV, CS%barotropic_CSp, OBC=CS%OBC)
+  endif
   call bt_mass_source(h, eta, .true., G, GV, CS%barotropic_CSp)
 
   SpV_avg(:,:) = 0.0
@@ -662,6 +664,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     !$omp target update to(CS%BT_cont%h_u, CS%BT_cont%h_v)
     call cpu_clock_end(id_clock_continuity)
     if (BT_cont_BT_thick) then
+      !$omp target update to(h, CS%BT_cont%h_u, CS%BT_cont%h_v)
       call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
                   OBC=CS%OBC)
     endif
@@ -894,6 +897,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
 
   if (BT_cont_BT_thick) then
+    !$omp target update to(h, CS%BT_cont%h_u, CS%BT_cont%h_v)
     call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
                 OBC=CS%OBC)
     if (showCallTree) call callTree_wayPoint("done with btcalc[BT_cont_BT_thick] (step_MOM_dyn_split_RK2)")
@@ -1651,6 +1655,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   ! Copy eta into an output array.
   do j=js,je ; do i=is,ie ; eta(i,j) = CS%eta(i,j) ; enddo ; enddo
 
+  !$omp target enter data map(alloc: CS%barotropic_CSp)
   call barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, &
                        CS%barotropic_CSp, restart_CS, calc_dtbt, CS%BT_cont, &
                        CS%OBC, CS%SAL_CSp, HA_CSp)
@@ -1949,6 +1954,7 @@ end subroutine initialize_dyn_split_RK2
 subroutine end_dyn_split_RK2(CS)
   type(MOM_dyn_split_RK2_CS), pointer :: CS  !< module control structure
 
+  !$omp target exit data map(delete: CS%barotropic_CSp)
   call barotropic_end(CS%barotropic_CSp)
 
   call vertvisc_end(CS%vertvisc_CSp)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1672,7 +1672,6 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   ! Copy eta into an output array.
   do j=js,je ; do i=is,ie ; eta(i,j) = CS%eta(i,j) ; enddo ; enddo
 
-  !$omp target enter data map(alloc: CS%barotropic_CSp)
   call barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, &
                        CS%barotropic_CSp, restart_CS, calc_dtbt, CS%BT_cont, &
                        CS%OBC, CS%SAL_CSp, HA_CSp)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -661,7 +661,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call cpu_clock_begin(id_clock_continuity)
     call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                     visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, BT_cont=CS%BT_cont)
-    !$omp target update to(CS%BT_cont%h_u, CS%BT_cont%h_v)
     call cpu_clock_end(id_clock_continuity)
     if (BT_cont_BT_thick) then
       !$omp target update to(h, CS%BT_cont%h_u, CS%BT_cont%h_v)
@@ -816,7 +815,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av, BT_cont=CS%BT_cont)
   call cpu_clock_end(id_clock_continuity)
-  !$omp target update to(CS%BT_cont%h_u, CS%BT_cont%h_v)
   if (showCallTree) call callTree_wayPoint("done with continuity (step_MOM_dyn_split_RK2)")
 
   call do_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
@@ -1678,7 +1676,6 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
 
   if (.not. query_initialized(CS%diffu, "diffu", restart_CS) .or. &
       .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
-    ! TODO: Cleanup BT_cont%h_[uv] handling
     !$omp target update to(u, v, h, uh, vh)
     call horizontal_viscosity(u, v, h, uh, vh, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
                               tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -576,13 +576,13 @@ subroutine alloc_BT_cont_type(BT_cont, G, GV, alloc_faces)
     "alloc_BT_cont_type called with an associated BT_cont_type pointer.")
 
   allocate(BT_cont)
+  !$omp target enter data map(to: BT_cont)
   allocate(BT_cont%FA_u_WW(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%FA_u_W0(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%FA_u_E0(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%FA_u_EE(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%uBT_WW(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%uBT_EE(IsdB:IedB,jsd:jed), source=0.0)
-  !$omp target enter data map(alloc: BT_cont) ! map(to: BT_cont) results in cuda memory access errors elsewhere...
   !$omp target enter data map(to: BT_cont%FA_u_WW, BT_cont%FA_u_W0, BT_cont%FA_u_E0, &
   !$omp   BT_cont%FA_u_EE, BT_cont%uBT_WW, BT_cont%uBT_EE)
 
@@ -621,10 +621,13 @@ subroutine dealloc_BT_cont_type(BT_cont)
   deallocate(BT_cont%FA_v_N0) ; deallocate(BT_cont%FA_v_NN)
   deallocate(BT_cont%vBT_SS)  ; deallocate(BT_cont%vBT_NN)
 
-  !$omp target exit data map(release: BT_cont%h_u, BT_cont%h_v)
-  if (allocated(BT_cont%h_u)) deallocate(BT_cont%h_u)
-  if (allocated(BT_cont%h_v)) deallocate(BT_cont%h_v)
+  ! These are always allocated in pairs.
+  if (allocated(BT_cont%h_u) .and. allocated(BT_cont%h_v)) then
+    !$omp target exit data map(release: BT_cont%h_u, BT_cont%h_v)
+    deallocate(BT_cont%h_u, BT_cont%h_v)
+  endif
 
+  !$omp target exit data map(delete: BT_cont)
   deallocate(BT_cont)
 
 end subroutine dealloc_BT_cont_type

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -583,8 +583,9 @@ subroutine alloc_BT_cont_type(BT_cont, G, GV, alloc_faces)
   allocate(BT_cont%FA_u_EE(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%uBT_WW(IsdB:IedB,jsd:jed), source=0.0)
   allocate(BT_cont%uBT_EE(IsdB:IedB,jsd:jed), source=0.0)
-  !$omp target enter data map(to: BT_cont%FA_u_WW, BT_cont%FA_u_W0, BT_cont%FA_u_E0, &
-  !$omp   BT_cont%FA_u_EE, BT_cont%uBT_WW, BT_cont%uBT_EE)
+  !$omp target enter data map(to: BT_cont%FA_u_WW, BT_cont%FA_u_W0)
+  !$omp target enter data map(to: BT_cont%FA_u_E0, BT_cont%FA_u_EE)
+  !$omp target enter data map(to: BT_cont%uBT_WW, BT_cont%uBT_EE)
 
   allocate(BT_cont%FA_v_SS(isd:ied,JsdB:JedB), source=0.0)
   allocate(BT_cont%FA_v_S0(isd:ied,JsdB:JedB), source=0.0)
@@ -592,8 +593,9 @@ subroutine alloc_BT_cont_type(BT_cont, G, GV, alloc_faces)
   allocate(BT_cont%FA_v_NN(isd:ied,JsdB:JedB), source=0.0)
   allocate(BT_cont%vBT_SS(isd:ied,JsdB:JedB), source=0.0)
   allocate(BT_cont%vBT_NN(isd:ied,JsdB:JedB), source=0.0)
-  !$omp target enter data map(to: BT_cont%FA_v_SS, BT_cont%FA_v_S0, BT_cont%FA_v_N0, &
-  !$omp   BT_cont%FA_v_NN, BT_cont%vBT_SS, BT_cont%vBT_NN)
+  !$omp target enter data map(to: BT_cont%FA_v_SS, BT_cont%FA_v_S0)
+  !$omp target enter data map(to: BT_cont%FA_v_N0, BT_cont%FA_v_NN)
+  !$omp target enter data map(to: BT_cont%vBT_SS, BT_cont%vBT_NN)
 
   if (present(alloc_faces)) then ; if (alloc_faces) then
     allocate(BT_cont%h_u(IsdB:IedB,jsd:jed,1:nz), source=0.0)
@@ -609,27 +611,28 @@ subroutine dealloc_BT_cont_type(BT_cont)
 
   if (.not.associated(BT_cont)) return
 
-  !$omp target exit data map(release: BT_cont, BT_cont%FA_u_WW, BT_cont%FA_u_W0, BT_cont%FA_u_E0, &
-  !$omp   BT_cont%FA_u_EE, BT_cont%uBT_WW, BT_cont%uBT_EE)
-  deallocate(BT_cont%FA_u_WW) ; deallocate(BT_cont%FA_u_W0)
-  deallocate(BT_cont%FA_u_E0) ; deallocate(BT_cont%FA_u_EE)
+  !$omp target exit data map(delete: BT_cont%FA_u_EE, BT_cont%FA_u_E0)
+  !$omp target exit data map(delete: BT_cont%FA_u_W0, BT_cont%FA_u_WW)
+  !$omp target exit data map(delete: BT_cont%uBT_WW, BT_cont%uBT_EE)
+  deallocate(BT_cont%FA_u_EE) ; deallocate(BT_cont%FA_u_E0)
+  deallocate(BT_cont%FA_u_W0) ; deallocate(BT_cont%FA_u_WW)
   deallocate(BT_cont%uBT_WW)  ; deallocate(BT_cont%uBT_EE)
 
-  !$omp target exit data map(release: BT_cont%FA_v_SS, BT_cont%FA_v_S0, BT_cont%FA_v_N0, &
-  !$omp   BT_cont%FA_v_NN, BT_cont%vBT_SS, BT_cont%vBT_NN)
-  deallocate(BT_cont%FA_v_SS) ; deallocate(BT_cont%FA_v_S0)
-  deallocate(BT_cont%FA_v_N0) ; deallocate(BT_cont%FA_v_NN)
+  !$omp target exit data map(delete: BT_cont%FA_v_NN, BT_cont%FA_v_N0)
+  !$omp target exit data map(delete: BT_cont%FA_v_S0, BT_cont%FA_v_SS)
+  !$omp target exit data map(delete: BT_cont%vBT_SS, BT_cont%vBT_NN)
+  deallocate(BT_cont%FA_v_NN) ; deallocate(BT_cont%FA_v_N0)
+  deallocate(BT_cont%FA_v_S0) ; deallocate(BT_cont%FA_v_SS)
   deallocate(BT_cont%vBT_SS)  ; deallocate(BT_cont%vBT_NN)
 
   ! These are always allocated in pairs.
   if (allocated(BT_cont%h_u) .and. allocated(BT_cont%h_v)) then
-    !$omp target exit data map(release: BT_cont%h_u, BT_cont%h_v)
+    !$omp target exit data map(delete: BT_cont%h_u, BT_cont%h_v)
     deallocate(BT_cont%h_u, BT_cont%h_v)
   endif
 
   !$omp target exit data map(delete: BT_cont)
   deallocate(BT_cont)
-
 end subroutine dealloc_BT_cont_type
 
 !> Diagnostic checksums on various elements of a thermo_var_ptrs type for debugging.


### PR DESCRIPTION
This patch replaces the safer barotropic CS alloc/delete inside of
btcalc and replaces it with a persistent CS created by barotropic_init.

A difficulty here is that btcalc is called by both the dynamic core step
function (e.g. stype_dyn_split_RK2) as well as barotropic_init, meaning
that it needs to be partially set up before btcalc can be called to
finialize the barotropic setup.

This is mostly a matter of timing each event so that the GPU state is
not out of sync with any of the CPU operations.

I'm not going to pretend that I understand everything here.  Multiple
attempts failed, and this is the one that worked.  We still have some
lessons to learn about CS initialization.