### PR TITLE
Continuity ppm port to gpu

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -962,9 +962,11 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       if (associated(CS%HA_CSp)) call HA_accum_FtF(Time_Local, CS%HA_CSp)
 
+      !$omp target enter data map(to: dt)
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_tradv_here, bbl_time_int, CS, &
                              Time_local, Waves=Waves)
+      !$omp target exit data map(release: dt)
 
       !===========================================================================
       ! This is the start of the tracer advection part of the algorithm.
@@ -2371,6 +2373,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ! Determining the internal unit scaling factors for this run.
   call unit_scaling_init(param_file, CS%US)
   US => CS%US
+  !$omp target enter data map(to: CS%US)
 
   ! Read relevant parameters and write them to the model log.
   call log_version(param_file, "MOM", version, "", log_to_all=.true., layout=.true., debugging=.true.)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1264,6 +1264,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     call disable_averaging(CS%diag)
     call pass_vector(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV, &
                      G%Domain, direction=To_All+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
+    !$omp target update to(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV)
   endif
 
   ! The bottom boundary layer properties need to be recalculated.
@@ -3068,6 +3069,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   allocate(CS%pbv%por_face_areaV(isd:ied,JsdB:JedB,nz), source=1.0)
   allocate(CS%pbv%por_layer_widthU(IsdB:IedB,jsd:jed,nz+1), source=1.0)
   allocate(CS%pbv%por_layer_widthV(isd:ied,JsdB:JedB,nz+1), source=1.0)
+  !$omp target enter data map(to: CS%pbv)
+  !$omp target enter data map(to: CS%pbv%por_face_areaU, CS%pbv%por_face_areaV)
 
   ! Use the Wright equation of state by default, unless otherwise specified
   ! Note: this line and the following block ought to be in a separate
@@ -4504,6 +4507,7 @@ subroutine MOM_end(CS)
   if (CS%use_ALE_algorithm) call ALE_end(CS%ALE_CSp)
 
   !deallocate porous topography variables
+  !$omp target exit data map(release: CS%pbv%por_face_areaU, CS%pbv%por_face_areaV)
   deallocate(CS%pbv%por_face_areaU) ; deallocate(CS%pbv%por_face_areaV)
   deallocate(CS%pbv%por_layer_widthU) ; deallocate(CS%pbv%por_layer_widthV)
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1703,6 +1703,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       call hchksum(eta_PF_1, "BT eta_PF_1",CS%debug_BT_HI,haloshift=0, unscale=GV%H_to_MKS)
       call hchksum(d_eta_PF, "BT d_eta_PF",CS%debug_BT_HI,haloshift=0, unscale=GV%H_to_MKS)
     else
+      !$omp target update from(eta_PF, eta_PF_in)
       call hchksum(eta_PF, "BT eta_PF",CS%debug_BT_HI,haloshift=0, unscale=GV%H_to_MKS)
       call hchksum(eta_PF_in, "BT eta_PF_in",G%HI,haloshift=0, unscale=GV%H_to_MKS)
     endif
@@ -4667,10 +4668,14 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
     call uvchksum("btcalc frhat[uv]", CS%frhatu, CS%frhatv, G%HI, &
                   haloshift=0, symmetric=.true., omit_corners=.true., &
                   scalar_pair=.true.)
-    if (present(h_u) .and. present(h_v)) &
+
+    if (present(h_u) .and. present(h_v)) then
+      !$omp target update from(h_u, h_v)
       call uvchksum("btcalc h_[uv]", h_u, h_v, G%HI, haloshift=0, &
                     symmetric=.true., omit_corners=.true., unscale=GV%H_to_MKS, &
                     scalar_pair=.true.)
+    endif
+
     call hchksum(h, "btcalc h", G%HI, haloshift=1, unscale=GV%H_to_MKS)
   endif
 end subroutine btcalc

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2921,12 +2921,12 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
   endif ; enddo ; enddo
 
   if (.not.domore) then
-    do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh
+    do j=jsh-1,jeh ; do i=ish,ieh
       BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
       BT_cont%vBT_SS(i,J) = 0.0
       BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
       BT_cont%vBT_NN(i,J) = 0.0
-    enddo ; enddo ; enddo
+    enddo ; enddo
     return
   endif
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2148,7 +2148,7 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
   ! This sets vh and dvhdv.
   do concurrent (k=1:nz, J=jsh-1:jeh, i=ish:ieh)
     call flux_elem(v(i,J,k), h_in(i,J,k), h_in(i,J+1,k), h_S(i,J,k), h_S(i,J+1,k), &
-                   h_N(i,J,k), h_N(i,J+1,k), vh(i,J,k), dvhdv(i,J,k), 1.0, G%dx_Cv, &
+                   h_N(i,J,k), h_N(i,J+1,k), vh(i,J,k), dvhdv(i,J,k), 1.0, G%dx_Cv(I,j), &
                    G%IareaT(i,J), G%IareaT(i,J+1), G%IdyT(i,J), G%IdyT(i,J+1), dt, G, GV, &
                    US, CS%vol_CFL, por_face_areaV(i,J,k))
     if (local_specified_BC) &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1229,7 +1229,9 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
   !$omp       du_max_CFL(ish-1:ieh, jsh:jeh), du_min_CFL(ish-1:ieh, jsh:jeh), &
   !$omp       uh_tot_0(ish-1:ieh, jsh:jeh), uhbt(ish-1:ieh, jsh:jeh), &
   !$omp       duhdu_tot_0(ish-1:ieh, jsh:jeh), G, G%IareaT(ish-1:ieh+1, jsh:jeh), CS, &
-  !$omp       u(ish-1:ieh, :, :), visc_rem(ish-1:ieh, :, :)) &
+  !$omp       u(ish-1:ieh, :, :), visc_rem(ish-1:ieh, :, :), h_W(ish-1:ieh+1, :, :), &
+  !$omp       h_E(ish-1:ieh+1, :, :), h_in(ish-1:ieh+1, :, :), G%dy_Cu(ish-1:ieh, jsh:jeh), &
+  !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), por_face_areaU(ish-1:ieh, :, :)) &
   !$omp   map(alloc: uh_aux(ish-1:ieh, :, :), duhdu(ish-1:ieh, :, :), du(ish-1:ieh, jsh:jeh), &
   !$omp       do_I(ish-1:ieh, jsh:jeh), du_max(ish-1:ieh, jsh:jeh), du_min(ish-1:ieh, jsh:jeh), &
   !$omp       duhdu_tot(ish-1:ieh, jsh:jeh), uh_err(ish-1:ieh, jsh:jeh), &
@@ -1367,7 +1369,10 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
   !$omp       duhdu_tot_0(ish-1:ieh, jsh:jeh), do_I(ish-1:ieh, jsh:jeh), du_max(ish-1:ieh, jsh:jeh), &
   !$omp       du_min(ish-1:ieh, jsh:jeh), duhdu_tot(ish-1:ieh, jsh:jeh), uh_err(ish-1:ieh, jsh:jeh), &
   !$omp       uh_err_best(ish-1:ieh, jsh:jeh), G, G%IareaT(ish-1:ieh+1, jsh:jeh), CS, &
-  !$omp       u(ish-1:ieh, :, :), visc_rem(ish-1:ieh, :, :), u_new(ish-1:ieh, :, :))
+  !$omp       u(ish-1:ieh, :, :), visc_rem(ish-1:ieh, :, :), u_new(ish-1:ieh, :, :), &
+  !$omp       h_W(ish-1:ieh+1, :, :), h_E(ish-1:ieh+1, :, :), h_in(ish-1:ieh+1, :, :), &
+  !$omp       G%dy_Cu(ish-1:ieh, jsh:jeh), G%IdxT(ish-1:ieh+1, jsh:jeh), &
+  !$omp       por_face_areaU(ish-1:ieh, :, :))
 
 end subroutine zonal_flux_adjust
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -661,10 +661,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
         visc_rem_u_tmp(i,j,k) = visc_rem_u(i,j,k)
       enddo
     end if
-
-    do concurrent (i=ish-1:ieh)
-      do_I(i, j) = .true.
-    enddo
   
     ! Set uh and duhdu.
     do concurrent (k=1:nz , I=ish-1:ieh)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -167,7 +167,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   !$omp   map(to: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
   !$omp     G%mask2dT, G%dx_Cv, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h, CS, US, OBC, pbv, &
   !$omp     pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, BT_cont, &
-  !$omp     hin) &
+  !$omp     hin, dt) &
   !$omp   map(alloc: h_W, h_E, h_S, h_N, uh, vh, u_cor, v_cor, du_cor, dv_cor, BT_cont%FA_u_E0, &
   !$omp     BT_cont%FA_u_W0, BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, &
   !$omp     BT_cont%FA_v_NN, BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, &
@@ -225,7 +225,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   !$omp   map(release: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
   !$omp     G%mask2dT, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h_W, h_E, h_S, h_N, CS, US, &
   !$omp     OBC, pbv, pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, &
-  !$omp     LB, hin)
+  !$omp     LB, hin, dt)
 
 end subroutine continuity_PPM
 
@@ -1730,13 +1730,7 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   !$omp   map(alloc: dvhdv, dv, dv_min_CFL, dv_max_CFL, dvhdv_tot_0, vh_tot_0, visc_rem_max, &
   !$omp     visc_rem_v_tmp)
 
-  !$omp target loop private(i, k) &
-  !$omp   map(to: G, G%dx_Cv, G%IdyT, G%dyT, G%mask2dCv, G%areaT, G%IareaT, v, h_in, h_S, &
-  !$omp     h_N, CS, por_face_areaV, vhbt, visc_rem_v) &
-  !$omp   map(from: vh, dv_cor, dv_min_CFL, dv_max_CFL, dvhdv_tot_0, vh_tot_0, visc_rem_max, &
-  !$omp     visc_rem_v_tmp) &
-  !$omp   map(alloc: dvhdv)
-  do J=jsh-1,jeh
+  do concurrent (J=jsh-1:jeh)
 
     if (present(dv_cor)) then
       do concurrent (i=ish:ieh)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1841,34 +1841,37 @@ end subroutine meridional_BT_mass_flux
 !> Evaluates the meridional mass or volume fluxes in a layer.
 subroutine merid_flux_layer_fused(v, h, h_S, h_N, vh, dvhdv, visc_rem, dt, G, GV, US, &
                             ish, ieh, jsh, jeh, nz, do_I, vol_CFL, por_face_areaV, OBC)
-  type(ocean_grid_type),        intent(in)    :: G        !< Ocean's grid structure.
-  type(verticalGrid_type),      intent(in)    :: GV       !< Ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)),     intent(in)    :: v        !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)),     intent(in)    :: visc_rem !< Both the fraction of the
+  type(ocean_grid_type),                      intent(in)    :: G        !< Ocean's grid structure.
+  type(verticalGrid_type),                    intent(in)    :: GV       !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)    :: v        !< Meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)    :: visc_rem !< Both the fraction of the
          !! momentum originally in a layer that remains after a time-step
          !! of viscosity, and the fraction of a time-step's worth of a barotropic
          !! acceleration that a layer experiences after viscosity is applied [nondim].
          !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in) :: h      !< Layer thickness used to calculate fluxes,
-                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in) :: h_S    !< South edge thickness in the reconstruction
-                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in) :: h_N    !< North edge thickness in the reconstruction
-                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: vh       !< Meridional mass or volume transport
-                                                          !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)),  intent(inout) :: dvhdv    !< Partial derivative of vh with v
-                                                          !! [H L ~> m2 or kg m-1].
-  real,                         intent(in)    :: dt       !< Time increment [T ~> s].
-  type(unit_scale_type),        intent(in)    :: US       !< A dimensional unit scaling type
-  integer,                      intent(in)    :: ish,jsh      !< Start of index range.
-  integer,                      intent(in)    :: ieh,jeh,nz      !< End of index range.
-  logical, dimension(SZI_(G),SZJB_(G)),  intent(in)    :: do_I     !< Which i values to work on.
-  logical,                      intent(in)    :: vol_CFL  !< If true, rescale the
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h       !< Layer thickness used to calculate fluxes,
+                                                                       !! [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_S     !< South edge thickness in the reconstruction
+                                                                       !! [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_N     !< North edge thickness in the reconstruction
+                                                                       !! [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: vh      !< Meridional mass or volume transport
+                                                                       !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: dvhdv   !< Partial derivative of vh with v
+                                                                       !! [H L ~> m2 or kg m-1].
+  real,                                       intent(in)    :: dt      !< Time increment [T ~> s].
+  type(unit_scale_type),                      intent(in)    :: US      !< A dimensional unit scaling type
+  integer,                                    intent(in)    :: ish     !< Start of i index range.
+  integer,                                    intent(in)    :: ieh     !< End of i index range.
+  integer,                                    intent(in)    :: jsh     !< End of j index range.
+  integer,                                    intent(in)    :: jeh     !< End of j index range.
+  integer,                                    intent(in)    :: nz      !< End of k index range.
+  logical, dimension(SZI_(G),SZJB_(G)),       intent(in)    :: do_I    !< Which i values to work on.
+  logical,                                    intent(in)    :: vol_CFL !< If true, rescale the
          !! ratio of face areas to the cell areas when estimating the CFL number.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                             intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
-  type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
+                                              intent(in)    :: por_face_areaV !< fractional open area of V-faces [nondim]
+  type(ocean_OBC_type),                   optional, pointer :: OBC !< Open boundaries control structure.
   ! Local variables
   real :: CFL ! The CFL number based on the local velocity and grid spacing [nondim]
   real :: curv_3 ! A measure of the thickness curvature over a grid length,

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1335,10 +1335,12 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
     if (itt < max_itts) then
       do concurrent (j=jsh:jeh, I=ish-1:ieh)
         uh_err(I,j) = -uhbt(I,j) ; duhdu_tot(i,j) = 0.0
-        do k=1,nz
-          uh_err(I,j) = uh_err(I,j) + uh_aux(I,j,k)
-          duhdu_tot(I,j) = duhdu_tot(I,j) + duhdu(I,j,k)
-        enddo
+      enddo
+      do k=1,nz ; do concurrent (j=jsh:jeh, I=ish-1:ieh)
+        uh_err(I,j) = uh_err(I,j) + uh_aux(I,j,k)
+        duhdu_tot(I,j) = duhdu_tot(I,j) + duhdu(I,j,k)
+      enddo ; enddo
+      do concurrent (j=jsh:jeh, I=ish-1:ieh)
         uh_err_best(I,j) = min(uh_err_best(I,j), abs(uh_err(I,j)))
       enddo
     endif
@@ -2334,10 +2336,12 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0
     if (itt < max_itts) then
       do concurrent (j=jsh-1:jeh, i=ish:ieh)
         vh_err(i,j) = -vhbt(i,j) ; dvhdv_tot(i,j) = 0.0
-        do k=1,nz
-          vh_err(i,j) = vh_err(i,j) + vh_aux(i,j,k)
-          dvhdv_tot(i,j) = dvhdv_tot(i,j) + dvhdv(i,j,k)
-        enddo
+      enddo
+      do k = 1,nz ; do concurrent (j=jsh-1:jeh, i=ish:ieh)
+        vh_err(i,j) = vh_err(i,j) + vh_aux(i,j,k)
+        dvhdv_tot(i,j) = dvhdv_tot(i,j) + dvhdv(i,j,k)
+      enddo ; enddo
+      do concurrent (j=jsh-1:jeh, i=ish:ieh)
         vh_err_best(i,j) = min(vh_err_best(i,j), abs(vh_err(i,j)))
       enddo
     endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -437,20 +437,13 @@ subroutine continuity_merdional_convergence(h, vh, dt, G, GV, LB, hin, hmin)
 
   if (present(hin)) then
     ! untested
-    !$omp target teams distribute parallel do collapse(3) &
-    !$omp   map(to: LB, hin(LB%ish:LB%ieh, :, :), G, G%IareaT(LB%ish:LB%ieh, LB%jsh:LB%jeh), &
-    !$omp       vh(LB%ish:LB%ieh, :, :)) &
-    !$omp   map(from: h(LB%ish:LB%ieh, :, :))
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do concurrent (k=1:GV%ke, j=LB%jsh:LB%jeh, i=LB%ish:LB%ieh)
       h(i,j,k) = max( hin(i,j,k) - dt * G%IareaT(i,j) * (vh(i,J,k) - vh(i,J-1,k)), h_min )
-    enddo ; enddo ; enddo
+    enddo
   else
-    !$omp target teams distribute parallel do collapse(3) &
-    !$omp   map(to: LB, G, G%IareaT(LB%ish:LB%ieh, LB%jsh:LB%jeh), vh(LB%ish:LB%ieh, :, :)) &
-    !$omp   map(tofrom: h(LB%ish:LB%ieh, :, :))
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do concurrent (k=1:GV%ke, j=LB%jsh:LB%jeh, i=LB%ish:LB%ieh)
       h(i,j,k) = max( h(i,j,k) - dt * G%IareaT(i,j) * (vh(i,J,k) - vh(i,J-1,k)), h_min )
-    enddo ; enddo ; enddo
+    enddo
   endif
 
   call cpu_clock_end(id_clock_update)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1599,7 +1599,7 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
   type(BT_cont_type),   intent(inout) :: BT_cont !< A structure with elements
                        !! that describe the effective open face areas as a function of barotropic flow.
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in) :: du0  !< The barotropic velocity increment that gives 0 transport 
+                           intent(in) :: du0  !< The barotropic velocity increment that gives 0 transport
                                                  !! [L T-1 ~> m s-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
                            intent(in) :: uh_tot_0    !< The summed transport with 0 adjustment

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -736,27 +736,26 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
       enddo ; enddo ; else ; do j=jsh,jeh ; do I=ish-1,ieh
         do_I(I, j) = .true.
       enddo ; enddo ; endif
-    endif
+      if (present(uhbt)) then
+        ! Find du and uh.
+        call zonal_flux_adjust_fused(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, du, &
+                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem_u, &
+                              ish, ieh, jsh, jeh, do_I, por_face_areaU, uh, OBC=OBC)
 
-    if (present(uhbt)) then
-      ! Find du and uh.
-      call zonal_flux_adjust_fused(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, du, &
-                            du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem_u, &
-                            ish, ieh, jsh, jeh, do_I, por_face_areaU, uh, OBC=OBC)
+        if (present(u_cor)) then
+          do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
+            u_cor(i,j,k) = u(i,j,k) + du(i,j) * visc_rem_u(i,j,k)
+          enddo ; enddo ; enddo
+          if (any_simple_OBC) then 
+            do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh ; if (simple_OBC_pt(I)) then
+              u_cor(I,j,k) = OBC%segment(abs(OBC%segnum_u(I,j)))%normal_vel(I,j,k)
+            endif ; enddo ; enddo ; enddo
+          endif
+        endif ! u-corrected
 
-      if (present(u_cor)) then
-        do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
-          u_cor(i,j,k) = u(i,j,k) + du(i,j) * visc_rem_u(i,j,k)
-        enddo ; enddo ; enddo
-        if (any_simple_OBC) then 
-          do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh ; if (simple_OBC_pt(I)) then
-            u_cor(I,j,k) = OBC%segment(abs(OBC%segnum_u(I,j)))%normal_vel(I,j,k)
-          endif ; enddo ; enddo ; enddo
+        if (present(du_cor)) then
+          do j=jsh,jeh ; do I=ish-1,ieh ; du_cor(I,j) = du(I,j) ; enddo ; enddo
         endif
-      endif ! u-corrected
-
-      if (present(du_cor)) then
-        do j=jsh,jeh ; do I=ish-1,ieh ; du_cor(I,j) = du(I,j) ; enddo ; enddo
       endif
     endif
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -984,6 +984,15 @@ subroutine zonal_flux_layer(u, h, h_W, h_E, uh, duhdu, visc_rem, dt, G, GV, US, 
     local_open_BC = OBC%open_u_BCs_exist_globally
   endif ; endif
 
+  !$omp target update to(uh, u)
+
+  !$omp target teams distribute parallel do collapse(3) &
+  !$omp   private(CFL, curv_3, h_marg) &
+  !$omp   map(to: do_I(ish-1:ieh, jsh:jeh), u(ish-1:ieh, :, :), u(ish-1:ieh, :, :), G, &
+  !$omp       G%dy_Cu(ish-1:ieh, jsh:jeh), G%IareaT(ish-1:ieh+1, jsh:jeh), &
+  !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), h_W(ish-1:ieh+1, :, :), h_E(ish-1:ieh+1, :, :), &
+  !$omp       h(ish-1:ieh+1, :, :), por_face_areaU(ish-1:ieh, :, :), visc_rem(ish-1:ieh, :, :)) &
+  !$omp   map(tofrom: uh(ish-1:ieh, :, :), duhdu(ish-1:ieh, :, :)) ! tofrom so non-updated elems so we don't accidentally zero old values
   do k = 1, nz; do j = jsh, jeh; do I=ish-1,ieh ; if (do_I(I, j)) then
     ! Set new values of uh and duhdu.
     if (u(I, j, k) > 0.0) then
@@ -1008,18 +1017,28 @@ subroutine zonal_flux_layer(u, h, h_W, h_E, uh, duhdu, visc_rem, dt, G, GV, US, 
   endif ; enddo; enddo; enddo
 
   if (local_open_BC) then
-    do I=ish-1,ieh ; if (do_I(I, j)) then ; if (OBC%segnum_u(I,j) /= 0) then
-      if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
-        if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
-          uh(i, j, k) = (G%dy_Cu(I,j) * por_face_areaU(I, j, k)) * u(I, j, k) * h(i, j, k)
-          duhdu(I, j, k) = (G%dy_Cu(I,j) * por_face_areaU(I, j, k)) * h(i, j, k) * visc_rem(I, j, k)
-        else !  OBC_DIRECTION_W
-          uh(i, j, k) = (G%dy_Cu(I,j) * por_face_areaU(I, j, k)) * u(I, j, k) * h(i+1, j, k)
-          duhdu(I, j, k) = (G%dy_Cu(I,j)* por_face_areaU(I, j, k)) * h(i+1, j, k) * visc_rem(I, j, k)
+    ! untested
+    !$omp target teams distribute parallel do collapse(3) &
+    !$omp   map(to: do_I(ish-1:ieh, jsh:jeh), OBC, OBC%segnum_u(ish-1:ieh, jsh:jeh), &
+    !$omp       OBC%segment(:), G, G%dy_Cu(ish-1:ieh, jsh:jeh), por_face_areaU(ish-1:ieh, :, :), &
+    !$omp       u(ish-1:ieh, :, :), h(ish-1:ieh+1, :, :), visc_rem(ish-1:ieh, :, :)) &
+    !$Omp   map(tofrom: uh(ish-1:ieh, :, :), duhdu(ish-1:ieh, :, :))
+    do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh 
+      if (do_I(I, j)) then ; if (OBC%segnum_u(I,j) /= 0) then
+        if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
+          if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
+            uh(i, j, k) = (G%dy_Cu(I,j) * por_face_areaU(I, j, k)) * u(I, j, k) * h(i, j, k)
+            duhdu(I, j, k) = (G%dy_Cu(I,j) * por_face_areaU(I, j, k)) * h(i, j, k) * visc_rem(I, j, k)
+          else !  OBC_DIRECTION_W
+            uh(i, j, k) = (G%dy_Cu(I,j) * por_face_areaU(I, j, k)) * u(I, j, k) * h(i+1, j, k)
+            duhdu(I, j, k) = (G%dy_Cu(I,j)* por_face_areaU(I, j, k)) * h(i+1, j, k) * visc_rem(I, j, k)
+          endif
         endif
-      endif
-    endif ; endif ; enddo
+      endif ; endif
+    enddo ; enddo ; enddo
   endif
+
+  !$omp target update from(uh)
 end subroutine zonal_flux_layer
 
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -921,31 +921,43 @@ end subroutine zonal_BT_mass_flux
 !> Evaluates the zonal mass or volume fluxes in a layer.
 subroutine zonal_flux_layer_fused(u, h, h_W, h_E, uh, duhdu, visc_rem, dt, G, US, &
                             ish, ieh, jsh, jeh, nz, do_I, vol_CFL, por_face_areaU, OBC, GV)
-  type(ocean_grid_type),        intent(in)    :: G        !< Ocean's grid structure.
-  type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(GV)),    intent(in)    :: u        !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(GV)),    intent(in)    :: visc_rem !< Both the fraction of the
+  type(ocean_grid_type),    intent(in)    :: G        !< Ocean's grid structure.
+  type(verticalGrid_type),  intent(in)    :: GV       !< Ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                            intent(in)    :: u        !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                            intent(in)    :: visc_rem !< Both the fraction of the
                         !! momentum originally in a layer that remains after a time-step
                         !! of viscosity, and the fraction of a time-step's worth of a barotropic
                         !! acceleration that a layer experiences after viscosity is applied [nondim].
                         !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G), SZJ_(G), SZK_(GV)),     intent(in)    :: h        !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G), SZJ_(G), SZK_(GV)),     intent(in)    :: h_W      !< West edge thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G), SZJ_(G), SZK_(GV)),     intent(in)    :: h_E      !< East edge thickness [H ~> m or kg m-2].
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(GV)),    intent(inout) :: uh       !< Zonal mass or volume
-                                                          !! transport [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(GV)),    intent(inout) :: duhdu    !< Partial derivative of uh
-                                                          !! with u [H L ~> m2 or kg m-1].
-  real,                         intent(in)    :: dt       !< Time increment [T ~> s]
-  type(unit_scale_type),        intent(in)    :: US       !< A dimensional unit scaling type
-  integer,                      intent(in)    :: jsh, jeh, nz        !< Spatial index.
-  integer,                      intent(in)    :: ish      !< Start of index range.
-  integer,                      intent(in)    :: ieh      !< End of index range.
-  logical, dimension(SZIB_(G), SZJ_(G)), intent(in)    :: do_I     !< Which i values to work on.
-  logical,                      intent(in)    :: vol_CFL  !< If true, rescale the
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(GV)),    intent(in)    :: por_face_areaU !< fractional open area of U-faces [nondim]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                            intent(in)    :: h        !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                            intent(in)    :: h_W      !< West edge thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
+                            intent(in)    :: h_E      !< East edge thickness [H ~> m or kg m-2].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                            intent(inout) :: uh       !< Zonal mass or volume
+                                                      !! transport [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                            intent(inout) :: duhdu    !< Partial derivative of uh
+                                                      !! with u [H L ~> m2 or kg m-1].
+  real,                     intent(in)    :: dt       !< Time increment [T ~> s]
+  type(unit_scale_type),    intent(in)    :: US       !< A dimensional unit scaling type.
+  integer,                  intent(in)    :: ish      !< Start of i index range.
+  integer,                  intent(in)    :: ieh      !< End of i index range.
+  integer,                  intent(in)    :: jsh      !< Start of j index range.
+  integer,                  intent(in)    :: jeh      !< End of j index range.
+  integer,                  intent(in)    :: nz       !< Edn of k index range.
+  logical, dimension(SZIB_(G),SZJ_(G)), &
+                            intent(in)    :: do_I     !< Which i values to work on.
+  logical,                  intent(in)    :: vol_CFL  !< If true, rescale the
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                            intent(in)    :: por_face_areaU !< fractional open area of U-faces 
+                                                            !! [nondim].
           !! ratio of face areas to the cell areas when estimating the CFL number.
-  type(ocean_OBC_type), optional, pointer     :: OBC !< Open boundaries control structure.
+  type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
   ! Local variables
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim]
   real :: curv_3 ! A measure of the thickness curvature over a grid length [H ~> m or kg m-2]
@@ -1201,60 +1213,60 @@ subroutine zonal_flux_adjust_fused(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_
                              du, du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              ish, ieh, jsh, jeh, do_I_in, por_face_areaU, uh_3d, OBC)
 
-  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)   :: u    !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to
-                                                                   !! calculate fluxes [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_W  !< West edge thickness in the
-                                                                   !! reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_E  !< East edge thickness in the
-                                                                   !! reconstruction [H ~> m or kg m-2].
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)),        intent(in)    :: visc_rem !< Both the fraction of the
+  type(ocean_grid_type),                      intent(in)    :: G    !< Ocean's grid structure.
+  type(verticalGrid_type),                    intent(in)    :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)    :: u     !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_in !< Layer thickness used to
+                                                                    !! calculate fluxes [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_W  !< West edge thickness in the
+                                                                    !! reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_E  !< East edge thickness in the
+                                                                    !! reconstruction [H ~> m or kg m-2].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)    :: visc_rem !< Both the fraction of the
                        !! momentum originally in a layer that remains after a time-step of viscosity, and
                        !! the fraction of a time-step's worth of a barotropic acceleration that a layer
                        !! experiences after viscosity is applied [nondim].
                        !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: uhbt !< The summed volume flux
+  real, dimension(SZIB_(G),SZJ_(G)),          intent(in)    :: uhbt !< The summed volume flux
                        !! through zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
-
-  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: du_max_CFL  !< Maximum acceptable
+  real, dimension(SZIB_(G),SZJ_(G)),          intent(in)    :: du_max_CFL  !< Maximum acceptable
                        !! value of du [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: du_min_CFL  !< Minimum acceptable
+  real, dimension(SZIB_(G),SZJ_(G)),          intent(in)    :: du_min_CFL  !< Minimum acceptable
                        !! value of du [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: uh_tot_0    !< The summed transport
+  real, dimension(SZIB_(G),SZJ_(G)),          intent(in)    :: uh_tot_0    !< The summed transport
                        !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: duhdu_tot_0 !< The partial derivative
+  real, dimension(SZIB_(G),SZJ_(G)),          intent(in)    :: duhdu_tot_0 !< The partial derivative
                        !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZIB_(G),SZJ_(G)),                 intent(inout)   :: du !<
+  real, dimension(SZIB_(G),SZJ_(G)),          intent(inout) :: du !<
                        !! The barotropic velocity adjustment [L T-1 ~> m s-1].
-  real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  integer,                                   intent(in)    :: ish, jsh  !< Start of index range.
-  integer,                                   intent(in)    :: ieh, jeh  !< End of index range.
-  logical, dimension(SZIB_(G),SZJ_(G)),              intent(in)    :: do_I_in     !<
-                       !! A logical flag indicating which I values to work on.
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
-                                      intent(in) :: por_face_areaU !< fractional open area of U-faces [nondim]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), optional, intent(inout) :: uh_3d !<
-                       !! Volume flux through zonal faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
-  type(ocean_OBC_type),            optional, pointer       :: OBC !< Open boundaries control structure.
+  real,                                       intent(in)    :: dt        !< Time increment [T ~> s].
+  type(unit_scale_type),                      intent(in)    :: US        !< A dimensional unit scaling type.
+  type(continuity_PPM_CS),                    intent(in)    :: CS        !< This module's control structure.
+  integer,                                    intent(in)    :: ish, jsh  !< Start of index range.
+  integer,                                    intent(in)    :: ieh, jeh  !< End of index range.
+  logical, dimension(SZIB_(G),SZJ_(G)),       intent(in)    :: do_I_in   !< A logical flag
+                       !! indicating which I values to work on.
+  real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), intent(in)   :: por_face_areaU !< fractional open area 
+                                                                              !! of U-faces [nondim].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                                    optional, intent(inout) :: uh_3d !< Volume flux through zonal
+                       !! faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
+  type(ocean_OBC_type),             optional, pointer       :: OBC !< Open boundaries control structure.
   ! Local variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
-    uh_aux, &  ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
-    duhdu      ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
+    uh_aux, &      ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
+    duhdu          ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
   real, dimension(SZIB_(G),SZJ_(G)) :: &
-    uh_err, &  ! Difference between uhbt and the summed uh [H L2 T-1 ~> m3 s-1 or kg s-1].
+    uh_err, &      ! Difference between uhbt and the summed uh [H L2 T-1 ~> m3 s-1 or kg s-1].
     uh_err_best, & ! The smallest value of uh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
-    duhdu_tot,&! Summed partial derivative of uh with u [H L ~> m2 or kg m-1].
-    du_min, &  ! Lower limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
-    du_max     ! Upper limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
+    duhdu_tot,&    ! Summed partial derivative of uh with u [H L ~> m2 or kg m-1].
+    du_min, &      ! Lower limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
+    du_max         ! Upper limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: u_new ! The velocity with the correction added [L T-1 ~> m s-1].
-  real :: du_prev ! The previous value of du [L T-1 ~> m s-1].
-  real :: ddu     ! The change in du from the previous iteration [L T-1 ~> m s-1].
-  real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
-  real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
+  real :: du_prev  ! The previous value of du [L T-1 ~> m s-1].
+  real :: ddu      ! The change in du from the previous iteration [L T-1 ~> m s-1].
+  real :: tol_eta  ! The tolerance for the current iteration [H ~> m or kg m-2].
+  real :: tol_vel  ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
   integer :: i, j, k, nz, itt, max_itts = 20
   logical :: domore, do_I(SZIB_(G),SZJ_(G))
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -657,18 +657,21 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
         visc_rem_u_tmp(i,j,k) = 1.0
       enddo
     else
+      ! this is expensive
       do concurrent (k=1:nz, i=ish-1:ieh)
         visc_rem_u_tmp(i,j,k) = visc_rem_u(i,j,k)
       enddo
     end if
   
     ! Set uh and duhdu.
+    !DIR$ FORCEINLINE
     do concurrent (k=1:nz , I=ish-1:ieh)
       call zonal_flux_layere(u(I,j,k), h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), h_E(I+1,j,k), &
                             uh(I,j,k), duhdu(I,j,k), visc_rem_u_tmp(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), &
                             dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
     enddo
     if (local_open_BC) then
+      !DIR$ FORCEINLINE
       do concurrent (k=1:nz, I=ish-1:ieh)
         call zonal_flux_layere_OBC(u(I,j,k), h_in, uh(I,j,k), duhdu(I,j,k), visc_rem_u_tmp(I,j,k), &
                                   G, GV, I, j, k, por_face_areaU(I,j,k), OBC)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2489,7 +2489,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
           vh_err(i) = vh_err(i) + vh_aux(i,J,k)
           dvhdv_tot(i) = dvhdv_tot(i) + dvhdv(i,J,k)
         enddo ; enddo
-        do concurrent (i=ish:jeh)
+        do concurrent (i=ish:ieh, do_I(i))
           vh_err_best(i) = min(vh_err_best(i), abs(vh_err(i)))
         enddo
       endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -3076,6 +3076,7 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS)
                  "solver for use as the weights in the barotropic solver. "//&
                  "Otherwise use the transport averaged areas.", default=.true.)
   CS%diag => diag
+  !$omp target enter data map(to: CS)
 
   id_clock_reconstruct = cpu_clock_id('(Ocean continuity reconstruction)', grain=CLOCK_ROUTINE)
   id_clock_update = cpu_clock_id('(Ocean continuity update)', grain=CLOCK_ROUTINE)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -722,6 +722,22 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
       du_min_CFL(I,j) = min(du_min_CFL(I,j),0.0)
     enddo ; enddo
 
+    any_simple_OBC = .false.
+    if (present(uhbt) .or. set_BT_cont) then
+      ! untested!
+      if (local_specified_BC .or. local_Flather_OBC) then ; do j=jsh,jeh ; do I=ish-1,ieh
+        l_seg = (OBC%segnum_u(I,j))
+
+        ! Avoid reconciling barotropic/baroclinic transports if transport is specified
+        simple_OBC_pt(I) = .false.
+        if (l_seg /= OBC_NONE) simple_OBC_pt(I) = OBC%segment(l_seg)%specified
+        do_I(I, j) = .not.simple_OBC_pt(I)
+        any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(I)
+      enddo ; enddo ; else ; do j=jsh,jeh ; do I=ish-1,ieh
+        do_I(I, j) = .true.
+      enddo ; enddo ; endif
+    endif
+
   endif
 
   do j=jsh,jeh

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2070,9 +2070,9 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
 
       if (present(vhbt)) then
         ! Find dv and vh.
-        call meridional_flux_adjust(v, h_in, h_S, h_N, vhbt(:,J), vh_tot_0(:,j), dvhdv_tot_0(:,j), dv, &
-                               dv_max_CFL(:,j), dv_min_CFL(:,j), dt, G, GV, US, CS, visc_rem, &
-                               j, ish, ieh, do_I(:,j), por_face_areaV, vh, OBC=OBC)
+        call meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, dv, &
+                               dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem_v, &
+                               j, ish, ieh, do_I, por_face_areaV, vh, OBC=OBC)
 
         if (present(v_cor)) then ; do k=1,nz
           do i=ish,ieh ; v_cor(i,J,k) = v(i,J,k) + dv(i) * visc_rem(i,k) ; enddo
@@ -2517,6 +2517,156 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
   endif
 
 end subroutine meridional_flux_thickness
+
+!> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
+subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
+                             dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
+                             j, ish, ieh, do_I_in, por_face_areaV, vh_3d, OBC)
+  type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                           intent(in)    :: v    !< Meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),&
+                           intent(in)    :: h_S  !< South edge thickness in the reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h_N  !< North edge thickness in the reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: visc_rem
+                             !< Both the fraction of the momentum originally
+                             !! in a layer that remains after a time-step of viscosity, and the
+                             !! fraction of a time-step's worth of a barotropic acceleration that
+                             !! a layer experiences after viscosity is applied [nondim].
+                             !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
+  real, dimension(SZI_(G),SZJB_(G)), intent(in)    :: vhbt !< The summed volume flux through meridional faces
+                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: dv_max_CFL !< Maximum acceptable value of dv [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: dv_min_CFL !< Minimum acceptable value of dv [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: vh_tot_0   !< The summed transport with 0 adjustment
+                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: dvhdv_tot_0 !< The partial derivative of dv_err with
+                                                  !! dv at 0 adjustment [H L ~> m2 or kg m-1].
+  real, dimension(SZI_(G)), intent(out)   :: dv   !< The barotropic velocity adjustment [L T-1 ~> m s-1].
+  real,                     intent(in)    :: dt   !< Time increment [T ~> s].
+  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
+  type(continuity_PPM_CS),  intent(in)    :: CS   !< This module's control structure.
+  integer,                  intent(in)    :: j    !< Spatial index.
+  integer,                  intent(in)    :: ish  !< Start of index range.
+  integer,                  intent(in)    :: ieh  !< End of index range.
+  logical, dimension(SZI_(G),SZJ_(G)), &
+                            intent(in)    :: do_I_in  !< A flag indicating which I values to work on.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                     intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                  optional, intent(inout) :: vh_3d !< Volume flux through meridional
+                             !! faces = v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
+  type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
+  ! Local variables
+  real, dimension(SZI_(G),SZK_(GV)) :: &
+    vh_aux, &  ! An auxiliary meridional volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
+    dvhdv      ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
+  real, dimension(SZI_(G)) :: &
+    vh_err, &  ! Difference between vhbt and the summed vh [H L2 T-1 ~> m3 s-1 or kg s-1].
+    vh_err_best, & ! The smallest value of vh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
+    v_new, &   ! The velocity with the correction added [L T-1 ~> m s-1].
+    dvhdv_tot,&! Summed partial derivative of vh with u [H L ~> m2 or kg m-1].
+    dv_min, &  ! Lower limit on dv correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
+    dv_max     ! Upper limit on dv correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
+  real :: dv_prev ! The previous value of dv [L T-1 ~> m s-1].
+  real :: ddv     ! The change in dv from the previous iteration [L T-1 ~> m s-1].
+  real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
+  real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
+  integer :: i, k, nz, itt, max_itts = 20
+  logical :: domore, do_I(SZI_(G))
+
+  nz = GV%ke
+
+  vh_aux(:,:) = 0.0 ; dvhdv(:,:) = 0.0
+
+  if (present(vh_3d)) then ; do k=1,nz ; do i=ish,ieh
+    vh_aux(i,k) = vh_3d(i,J,k)
+  enddo ; enddo ; endif
+
+  do i=ish,ieh
+    dv(i) = 0.0 ; do_I(i) = do_I_in(i,j)
+    dv_max(i) = dv_max_CFL(i,j) ; dv_min(i) = dv_min_CFL(i,j)
+    vh_err(i) = vh_tot_0(i,j) - vhbt(i,j) ; dvhdv_tot(i) = dvhdv_tot_0(i,j)
+    vh_err_best(i) = abs(vh_err(i))
+  enddo
+
+  do itt=1,max_itts
+    select case (itt)
+      case (:1) ; tol_eta = 1e-6 * CS%tol_eta
+      case (2)  ; tol_eta = 1e-4 * CS%tol_eta
+      case (3)  ; tol_eta = 1e-2 * CS%tol_eta
+      case default ; tol_eta = CS%tol_eta
+    end select
+    tol_vel = CS%tol_vel
+
+    do i=ish,ieh
+      if (vh_err(i) > 0.0) then ; dv_max(i) = dv(i)
+      elseif (vh_err(i) < 0.0) then ; dv_min(i) = dv(i)
+      else ; do_I(i) = .false. ; endif
+    enddo
+    domore = .false.
+    do i=ish,ieh ; if (do_I(i)) then
+      if ((dt * min(G%IareaT(i,j),G%IareaT(i,j+1))*abs(vh_err(i)) > tol_eta) .or. &
+          (CS%better_iter .and. ((abs(vh_err(i)) > tol_vel * dvhdv_tot(i)) .or. &
+                                 (abs(vh_err(i)) > vh_err_best(i))) )) then
+        !   Use Newton's method, provided it stays bounded.  Otherwise bisect
+        ! the value with the appropriate bound.
+        ddv = -vh_err(i) / dvhdv_tot(i)
+        dv_prev = dv(i)
+        dv(i) = dv(i) + ddv
+        if (abs(ddv) < 1.0e-15*abs(dv(i))) then
+          do_I(i) = .false. ! ddv is small enough to quit.
+        elseif (ddv > 0.0) then
+          if (dv(i) >= dv_max(i)) then
+            dv(i) = 0.5*(dv_prev + dv_max(i))
+            if (dv_max(i) - dv_prev < 1.0e-15*abs(dv(i))) do_I(i) = .false.
+          endif
+        else ! dvv(i) < 0.0
+          if (dv(i) <= dv_min(i)) then
+            dv(i) = 0.5*(dv_prev + dv_min(i))
+            if (dv_prev - dv_min(i) < 1.0e-15*abs(dv(i))) do_I(i) = .false.
+          endif
+        endif
+        if (do_I(i)) domore = .true.
+      else
+        do_I(i) = .false.
+      endif
+    endif ; enddo
+    if (.not.domore) exit
+
+    if ((itt < max_itts) .or. present(vh_3d)) then ; do k=1,nz
+      do i=ish,ieh ; v_new(i) = v(i,J,k) + dv(i) * visc_rem(i,j,k) ; enddo
+      call merid_flux_layer(v_new, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), &
+                            vh_aux(:,k), dvhdv(:,k), visc_rem(:,j,k), &
+                            dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k), OBC)
+    enddo ; endif
+
+    if (itt < max_itts) then
+      do i=ish,ieh
+        vh_err(i) = -vhbt(i,j) ; dvhdv_tot(i) = 0.0
+      enddo
+      do k=1,nz ; do i=ish,ieh
+        vh_err(i) = vh_err(i) + vh_aux(i,k)
+        dvhdv_tot(i) = dvhdv_tot(i) + dvhdv(i,k)
+      enddo ; enddo
+      do i=ish,ieh
+        vh_err_best(i) = min(vh_err_best(i), abs(vh_err(i)))
+      enddo
+    endif
+  enddo ! itt-loop
+  ! If there are any faces which have not converged to within the tolerance,
+  ! so-be-it, or else use a final upwind correction?
+  ! This never seems to happen with 20 iterations as max_itt.
+
+  if (present(vh_3d)) then ; do k=1,nz ; do i=ish,ieh
+    vh_3d(i,J,k) = vh_aux(i,k)
+  enddo ; enddo ; endif
+
+end subroutine meridional_flux_adjust_fused
 
 !> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
 subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -691,6 +691,31 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
             du_min_CFL(I,j) = -(dx_E*CFL_dt + u(I,j,k)) / visc_rem(I,k)
         enddo ; enddo ; enddo
       endif
+    else
+      ! untested!
+      if (CS%aggress_adjust) then
+        do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
+          if (CS%vol_CFL) then
+            dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
+            dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
+          else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+
+          du_max_CFL(I,j) = MIN(du_max_CFL(I,j), 0.499 * &
+                      ((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k))) )
+          du_min_CFL(I,j) = MAX(du_min_CFL(I,j), 0.499 * &
+                      ((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k))) )
+        enddo ; enddo ; enddo
+      else
+        do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
+          if (CS%vol_CFL) then
+            dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
+            dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
+          else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+
+          du_max_CFL(I,j) = MIN(du_max_CFL(I,j), dx_W*CFL_dt - u(I,j,k))
+          du_min_CFL(I,j) = MAX(du_min_CFL(I,j), -(dx_E*CFL_dt + u(I,j,k)))
+        enddo ; enddo ; enddo
+      endif
     endif
 
   endif
@@ -704,32 +729,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     enddo
 
     if (present(uhbt) .or. set_BT_cont) then
-      if (use_visc_rem) then
-      else
-        if (CS%aggress_adjust) then
-          do k=1,nz ; do I=ish-1,ieh
-            if (CS%vol_CFL) then
-              dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
-              dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
-            else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
-
-            du_max_CFL(I,j) = MIN(du_max_CFL(I,j), 0.499 * &
-                        ((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k))) )
-            du_min_CFL(I,j) = MAX(du_min_CFL(I,j), 0.499 * &
-                        ((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k))) )
-          enddo ; enddo
-        else
-          do k=1,nz ; do I=ish-1,ieh
-            if (CS%vol_CFL) then
-              dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
-              dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
-            else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
-
-            du_max_CFL(I,j) = MIN(du_max_CFL(I,j), dx_W*CFL_dt - u(I,j,k))
-            du_min_CFL(I,j) = MAX(du_min_CFL(I,j), -(dx_E*CFL_dt + u(I,j,k)))
-          enddo ; enddo
-        endif
-      endif
       do I=ish-1,ieh
         du_max_CFL(I,j) = max(du_max_CFL(I,j),0.0)
         du_min_CFL(I,j) = min(du_min_CFL(I,j),0.0)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -170,11 +170,12 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   !$omp   map(alloc: h_W, h_E, h_S, h_N, uh, vh, u_cor, v_cor, du_cor, dv_cor, BT_cont%FA_u_E0, &
   !$omp       BT_cont%FA_u_W0, BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, &
   !$omp       BT_cont%FA_v_NN, BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, &
-  !$omp       BT_cont%vBT_SS, BT_cont%h_u, BT_cont%h_V)
+  !$omp       BT_cont%vBT_SS, BT_cont%h_u, BT_cont%h_V, LB)
 
   if (x_first) then
     !  First advect zonally, with loop bounds that accomodate the subsequent meridional advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.true.)
+    !$omp target update to(LB)
     call zonal_edge_thickness(hin, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, hin, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
                          LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
@@ -184,6 +185,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
     !  Now advect meridionally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
+    !$omp target update to(LB)
     call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
                               LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
@@ -192,6 +194,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   else  ! .not. x_first
     !  First advect meridionally, with loop bounds that accomodate the subsequent zonal advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.true., j_stencil=.false.)
+    !$omp target update to(LB)
     call meridional_edge_thickness(hin, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, hin, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
                               LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
@@ -199,6 +202,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
     !  Now advect zonally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
+    !$omp target update to(LB)
     call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
                          LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
@@ -219,7 +223,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   !$omp       BT_cont%h_u, BT_cont%h_V) &
   !$omp   map(release: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
   !$omp       G%mask2dT, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h_W, h_E, h_S, h_N, CS, pbv, &
-  !$omp       pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v)
+  !$omp       pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, LB)
 
 end subroutine continuity_PPM
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2919,17 +2919,18 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     FAmt_L(i,j) = 0.0 ; FAmt_R(i,j) = 0.0 ; FAmt_0(i,j) = 0.0
     vhtot_L(i,j) = 0.0 ; vhtot_R(i,j) = 0.0
   endif ; enddo ; enddo
-  do j = jsh-1, jeh
 
   if (.not.domore) then
-    do k=1,nz ; do i=ish,ieh
+    do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh
       BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
       BT_cont%vBT_SS(i,J) = 0.0
       BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
       BT_cont%vBT_NN(i,J) = 0.0
-    enddo ; enddo
+    enddo ; enddo ; enddo
     return
   endif
+
+  do j = jsh-1, jeh
 
   do k=1,nz ; do i=ish,ieh ; if (do_I(i,j)) then
     visc_rem_lim = max(visc_rem(i,j,k), min_visc_rem*visc_rem_max(i,j))

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1586,50 +1586,50 @@ end subroutine zonal_flux_adjust
 subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_tot_0, &
                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaU)
-  type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
+  type(ocean_grid_type),   intent(in) :: G    !< Ocean's grid structure.
+  type(verticalGrid_type), intent(in) :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: u    !< Zonal velocity [L T-1 ~> m s-1].
+                           intent(in) :: u    !< Zonal velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
+                           intent(in) :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_W  !< West edge thickness in the reconstruction [H ~> m or kg m-2].
+                           intent(in) :: h_W  !< West edge thickness in the reconstruction [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_E  !< East edge thickness in the reconstruction [H ~> m or kg m-2].
-  type(BT_cont_type),      intent(inout) :: BT_cont !< A structure with elements
+                           intent(in) :: h_E  !< East edge thickness in the reconstruction [H ~> m or kg m-2].
+  type(BT_cont_type),   intent(inout) :: BT_cont !< A structure with elements
                        !! that describe the effective open face areas as a function of barotropic flow.
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: du0  !< The barotropic velocity increment that gives 0 transport 
+                           intent(in) :: du0  !< The barotropic velocity increment that gives 0 transport 
                                                  !! [L T-1 ~> m s-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: uh_tot_0    !< The summed transport with 0 adjustment
+                           intent(in) :: uh_tot_0    !< The summed transport with 0 adjustment
                                                         !! [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: duhdu_tot_0 !< The partial derivative
+                           intent(in) :: duhdu_tot_0 !< The partial derivative
                        !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: du_max_CFL  !< Maximum acceptable value of du [L T-1 ~> m s-1].
+                           intent(in) :: du_max_CFL  !< Maximum acceptable value of du [L T-1 ~> m s-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: du_min_CFL  !< Minimum acceptable value of du [L T-1 ~> m s-1].
-  real,                    intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS), intent(in)    :: CS   !< This module's control structure.
+                           intent(in) :: du_min_CFL  !< Minimum acceptable value of du [L T-1 ~> m s-1].
+  real,                    intent(in) :: dt   !< Time increment [T ~> s].
+  type(unit_scale_type),   intent(in) :: US   !< A dimensional unit scaling type
+  type(continuity_PPM_CS), intent(in) :: CS   !< This module's control structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: visc_rem !< Both the fraction of the
+                           intent(in) :: visc_rem !< Both the fraction of the
                        !! momentum originally in a layer that remains after a time-step of viscosity, and
                        !! the fraction of a time-step's worth of a barotropic acceleration that a layer
                        !! experiences after viscosity is applied [nondim].
                        !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim].
-  integer,                 intent(in)    :: ish      !< Start of i index range.
-  integer,                 intent(in)    :: ieh      !< End of i index range.
-  integer,                 intent(in)    :: jsh      !< Start of j index range.
-  integer,                 intent(in)    :: jeh      !< End of j index range.
+                           intent(in) :: visc_rem_max !< Maximum allowable visc_rem [nondim].
+  integer,                 intent(in) :: ish      !< Start of i index range.
+  integer,                 intent(in) :: ieh      !< End of i index range.
+  integer,                 intent(in) :: jsh      !< Start of j index range.
+  integer,                 intent(in) :: jeh      !< End of j index range.
   logical, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: do_I     !< A logical flag indicating which I values to work on.
+                           intent(in) :: do_I     !< A logical flag indicating which I values to work on.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                           intent(in)    :: por_face_areaU !< fractional open area of U-faces [nondim]
+                           intent(in) :: por_face_areaU !< fractional open area of U-faces [nondim]
   ! Local variables
   real, dimension(SZIB_(G)) :: &
     duL, duR, &       ! The barotropic velocity increments that give the westerly
@@ -2203,8 +2203,8 @@ subroutine merid_flux_layer(v, h, h_S, h_N, vh, dvhdv, visc_rem, dt, G, GV, US, 
   logical, dimension(SZI_(G),SZJB_(G)),       intent(in)    :: do_I    !< Which i values to work on.
   logical,                                    intent(in)    :: vol_CFL !< If true, rescale the
          !! ratio of face areas to the cell areas when estimating the CFL number.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                                              intent(in)    :: por_face_areaV !< fractional open area of V-faces [nondim]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)    :: por_face_areaV !< fractional open area of
+                                                                              !! V-faces [nondim]
   type(ocean_OBC_type),                   optional, pointer :: OBC !< Open boundaries control structure.
   ! Local variables
   real :: CFL ! The CFL number based on the local velocity and grid spacing [nondim]

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1150,7 +1150,8 @@ elemental subroutine flux_elem_OBC(u, h, h_p1, uh, duhdu, visc_rem, G, GV, por_f
                                                       !! with u [H L ~> m2 or kg m-1].
   real,                     intent(in)    :: por_face_area !< fractional open area of U/V-faces
                                                             !! [nondim].
-  real,                     intent(in)    :: G_dy_Cu
+  real,                     intent(in)    :: G_dy_Cu  !< The grid cell's unblocked lengths of the
+                                                      !! u/v-faces of the h-cell [L ~> m].
           !! ratio of face areas to the cell areas when estimating the CFL number.
   type(ocean_OBC_type),     intent(in)    :: OBC !< Open boundaries control structure.
   integer, intent(in) :: l_seg
@@ -1921,12 +1922,13 @@ end subroutine meridional_mass_flux
 
 
 subroutine present_vhbt_or_set_BT_cont(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, dv, dv_max_CFL, &
-                                       dv_min_CFL, visc_rem_v, visc_rem_max, por_face_areaV, vhbt, vh, v_cor, dv_cor, BT_cont, dt, &
-                                       set_BT_cont, local_specified_BC, local_Flather_OBC, local_open_BC, ish, &
+                                       dv_min_CFL, visc_rem_v, visc_rem_max, por_face_areaV, vhbt, &
+                                       vh, v_cor, dv_cor, BT_cont, dt, set_BT_cont, &
+                                       local_specified_BC, local_Flather_OBC, local_open_BC, ish, &
                                        ieh, jsh, jeh, nz, G, GV, US, CS, OBC, LB)
 
-  type(ocean_grid_type),   intent(in) :: G
-  type(verticalGrid_type), intent(in) :: GV
+  type(ocean_grid_type),   intent(in) :: G    !< Ocean's grid structure.
+  type(verticalGrid_type), intent(in) :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
                            intent(in) :: v    !< Meridional velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -1939,19 +1941,19 @@ subroutine present_vhbt_or_set_BT_cont(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0,
                            intent(in) :: vh_tot_0 !< Summed transport with no barotropic correction
                                                   !! [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZI_(G),SZJB_(G)), &
-                           intent(in) :: dvhdv_tot_0 !< Summed partial derivative of vh with v 
+                           intent(in) :: dvhdv_tot_0 !< Summed partial derivative of vh with v
                                                      !! [H L ~> m2 or kg m-1].
   real, dimension(SZI_(G),SZJB_(G)), &
-                          intent(out) :: dv !< Corrective barotropic change in the velocity to give vhbt 
+                          intent(out) :: dv !< Corrective barotropic change in the velocity to give vhbt
                                             !! [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJB_(G)), &
-                          intent(in) :: dv_max_CFL !< Upper limit on dv correction to avoid CFL violations 
+                          intent(in) :: dv_max_CFL !< Upper limit on dv correction to avoid CFL violations
                                                    !! [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G)), &
-                          intent(in) :: dv_min_CFL !< Lower limit on dv correction to avoid CFL violations 
+                          intent(in) :: dv_min_CFL !< Lower limit on dv correction to avoid CFL violations
                                                    !! [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                       intent(inout) :: vh !< Volume flux through meridional faces = v*h*dx 
+                       intent(inout) :: vh !< Volume flux through meridional faces = v*h*dx
                                            !! [H L2 T-1 ~> m3 s-1 or kg s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)  :: visc_rem_v !< Both the fraction of the momentum
                                    !! originally in a layer that remains after a time-step of viscosity,
@@ -2120,7 +2122,7 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
                                                                   !! faces [H L2 T-1 ~> m3 s-1 or kg s-1].
   real,                                       intent(in)  :: dt   !< Time increment [T ~> s].
   type(unit_scale_type),                      intent(in)  :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                    intent(in)  :: CS   !< This module's control structure.G
+  type(continuity_PPM_CS),                    intent(in)  :: CS   !< This module's control structure.
   type(ocean_OBC_type),                       pointer     :: OBC  !< Open boundary condition type
                                                                   !! specifies whether, where, and what
                                                                   !! open boundary conditions are used.
@@ -2528,7 +2530,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
                                                                     !! [H ~> m or kg m-2].
   type(BT_cont_type),                         intent(inout) :: BT_cont !< A structure with elements
                        !! that describe the effective open face areas as a function of barotropic flow.
-  real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: dv0  !< The barotropic velocity increment that 
+  real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: dv0  !< The barotropic velocity increment that
                                                                     !! gives 0 transport [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: vh_tot_0 !< The summed transport
                        !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1280,7 +1280,6 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
 
 end subroutine zonal_flux_adjust
 
-
 !> Sets a structure that describes the zonal barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
 subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -661,6 +661,26 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
       duhdu_tot_0(I,j) = duhdu_tot_0(I,j) + duhdu(I, j, k)
       uh_tot_0(I,j) = uh_tot_0(I,j) + uh(I,j,k)
     enddo ; enddo ; enddo
+    if (use_visc_rem) then
+      if (CS%aggress_adjust) then
+        ! untested!
+        do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
+          if (CS%vol_CFL) then
+            dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
+            dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
+          else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+
+          du_lim = 0.499*((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k)))
+          if (du_max_CFL(I,j) * visc_rem(I,k) > du_lim) &
+            du_max_CFL(I,j) = du_lim / visc_rem(I,k)
+
+          du_lim = 0.499*((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k)))
+          if (du_min_CFL(I,j) * visc_rem(I,k) < du_lim) &
+            du_min_CFL(I,j) = du_lim / visc_rem(I,k)
+        enddo ; enddo ; enddo
+      endif
+    endif
+
   endif
 
   do j=jsh,jeh
@@ -674,20 +694,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     if (present(uhbt) .or. set_BT_cont) then
       if (use_visc_rem) then
         if (CS%aggress_adjust) then
-          do k=1,nz ; do I=ish-1,ieh
-            if (CS%vol_CFL) then
-              dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
-              dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
-            else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
-
-            du_lim = 0.499*((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k)))
-            if (du_max_CFL(I,j) * visc_rem(I,k) > du_lim) &
-              du_max_CFL(I,j) = du_lim / visc_rem(I,k)
-
-            du_lim = 0.499*((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k)))
-            if (du_min_CFL(I,j) * visc_rem(I,k) < du_lim) &
-              du_min_CFL(I,j) = du_lim / visc_rem(I,k)
-          enddo ; enddo
         else
           do k=1,nz ; do I=ish-1,ieh
             if (CS%vol_CFL) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2046,7 +2046,6 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
 
 end subroutine meridional_flux_thickness
 
-
 !> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
 subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
                              dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1280,6 +1280,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
 
 end subroutine zonal_flux_adjust
 
+
 !> Sets a structure that describes the zonal barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
 subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1154,7 +1154,7 @@ elemental subroutine flux_elem_OBC(u, h, h_p1, uh, duhdu, visc_rem, G, GV, por_f
                                                       !! u/v-faces of the h-cell [L ~> m].
           !! ratio of face areas to the cell areas when estimating the CFL number.
   type(ocean_OBC_type),     intent(in)    :: OBC !< Open boundaries control structure.
-  integer, intent(in) :: l_seg
+  integer, intent(in) :: l_seg !< Segment index.
 
   ! untested
   if (l_seg /= 0) then
@@ -1971,7 +1971,8 @@ subroutine present_vhbt_or_set_BT_cont(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0,
                                                !! vhbt as the depth-integrated transports [L T-1 ~> m s-1].
   type(BT_cont_type), optional, pointer :: BT_cont !< A structure with elements that describe the
                      !! effective open face areas as a function of barotropic flow.
-  real, dimension(SZI_(G),SZJB_(G)), optional, intent(in) :: vhbt
+  real, dimension(SZI_(G),SZJB_(G)), optional, intent(in) :: vhbt !< The summed volume flux through meridional
+                                                                  !! faces [H L2 T-1 ~> m3 s-1 or kg s-1].
   logical,                intent(in) :: set_BT_cont !< Whether to update BT_cont member arrays.
   logical,                intent(in) :: local_specified_BC !< Whether specified u BCs exist globally.
   logical,                intent(in) :: local_Flather_OBC !< Whether Flather u BCs exist globally.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1549,9 +1549,10 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
     uhtot_L, &    ! The summed transport with the westerly (uhtot_L) and
     uhtot_R       ! and easterly (uhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G)) :: &
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
     u_L, u_R, &   ! The westerly (u_L), easterly (u_R), and zero-barotropic
-    u_0, &        ! transport (u_0) layer test velocities [L T-1 ~> m s-1].
+    u_0           ! transport (u_0) layer test velocities [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G)) :: &
     duhdu_L, &    ! The effective layer marginal face areas with the westerly
     duhdu_R, &    ! (_L), easterly (_R), and zero-barotropic (_0) test
     duhdu_0, &    ! velocities [H L ~> m2 or kg m-1].
@@ -1615,19 +1616,20 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     endif
   endif ; enddo ; enddo ; enddo
 
+  do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh ; if (do_I(I,j)) then
+    u_L(I,j,k) = u(I,j,k) + duL(I,j) * visc_rem(I,j,k)
+    u_R(I,j,k) = u(I,j,k) + duR(I,j) * visc_rem(I,j,k)
+    u_0(I,j,k) = u(I,j,k) + du0(I,j) * visc_rem(I,j,k)
+  endif ; enddo ; enddo ; enddo
+
   do j=jsh,jeh
 
   do k=1,nz
-    do I=ish-1,ieh ; if (do_I(I,j)) then
-      u_L(I) = u(I,j,k) + duL(I,j) * visc_rem(I,j,k)
-      u_R(I) = u(I,j,k) + duR(I,j) * visc_rem(I,j,k)
-      u_0(I) = u(I,j,k) + du0(I,j) * visc_rem(I,j,k)
-    endif ; enddo
-    call zonal_flux_layer(u_0, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_0, duhdu_0, &
+    call zonal_flux_layer(u_0(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_0, duhdu_0, &
                           visc_rem(:,j,k), dt, G, US, j, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaU(:,j,k))
-    call zonal_flux_layer(u_L, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_L, duhdu_L, &
+    call zonal_flux_layer(u_L(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_L, duhdu_L, &
                           visc_rem(:,j,k), dt, G, US, j, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaU(:,j,k))
-    call zonal_flux_layer(u_R, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_R, duhdu_R, &
+    call zonal_flux_layer(u_R(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_R, duhdu_R, &
                           visc_rem(:,j,k), dt, G, US, j, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaU(:,j,k))
     do I=ish-1,ieh ; if (do_I(I,j)) then
       FAmt_0(I,j) = FAmt_0(I,j) + duhdu_0(I)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2198,7 +2198,6 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0
 
 end subroutine meridional_flux_adjust
 
-
 !> Sets of a structure that describes the meridional barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
 subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -724,7 +724,7 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     if (present(uhbt) .or. set_BT_cont) then
       ! untested!
       if (local_specified_BC .or. local_Flather_OBC) then ; do j=jsh,jeh ; do I=ish-1,ieh
-        l_seg = (OBC%segnum_u(I,j))
+        l_seg = abs(OBC%segnum_u(I,j))
 
         ! Avoid reconciling barotropic/baroclinic transports if transport is specified
         simple_OBC_pt(I) = .false.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1002,7 +1002,7 @@ elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh,
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim]
   real :: curv_3 ! A measure of the thickness curvature over a grid length [H ~> m or kg m-2]
   real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
-  real :: tmp
+  real :: tmp, dh
 
   ! Set new values of uh and duhdu.
   tmp = G_dy_Cu * por_face_areaU ! precalculate things
@@ -1010,16 +1010,18 @@ elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh,
     if (vol_CFL) then ; CFL = (u * dt) * (G_dy_Cu * G_IareaT)
     else ; CFL = u * dt * G_IdxT ; endif
     curv_3 = (h_W + h_E) - 2.0*h
+    dh = h_W - h_E
     uh = tmp * u * &
-        (h_E + CFL * (0.5*(h_W - h_E) + curv_3*(CFL - 1.5)))
-    h_marg = h_E + CFL * ((h_W - h_E) + 3.0*curv_3*(CFL - 1.0))
+        (h_E + CFL * (0.5*dh + curv_3*(CFL - 1.5)))
+    h_marg = h_E + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
   elseif (u < 0.0) then
     if (vol_CFL) then ; CFL = (-u * dt) * (G_dy_Cu * G_IareaT_p1)
     else ; CFL = -u * dt * G_IdxT_p1 ; endif
     curv_3 = (h_W_p1 + h_E_p1) - 2.0*h_p1
+    dh = h_E_p1-h_W_p1
     uh = tmp * u * &
-        (h_W_p1 + CFL * (0.5*(h_E_p1-h_W_p1) + curv_3*(CFL - 1.5)))
-    h_marg = h_W_p1 + CFL * ((h_E_p1-h_W_p1) + 3.0*curv_3*(CFL - 1.0))
+        (h_W_p1 + CFL * (0.5*dh + curv_3*(CFL - 1.5)))
+    h_marg = h_W_p1 + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
   else
     uh = 0.0
     h_marg = 0.5 * (h_W_p1 + h_E)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1780,11 +1780,11 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
 
     ! this is expensive
     if (.not.use_visc_rem) then
-      do concurrent (k=1:nz, i=ish:ieh)
+      do concurrent (k=1:nz, i=G%isd:G%ied)
         visc_rem_v_tmp(i,J,k) = 1.0
       enddo
     else
-      do concurrent (k=1:nz, i=ish:ieh)
+      do concurrent (k=1:nz, i=G%isd:G%ied)
         visc_rem_v_tmp(i,J,k) = visc_rem_v(i,J,k)
       enddo
     endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1048,8 +1048,8 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
 end subroutine zonal_BT_mass_flux
 
 !> Evaluates the zonal mass or volume fluxes in a layer.
-elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh, duhdu, visc_rem, G_dy_Cu, G_IareaT, G_IareaT_p1, &
-                                      G_IdxT, G_IdxT_p1, dt, G, GV, US, vol_CFL, por_face_areaU)
+elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh, duhdu, visc_rem, G_dy_Cu, G_IareaT, G_IareaT_p1, G_IdxT, G_IdxT_p1, dt, G, GV, US, &
+                            vol_CFL, por_face_areaU)
   type(ocean_grid_type),    intent(in)    :: G        !< Ocean's grid structure.
   type(verticalGrid_type),  intent(in)    :: GV       !< Ocean's vertical grid structure.
   real,                     intent(in)    :: u        !< Zonal velocity [L T-1 ~> m s-1].
@@ -1083,9 +1083,6 @@ elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh,
   ! Set new values of uh and duhdu.
   tmp = G_dy_Cu * por_face_areaU ! precalculate things
   CFL = abs(u*dt) ! increases inlining likelihood
-  c1 = 0.5 * (h_W_p1 + h_E)
-  c2 = 0.0
-  c3 = 0.0
   if (u > 0.0) then
     CFL = CFL * merge(G_dy_Cu * G_IareaT, G_IdxT, vol_CFL)
     c1 = h_E
@@ -1096,6 +1093,11 @@ elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh,
     c1 = h_W_p1
     c2 = h_E_p1
     c3 = h_p1
+  else
+    CFL = 0.0
+    c1 = 0.5 * (h_W_p1 + h_E)
+    c2 = 0.0
+    c3 = 0.0
   endif
   curv_3 = (c2 + c1) - 2.0*c3
   dh = (c2 - c1)
@@ -1525,8 +1527,8 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
         do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I))
           u_new = u(I,j,k) + du(I,j) * visc_rem(I,j,k)
           call zonal_flux_layere(u_new, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), h_E(I+1,j,k), &
-                                uh_aux(I,k), duhdu, visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), &
-                                G%IdxT(i+1,j), dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
+                                uh_aux(I,k), duhdu, visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), &
+                                dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
           ! Below if statement looks expensive in profiling results, but I believe it's
           ! masking the expensive update of uh_err beneath 
           if (local_OBC) call zonal_flux_layere_OBC(u_new, h_in, uh_aux(I,k), duhdu, visc_rem(I,j,k), &
@@ -1679,14 +1681,11 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
       u_R = u(I,j,k) + duR(I) * visc_rem(I,j,k)
       u_0 = u(I,j,k) + du0(I,j) * visc_rem(I,j,k)
       call zonal_flux_layere(u_0, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), h_E(I+1,j,k), uh_0, duhdu_0, &
-                            visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, &
-                            US, CS%vol_CFL, por_face_areaU(I,j,k))
+                            visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
       call zonal_flux_layere(u_L, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), h_E(I+1,j,k), uh_L, duhdu_L, &
-                            visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, &
-                            US, CS%vol_CFL, por_face_areaU(I,j,k))
+                            visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
       call zonal_flux_layere(u_R, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), h_E(I+1,j,k), uh_R, duhdu_R, &
-                            visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, &
-                            US, CS%vol_CFL, por_face_areaU(I,j,k))
+                            visc_rem(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
       FAmt_0(I) = FAmt_0(I) + duhdu_0
       FAmt_L(I) = FAmt_L(I) + duhdu_L
       FAmt_R(I) = FAmt_R(I) + duhdu_R

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2468,6 +2468,12 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
   integer :: i, j, k, ish, ieh, jsh, jeh, n, nz
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
 
+  !$omp target enter data &
+  !$omp   map(to: v(ish:ieh, :, :), G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%IareaT(ish:ieh, jsh-1:jeh+1), &
+  !$omp       G%IdyT(ish:ieh, jsh-1:jeh+1), h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), h(ish:ieh, :, :), &
+  !$omp       visc_rem_v(ish:ieh, :, :), por_face_areaV(ish:ieh, :, :)) &
+  !$omp   map(alloc: h_v(ish:ieh, :, :))
+
   !$omp target teams distribute parallel do collapse(3) &
   !$omp   private(CFL, curv_3, h_avg, h_marg) &
   !$omp   map(to: v(ish:ieh, :, :), G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%IareaT(ish:ieh, jsh-1:jeh+1), &
@@ -2574,6 +2580,13 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
       endif
     enddo
   endif
+
+  !$omp target exit data &
+  !$omp   map(from: h_v(ish:ieh, :, :)) &
+  !$omp   map(release: v(ish:ieh, :, :), G, G%dx_Cv(ish:ieh, jsh-1:jeh), &
+  !$omp       G%IareaT(ish:ieh, jsh-1:jeh+1), G%IdyT(ish:ieh, jsh-1:jeh+1), h_S(ish:ieh, :, :), &
+  !$omp       h_N(ish:ieh, :, :), h(ish:ieh, :, :), visc_rem_v(ish:ieh, :, :), &
+  !$omp       por_face_areaV(ish:ieh, :, :))
 
 end subroutine meridional_flux_thickness
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -622,21 +622,24 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
 
   do_I(:, :) = .true.
   
+  ! Set uh and duhdu.
   call zonal_flux_layer_fused(u, h_in, h_W, h_E, &
                               uh, duhdu, visc_rem_u_tmp, &
                               dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC, gv)
+  
+  ! untested!
+  if (local_specified_BC) then
+    do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh ; if (OBC%segnum_u(I,j) /= 0) then
+      l_seg = abs(OBC%segnum_u(I,j))
+      if (OBC%segment(l_seg)%specified) uh(I,j,k) = OBC%segment(l_seg)%normal_trans(I,j,k)
+    endif ; enddo ; enddo ; enddo
+  endif
   do j=jsh,jeh
-    ! Set uh and duhdu.
+    ! init visc_rem. This will be parted out later
     do k=1,nz
       if (use_visc_rem) then ; do I=ish-1,ieh
         visc_rem(I,k) = visc_rem_u(I,j,k)
       enddo ; endif
-      if (local_specified_BC) then
-        do I=ish-1,ieh ; if (OBC%segnum_u(I,j) /= 0) then
-          l_seg = abs(OBC%segnum_u(I,j))
-          if (OBC%segment(l_seg)%specified) uh(I,j,k) = OBC%segment(l_seg)%normal_trans(I,j,k)
-        endif ; enddo
-      endif
     enddo
 
     if (present(uhbt) .or. set_BT_cont) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2947,6 +2947,10 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, sim
     call MOM_error(FATAL,mesg)
   endif
 
+  !$omp target enter data &
+  !$omp   map(to: G, G%mask2dT(isl:iel, jsl-2:jel+2), h_in(isl:iel, :, :)) &
+  !$omp   map(alloc: slp, h_S, h_N)
+
   if (simple_2nd) then
     ! untested
     !$omp target teams distribute parallel do collapse(3) &
@@ -3049,6 +3053,10 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, sim
   else
     call PPM_limit_pos(h_in, h_S, h_N, h_min, G, GV, isl, iel, jsl, jel, nz)
   endif
+
+  !$omp target exit data &
+  !$omp   map(release: G, G%mask2dT(isl:iel, jsl-2:jel+2), h_in(isl:iel, :, :), slp) &
+  !$omp   map(from: h_S, h_N)
 
   return
 end subroutine PPM_reconstruction_y

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1628,9 +1628,7 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
   call zonal_flux_layer_fused(u_R, h_in, h_W, h_E, uh_R, duhdu_R, &
                         visc_rem, dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, gv=gv)
 
-  do j=jsh,jeh
-
-  do k=1,nz
+  do k=1,nz ; do j=jsh,jeh
     do I=ish-1,ieh ; if (do_I(I,j)) then
       FAmt_0(I,j) = FAmt_0(I,j) + duhdu_0(I,j,k)
       FAmt_L(I,j) = FAmt_L(I,j) + duhdu_L(I,j,k)
@@ -1638,8 +1636,9 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
       uhtot_L(I,j) = uhtot_L(I,j) + uh_L(I,j,k)
       uhtot_R(I,j) = uhtot_R(I,j) + uh_R(I,j,k)
     endif ; enddo
-  enddo
-  do I=ish-1,ieh ; if (do_I(I,j)) then
+  enddo ; enddo
+
+  do j=jsh,jeh ; do I=ish-1,ieh ; if (do_I(I,j)) then
     FA_0 = FAmt_0(I,j) ; FA_avg = FAmt_0(I,j)
     if ((duL(I,j) - du0(I,j)) /= 0.0) &
       FA_avg = uhtot_L(I,j) / (duL(I,j) - du0(I,j))
@@ -1667,9 +1666,7 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
     BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
     BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
-  endif ; enddo
-
-  enddo
+  endif ; enddo ; enddo
 
 end subroutine set_zonal_BT_cont_fused
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2866,22 +2866,22 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
   ! Local variables
   real, dimension(SZI_(G),SZJB_(G)) :: &
     dv0, &        ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
-    zeros         ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
-  real, dimension(SZI_(G)) :: &
     dvL, dvR, &   ! The barotropic velocity increments that give the southerly
                   ! (dvL) and northerly (dvR) test velocities [L T-1 ~> m s-1].
     dv_CFL, &     ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
+    zeros, &      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
+    FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
+    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
+    vhtot_L, &    ! The summed transport with the southerly (vhtot_L) and
+    vhtot_R       ! and northerly (vhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G)) :: &
     v_L, v_R, &   ! The southerly (v_L), northerly (v_R), and zero-barotropic
     v_0, &        ! transport (v_0) layer test velocities [L T-1 ~> m s-1].
     dvhdv_L, &    ! The effective layer marginal face areas with the southerly
     dvhdv_R, &    ! (_L), northerly (_R), and zero-barotropic (_0) test
     dvhdv_0, &    ! velocities [H L ~> m2 or kg m-1].
     vh_L, vh_R, & ! The layer transports with the southerly (_L), northerly (_R)
-    vh_0, &       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-    FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
-    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
-    vhtot_L, &    ! The summed transport with the southerly (vhtot_L) and
-    vhtot_R       ! and northerly (vhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+    vh_0       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
   real :: FA_0    ! The effective face area with 0 barotropic transport [H L ~> m2 or kg m-1].
   real :: FA_avg  ! The average effective face area [H L ~> m2 or kg m-1], nominally given by
                   ! the realized transport divided by the barotropic velocity.
@@ -2906,20 +2906,20 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
   call meridional_flux_adjust_fused(v, h_in, h_S, h_N, zeros, vh_tot_0, dvhdv_tot_0, dv0, &
                          dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
                          ish, ieh, jsh, jeh, do_I, por_face_areaV)
-  do j = jsh-1, jeh
 
   !   Determine the southerly- and northerly- fluxes.  Choose a sufficiently
   ! negative velocity correction for the northerly-flux, and a sufficiently
   ! positive correction for the southerly-flux.
   domore = .false.
-  do i=ish,ieh ; if (do_I(i,j)) then
+  do j=jsh-1,jeh ; do i=ish,ieh ; if (do_I(i,j)) then
     domore = .true.
-    dv_CFL(i) = (CFL_min * Idt) * G%dyCv(i,J)
-    dvR(i) = min(0.0,dv0(i,j) - dv_CFL(i))
-    dvL(i) = max(0.0,dv0(i,j) + dv_CFL(i))
-    FAmt_L(i) = 0.0 ; FAmt_R(i) = 0.0 ; FAmt_0(i) = 0.0
-    vhtot_L(i) = 0.0 ; vhtot_R(i) = 0.0
-  endif ; enddo
+    dv_CFL(i,j) = (CFL_min * Idt) * G%dyCv(i,J)
+    dvR(i,j) = min(0.0,dv0(i,j) - dv_CFL(i,j))
+    dvL(i,j) = max(0.0,dv0(i,j) + dv_CFL(i,j))
+    FAmt_L(i,j) = 0.0 ; FAmt_R(i,j) = 0.0 ; FAmt_0(i,j) = 0.0
+    vhtot_L(i,j) = 0.0 ; vhtot_R(i,j) = 0.0
+  endif ; enddo ; enddo
+  do j = jsh-1, jeh
 
   if (.not.domore) then
     do k=1,nz ; do i=ish,ieh
@@ -2934,16 +2934,16 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
   do k=1,nz ; do i=ish,ieh ; if (do_I(i,j)) then
     visc_rem_lim = max(visc_rem(i,j,k), min_visc_rem*visc_rem_max(i,j))
     if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
-      if (v(i,J,k) + dvR(i)*visc_rem_lim > -dv_CFL(i)*visc_rem(i,j,k)) &
-        dvR(i) = -(v(i,J,k) + dv_CFL(i)*visc_rem(i,j,k)) / visc_rem_lim
-      if (v(i,J,k) + dvL(i)*visc_rem_lim < dv_CFL(i)*visc_rem(i,j,k)) &
-        dvL(i) = -(v(i,J,k) - dv_CFL(i)*visc_rem(i,j,k)) / visc_rem_lim
+      if (v(i,J,k) + dvR(i,j)*visc_rem_lim > -dv_CFL(i,j)*visc_rem(i,j,k)) &
+        dvR(i,j) = -(v(i,J,k) + dv_CFL(i,j)*visc_rem(i,j,k)) / visc_rem_lim
+      if (v(i,J,k) + dvL(i,j)*visc_rem_lim < dv_CFL(i,j)*visc_rem(i,j,k)) &
+        dvL(i,j) = -(v(i,J,k) - dv_CFL(i,j)*visc_rem(i,j,k)) / visc_rem_lim
     endif
   endif ; enddo ; enddo
   do k=1,nz
     do i=ish,ieh ; if (do_I(i,j)) then
-      v_L(i) = v(I,j,k) + dvL(i) * visc_rem(i,j,k)
-      v_R(i) = v(I,j,k) + dvR(i) * visc_rem(i,j,k)
+      v_L(i) = v(I,j,k) + dvL(i,j) * visc_rem(i,j,k)
+      v_R(i) = v(I,j,k) + dvR(i,j) * visc_rem(i,j,k)
       v_0(i) = v(I,j,k) + dv0(i,j) * visc_rem(i,j,k)
     endif ; enddo
     call merid_flux_layer(v_0, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_0, dvhdv_0, &
@@ -2953,34 +2953,34 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     call merid_flux_layer(v_R, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_R, dvhdv_R, &
                           visc_rem(:,j,k), dt, G, US, J, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaV(:,:,k))
     do i=ish,ieh ; if (do_I(i,j)) then
-      FAmt_0(i) = FAmt_0(i) + dvhdv_0(i)
-      FAmt_L(i) = FAmt_L(i) + dvhdv_L(i)
-      FAmt_R(i) = FAmt_R(i) + dvhdv_R(i)
-      vhtot_L(i) = vhtot_L(i) + vh_L(i)
-      vhtot_R(i) = vhtot_R(i) + vh_R(i)
+      FAmt_0(i,j) = FAmt_0(i,j) + dvhdv_0(i)
+      FAmt_L(i,j) = FAmt_L(i,j) + dvhdv_L(i)
+      FAmt_R(i,j) = FAmt_R(i,j) + dvhdv_R(i)
+      vhtot_L(i,j) = vhtot_L(i,j) + vh_L(i)
+      vhtot_R(i,j) = vhtot_R(i,j) + vh_R(i)
     endif ; enddo
   enddo
   do i=ish,ieh ; if (do_I(i,j)) then
-    FA_0 = FAmt_0(i) ; FA_avg = FAmt_0(i)
-    if ((dvL(i) - dv0(i,j)) /= 0.0) &
-      FA_avg = vhtot_L(i) / (dvL(i) - dv0(i,j))
-    if (FA_avg > max(FA_0, FAmt_L(i))) then ; FA_avg = max(FA_0, FAmt_L(i))
-    elseif (FA_avg < min(FA_0, FAmt_L(i))) then ; FA_0 = FA_avg ; endif
-    BT_cont%FA_v_S0(i,J) = FA_0 ; BT_cont%FA_v_SS(i,J) = FAmt_L(i)
-    if (abs(FA_0-FAmt_L(i)) <= 1e-12*FA_0) then ; BT_cont%vBT_SS(i,J) = 0.0 ; else
-      BT_cont%vBT_SS(i,J) = (1.5 * (dvL(i) - dv0(i,j))) * &
-                   ((FAmt_L(i) - FA_avg) / (FAmt_L(i) - FA_0))
+    FA_0 = FAmt_0(i,j) ; FA_avg = FAmt_0(i,j)
+    if ((dvL(i,j) - dv0(i,j)) /= 0.0) &
+      FA_avg = vhtot_L(i,j) / (dvL(i,j) - dv0(i,j))
+    if (FA_avg > max(FA_0, FAmt_L(i,j))) then ; FA_avg = max(FA_0, FAmt_L(i,j))
+    elseif (FA_avg < min(FA_0, FAmt_L(i,j))) then ; FA_0 = FA_avg ; endif
+    BT_cont%FA_v_S0(i,J) = FA_0 ; BT_cont%FA_v_SS(i,J) = FAmt_L(i,j)
+    if (abs(FA_0-FAmt_L(i,j)) <= 1e-12*FA_0) then ; BT_cont%vBT_SS(i,J) = 0.0 ; else
+      BT_cont%vBT_SS(i,J) = (1.5 * (dvL(i,j) - dv0(i,j))) * &
+                   ((FAmt_L(i,j) - FA_avg) / (FAmt_L(i,j) - FA_0))
     endif
 
-    FA_0 = FAmt_0(i) ; FA_avg = FAmt_0(i)
-    if ((dvR(i) - dv0(i,j)) /= 0.0) &
-      FA_avg = vhtot_R(i) / (dvR(i) - dv0(i,j))
-    if (FA_avg > max(FA_0, FAmt_R(i))) then ; FA_avg = max(FA_0, FAmt_R(i))
-    elseif (FA_avg < min(FA_0, FAmt_R(i))) then ; FA_0 = FA_avg ; endif
-    BT_cont%FA_v_N0(i,J) = FA_0 ; BT_cont%FA_v_NN(i,J) = FAmt_R(i)
-    if (abs(FAmt_R(i) - FA_0) <= 1e-12*FA_0) then ; BT_cont%vBT_NN(i,J) = 0.0 ; else
-      BT_cont%vBT_NN(i,J) = (1.5 * (dvR(i) - dv0(i,j))) * &
-                   ((FAmt_R(i) - FA_avg) / (FAmt_R(i) - FA_0))
+    FA_0 = FAmt_0(i,j) ; FA_avg = FAmt_0(i,j)
+    if ((dvR(i,j) - dv0(i,j)) /= 0.0) &
+      FA_avg = vhtot_R(i,j) / (dvR(i,j) - dv0(i,j))
+    if (FA_avg > max(FA_0, FAmt_R(i,j))) then ; FA_avg = max(FA_0, FAmt_R(i,j))
+    elseif (FA_avg < min(FA_0, FAmt_R(i,j))) then ; FA_0 = FA_avg ; endif
+    BT_cont%FA_v_N0(i,J) = FA_0 ; BT_cont%FA_v_NN(i,J) = FAmt_R(i,j)
+    if (abs(FAmt_R(i,j) - FA_0) <= 1e-12*FA_0) then ; BT_cont%vBT_NN(i,J) = 0.0 ; else
+      BT_cont%vBT_NN(i,J) = (1.5 * (dvR(i,j) - dv0(i,j))) * &
+                   ((FAmt_R(i,j) - FA_avg) / (FAmt_R(i,j) - FA_0))
     endif
   else
     BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -652,8 +652,9 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   !$omp       u_cor(ish-1:ieh, :, :), BT_cont%FA_u_E0(ish-1:ieh, jsh:jeh), &
   !$omp       BT_cont%FA_u_W0(ish-1:ieh, jsh:jeh), BT_cont%FA_u_EE(ish-1:ieh, jsh:jeh), &
   !$omp       BT_cont%FA_u_WW(ish-1:ieh, jsh:jeh), BT_cont%uBT_EE(ish-1:ieh, jsh:jeh), &
-  !$omp       BT_cont%uBT_WW(ish-1:ieh, jsh:jeh), du_cor(ish-1:ieh, jsh:jeh), duhdu(ish-1:ieh, :, :), &
-  !$omp       du(ish-1:ieh, jsh:jeh), du_min_CFL(ish-1:ieh, jsh:jeh), du_max_CFL(ish-1:ieh, jsh:jeh), &
+  !$omp       BT_cont%uBT_WW(ish-1:ieh, jsh:jeh), BT_cont%h_u(ish-1:ieh, :, :), &
+  !$omp       du_cor(ish-1:ieh, jsh:jeh), duhdu(ish-1:ieh, :, :), du(ish-1:ieh, jsh:jeh), &
+  !$omp       du_min_CFL(ish-1:ieh, jsh:jeh), du_max_CFL(ish-1:ieh, jsh:jeh), &
   !$omp       duhdu_tot_0(ish-1:ieh, jsh:jeh), uh_tot_0(ish-1:ieh, jsh:jeh), &
   !$omp       visc_rem_max(ish-1:ieh, jsh:jeh))
 
@@ -990,7 +991,8 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   !$omp   map(from: uh(ish-1:ieh, :, :), u_cor(ish-1:ieh, :, :), BT_cont%FA_u_E0(ish-1:ieh, jsh:jeh), &
   !$omp       BT_cont%FA_u_W0(ish-1:ieh, jsh:jeh), BT_cont%FA_u_EE(ish-1:ieh, jsh:jeh), &
   !$omp       BT_cont%FA_u_WW(ish-1:ieh, jsh:jeh), BT_cont%uBT_EE(ish-1:ieh, jsh:jeh), &
-  !$omp       BT_cont%uBT_WW(ish-1:ieh, jsh:jeh), du_cor(ish-1:ieh, jsh:jeh)) &
+  !$omp       BT_cont%uBT_WW(ish-1:ieh, jsh:jeh), BT_cont%h_u(ish-1:ieh, :, :), &
+  !$omp       du_cor(ish-1:ieh, jsh:jeh)) &
   !$omp   map(release: visc_rem_u_tmp(ish-1:ieh, :, :), do_I(ish-1:ieh, jsh:jeh), G, &
   !$omp       G%dy_Cu(ish-1:ieh, jsh:jeh), G%IareaT(ish-1:ieh+1, jsh:jeh), &
   !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), G%areaT(ish-1:ieh+1, jsh:jeh), &
@@ -1914,14 +1916,16 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   !$omp target enter data &
   !$omp   map(to: G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%IdyT(ish:ieh, jsh-1:jeh+1), &
   !$omp       G%dyT(ish:ieh, jsh-1:jeh+1), G%dyT(ish:ieh, jsh-1:jeh+1), G%dyCv(ish:ieh, jsh-1:jeh), &
-  !$omp       G%mask2dCv(ish:ieh, jsh-1:jeh), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
+  !$omp       G%mask2dCv(ish:ieh, jsh-1:jeh), G%areaT(ish:ieh, jsh-1:jeh+1), &
+  !$omp       G%IareaT(ish:ieh, jsh-1:jeh+1), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
   !$omp       h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), CS, por_face_areaV(ish:ieh, :, :), &
   !$omp       vhbt(ish:ieh, jsh-1:jeh), visc_rem_v(ish:ieh, :, :), BT_cont) &
   !$omp   map(alloc: vh(ish:ieh, :, :), v_cor(ish:ieh, :, :), BT_cont%FA_v_S0(ish:ieh, jsh-1:jeh), &
   !$omp       BT_cont%FA_v_SS(ish:ieh, jsh-1:jeh), BT_cont%vBT_SS(ish:ieh, jsh-1:jeh), &
   !$omp       BT_cont%FA_v_N0(ish:ieh, jsh-1:jeh), BT_cont%FA_v_NN(ish:ieh, jsh-1:jeh), &
-  !$omp       BT_cont%vBT_NN(ish:ieh, jsh-1:jeh), dv_cor(ish:ieh, jsh-1:jeh), dvhdv(ish:ieh, :, :), &
-  !$omp       dv(ish:ieh, jsh-1:jeh), dv_min_CFL(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%vBT_NN(ish:ieh, jsh-1:jeh), BT_cont%h_v(ish:ieh, :, :), &
+  !$omp       dv_cor(ish:ieh, jsh-1:jeh), dvhdv(ish:ieh, :, :), dv(ish:ieh, jsh-1:jeh), &
+  !$omp       dv_min_CFL(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
   !$omp       dvhdv_tot_0(ish:ieh, jsh-1:jeh), vh_tot_0(ish:ieh, jsh-1:jeh), &
   !$omp       visc_rem_max(ish:ieh, jsh-1:jeh), do_I(ish:ieh, jsh-1:jeh), FAvi(ish:ieh, jsh-1:jeh), &
   !$omp       visc_rem_v_tmp(ish:ieh, :, :), simple_OBC_pt(ish:ieh, jsh:jeh))
@@ -2253,10 +2257,12 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   !$omp   map(from: vh(ish:ieh, :, :), v_cor(ish:ieh, :, :), BT_cont%FA_v_S0(ish:ieh, jsh-1:jeh), &
   !$omp       BT_cont%FA_v_SS(ish:ieh, jsh-1:jeh), BT_cont%vBT_SS(ish:ieh, jsh-1:jeh), &
   !$omp       BT_cont%FA_v_N0(ish:ieh, jsh-1:jeh), BT_cont%FA_v_NN(ish:ieh, jsh-1:jeh), &
-  !$omp       BT_cont%vBT_NN(ish:ieh, jsh-1:jeh), dv_cor(ish:ieh, jsh-1:jeh)) &
+  !$omp       BT_cont%vBT_NN(ish:ieh, jsh-1:jeh), BT_cont%h_v(ish:ieh, :, :), &
+  !$omp       dv_cor(ish:ieh, jsh-1:jeh)) &
   !$omp   map(release: G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%IdyT(ish:ieh, jsh-1:jeh+1), &
   !$omp       G%dyT(ish:ieh, jsh-1:jeh+1), G%dyT(ish:ieh, jsh-1:jeh+1), G%dyCv(ish:ieh, jsh-1:jeh), &
-  !$omp       G%mask2dCv(ish:ieh, jsh-1:jeh), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
+  !$omp       G%mask2dCv(ish:ieh, jsh-1:jeh), G%areaT(ish:ieh, jsh-1:jeh+1), &
+  !$omp       G%IareaT(ish:ieh, jsh-1:jeh+1), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
   !$omp       h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), CS, por_face_areaV(ish:ieh, :, :), &
   !$omp       vhbt(ish:ieh, jsh-1:jeh), visc_rem_v(ish:ieh, :, :), dvhdv(ish:ieh, :, :), &
   !$omp       dv(ish:ieh, jsh-1:jeh), dv_min_CFL(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -623,7 +623,7 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   ! Set uh and duhdu.
   call zonal_flux_layer(u, h_in, h_W, h_E, &
                         uh, duhdu, visc_rem_u_tmp, &
-                        dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC, gv)
+                        dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC)
   
   ! untested!
   if (local_specified_BC) then
@@ -900,7 +900,7 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
 
   ! This sets uh and duhdu.
   call zonal_flux_layer(u, h_in, h_W, h_E, uh, duhdu, ones, &
-                        dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC, GV)
+                        dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC)
   
   do k=1,nz ; do j=jsh,jeh ; do i=ish-1,ieh
     if (OBC_in_row(j) .and. OBC%segnum_u(I,j) /= 0) then
@@ -919,8 +919,8 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
 end subroutine zonal_BT_mass_flux
 
 !> Evaluates the zonal mass or volume fluxes in a layer.
-subroutine zonal_flux_layer(u, h, h_W, h_E, uh, duhdu, visc_rem, dt, G, US, &
-                            ish, ieh, jsh, jeh, nz, do_I, vol_CFL, por_face_areaU, OBC, GV)
+subroutine zonal_flux_layer(u, h, h_W, h_E, uh, duhdu, visc_rem, dt, G, GV, US, &
+                            ish, ieh, jsh, jeh, nz, do_I, vol_CFL, por_face_areaU, OBC)
   type(ocean_grid_type),    intent(in)    :: G        !< Ocean's grid structure.
   type(verticalGrid_type),  intent(in)    :: GV       !< Ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
@@ -1254,7 +1254,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
       do I=ish-1,ieh ; u_new(I,j,k) = u(I,j,k) + du(I,j) * visc_rem(I,j,k) ; enddo ; enddo ; enddo
       call zonal_flux_layer(u_new, h_in, h_W, h_E, &
                             uh_aux, duhdu, visc_rem, &
-                            dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC, GV)
+                            dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC)
     endif
 
     if (itt < max_itts) then
@@ -1411,11 +1411,11 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, 
   endif ; enddo ; enddo ; enddo
 
   call zonal_flux_layer(u_0, h_in, h_W, h_E, uh_0, duhdu_0, &
-                        visc_rem, dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, gv=gv)
+                        visc_rem, dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU)
   call zonal_flux_layer(u_L, h_in, h_W, h_E, uh_L, duhdu_L, &
-                        visc_rem, dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, gv=gv)
+                        visc_rem, dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU)
   call zonal_flux_layer(u_R, h_in, h_W, h_E, uh_R, duhdu_R, &
-                        visc_rem, dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, gv=gv)
+                        visc_rem, dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU)
 
   do k=1,nz ; do j=jsh,jeh
     do I=ish-1,ieh ; if (do_I(I,j)) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1002,27 +1002,29 @@ elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh,
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim]
   real :: curv_3 ! A measure of the thickness curvature over a grid length [H ~> m or kg m-2]
   real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
+  real :: tmp
 
   ! Set new values of uh and duhdu.
+  tmp = G_dy_Cu * por_face_areaU ! precalculate things
   if (u > 0.0) then
     if (vol_CFL) then ; CFL = (u * dt) * (G_dy_Cu * G_IareaT)
     else ; CFL = u * dt * G_IdxT ; endif
     curv_3 = (h_W + h_E) - 2.0*h
-    uh = (G_dy_Cu * por_face_areaU) * u * &
+    uh = tmp * u * &
         (h_E + CFL * (0.5*(h_W - h_E) + curv_3*(CFL - 1.5)))
     h_marg = h_E + CFL * ((h_W - h_E) + 3.0*curv_3*(CFL - 1.0))
   elseif (u < 0.0) then
     if (vol_CFL) then ; CFL = (-u * dt) * (G_dy_Cu * G_IareaT_p1)
     else ; CFL = -u * dt * G_IdxT_p1 ; endif
     curv_3 = (h_W_p1 + h_E_p1) - 2.0*h_p1
-    uh = (G_dy_Cu * por_face_areaU) * u * &
+    uh = tmp * u * &
         (h_W_p1 + CFL * (0.5*(h_E_p1-h_W_p1) + curv_3*(CFL - 1.5)))
     h_marg = h_W_p1 + CFL * ((h_E_p1-h_W_p1) + 3.0*curv_3*(CFL - 1.0))
   else
     uh = 0.0
     h_marg = 0.5 * (h_W_p1 + h_E)
   endif
-  duhdu = (G_dy_Cu * por_face_areaU) * h_marg * visc_rem
+  duhdu = tmp * h_marg * visc_rem
 
 end subroutine zonal_flux_layere
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -988,10 +988,10 @@ subroutine zonal_flux_layer(u, h, h_W, h_E, uh, duhdu, visc_rem, dt, G, GV, US, 
 
   !$omp target teams distribute parallel do collapse(3) &
   !$omp   private(CFL, curv_3, h_marg) &
-  !$omp   map(to: do_I(ish-1:ieh, jsh:jeh), u(ish-1:ieh, :, :), u(ish-1:ieh, :, :), G, &
-  !$omp       G%dy_Cu(ish-1:ieh, jsh:jeh), G%IareaT(ish-1:ieh+1, jsh:jeh), &
-  !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), h_W(ish-1:ieh+1, :, :), h_E(ish-1:ieh+1, :, :), &
-  !$omp       h(ish-1:ieh+1, :, :), por_face_areaU(ish-1:ieh, :, :), visc_rem(ish-1:ieh, :, :)) &
+  !$omp   map(to: do_I(ish-1:ieh, jsh:jeh), u(ish-1:ieh, :, :), G, G%dy_Cu(ish-1:ieh, jsh:jeh), &
+  !$omp       G%IareaT(ish-1:ieh+1, jsh:jeh), G%IdxT(ish-1:ieh+1, jsh:jeh), h_W(ish-1:ieh+1, :, :), &
+  !$omp       h_E(ish-1:ieh+1, :, :), h(ish-1:ieh+1, :, :), por_face_areaU(ish-1:ieh, :, :), &
+  !$omp       visc_rem(ish-1:ieh, :, :)) &
   !$omp   map(tofrom: uh(ish-1:ieh, :, :), duhdu(ish-1:ieh, :, :)) ! tofrom so non-updated elems so we don't accidentally zero old values
   do k = 1, nz; do j = jsh, jeh; do I=ish-1,ieh ; if (do_I(I, j)) then
     ! Set new values of uh and duhdu.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2047,6 +2047,7 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
 
 end subroutine meridional_flux_thickness
 
+
 !> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
 subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
                              dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
@@ -2198,6 +2199,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0
   enddo ; enddo ; enddo ; endif
 
 end subroutine meridional_flux_adjust
+
 
 !> Sets of a structure that describes the meridional barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -160,9 +160,6 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
       "MOM_continuity_PPM: Either both visc_rem_u and visc_rem_v or neither"// &
       " one must be present in call to continuity_PPM.")
 
-  ! update device visc_rem_u for zonal_mass_flux
-  !$omp target update to(visc_rem_u, u, visc_rem_v, v)
-  ! problems with hin
   !$omp target enter data &
   !$omp   map(to: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
   !$omp     G%mask2dT, G%dx_Cv, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h, CS, US, OBC, pbv, &
@@ -209,13 +206,6 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
                          LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
     call continuity_zonal_convergence(h, uh, dt, G, GV, LB, hmin=h_min)
   endif
-
-  !$omp target update from(uh, u_cor, du_cor, vh, v_cor, dv_cor)
-  !$omp target update from(BT_cont%FA_u_W0, BT_cont%FA_u_WW, BT_cont%FA_u_E0, BT_cont%FA_u_EE, &
-  !$omp       BT_cont%uBT_WW, BT_cont%uBT_EE, BT_cont%h_u)
-  !$omp target update from(BT_cont%FA_v_S0, BT_cont%FA_v_SS, BT_cont%FA_v_N0, BT_cont%FA_v_NN, &
-  !$omp       BT_cont%vBT_SS, BT_cont%vBT_NN, BT_cont%h_v)
-  !$omp target update from(h)
 
   !$omp target exit data &
   !$omp   map(from: uh, h, vh, u_cor, v_cor, du_cor, dv_cor, BT_cont%FA_u_E0, BT_cont%FA_u_W0, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -622,8 +622,8 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   
   ! Set uh and duhdu.
   call zonal_flux_layer(u, h_in, h_W, h_E, &
-                              uh, duhdu, visc_rem_u_tmp, &
-                              dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC, gv)
+                        uh, duhdu, visc_rem_u_tmp, &
+                        dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, OBC, gv)
   
   ! untested!
   if (local_specified_BC) then
@@ -1818,7 +1818,7 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
   
   ! This sets vh and dvhdv.
   call merid_flux_layer(v, h_in, h_S, h_N, vh, dvhdv, ones, &
-    dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaV, OBC)
+                        dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaV, OBC)
   
   do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh
     if (OBC_in_row(j) .and. OBC%segnum_v(i,J) /= 0) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2491,6 +2491,19 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0
 
   nz = GV%ke
 
+  !$omp target enter data &
+  !$omp   map(to: G, G%IareaT(ish:ieh, jsh-1:jeh+1), G%IdyT(ish:ieh, jsh-1:jeh+1), &
+  !$omp       G%dx_Cv(ish:ieh, jsh-1:jeh), G%IdyT(ish:ieh, jsh-1:jeh+1), v(ish:ieh, :, :), &
+  !$omp       h_in(ish:ieh, :, :), h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), visc_rem(ish:ieh, :, :), &
+  !$omp       vhbt(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
+  !$omp       dv_min_CFL(ish:ieh, jsh-1:jeh), vh_tot_0(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot_0(ish:ieh, jsh-1:jeh), CS, do_I_in(ish:ieh, jsh-1:jeh), &
+  !$omp       por_face_areaV(ish:ieh, :, :), vh_3d(ish:ieh, :, :)) &
+  !$omp   map(alloc: dv(ish:ieh, jsh-1:jeh), vh_aux(ish:ieh, :, :), dvhdv(ish:ieh, :, :), &
+  !$omp       v_new(ish:ieh, :, :), vh_err(ish:ieh, jsh-1:jeh), vh_err_best(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot(ish:ieh, jsh-1:jeh), dv_min(ish:ieh, jsh-1:jeh), dv_max(ish:ieh, jsh-1:jeh), &
+  !$omp       do_I(ish:ieh, jsh-1:jeh))
+
   !$omp target teams distribute parallel do collapse(3) &
   !$omp   map(from: vh_aux(ish:ieh, :, :), dvhdv(ish:ieh, :, :))
   do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh
@@ -2615,6 +2628,19 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0
       vh_3d(i,J,k) = vh_aux(i,j,k)
     enddo ; enddo ; enddo
   endif
+
+  !$omp target exit data &
+  !$omp   map(from: dv(ish:ieh, jsh-1:jeh), vh_3d(ish:ieh, :, :)) &
+  !$omp   map(release: G, G%IareaT(ish:ieh, jsh-1:jeh+1), G%IdyT(ish:ieh, jsh-1:jeh+1), &
+  !$omp       G%dx_Cv(ish:ieh, jsh-1:jeh), G%IdyT(ish:ieh, jsh-1:jeh+1), v(ish:ieh, :, :), &
+  !$omp       h_in(ish:ieh, :, :), h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), visc_rem(ish:ieh, :, :), &
+  !$omp       vhbt(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
+  !$omp       dv_min_CFL(ish:ieh, jsh-1:jeh), vh_tot_0(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot_0(ish:ieh, jsh-1:jeh), CS, do_I_in(ish:ieh, jsh-1:jeh), &
+  !$omp       por_face_areaV(ish:ieh, :, :), vh_aux(ish:ieh, :, :), dvhdv(ish:ieh, :, :), &
+  !$omp       v_new(ish:ieh, :, :), vh_err(ish:ieh, jsh-1:jeh), vh_err_best(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot(ish:ieh, jsh-1:jeh), dv_min(ish:ieh, jsh-1:jeh), dv_max(ish:ieh, jsh-1:jeh), &
+  !$omp       do_I(ish:ieh, jsh-1:jeh))
 
 end subroutine meridional_flux_adjust
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1946,6 +1946,15 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   call merid_flux_layer_fused(v, h_in, h_S, h_N, &
                         vh, dvhdv, visc_rem_v_tmp, &
                         dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaV, OBC)
+
+  ! untested
+  if (local_specified_BC) then
+    do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh ; if (OBC%segnum_v(i,J) /= 0) then
+      l_seg = abs(OBC%segnum_v(i,J))
+      if (OBC%segment(l_seg)%specified) vh(i,J,k) = OBC%segment(l_seg)%normal_trans(i,J,k)
+    endif ; enddo ; enddo ; enddo
+  endif
+  
   !$OMP parallel do default(shared) private(do_I,dvhdv,dv,dv_max_CFL,dv_min_CFL,vh_tot_0, &
   !$OMP                                     dvhdv_tot_0,FAvi,visc_rem_max,I_vrm,dv_lim,dy_N,dy_S, &
   !$OMP                                     simple_OBC_pt,any_simple_OBC,l_seg) &
@@ -1956,12 +1965,6 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
       if (use_visc_rem) then ; do i=ish,ieh
         visc_rem(i,k) = visc_rem_v(i,J,k)
       enddo ; endif
-      if (local_specified_BC) then
-        do i=ish,ieh ; if (OBC%segnum_v(i,J) /= 0) then
-          l_seg = abs(OBC%segnum_v(i,J))
-          if (OBC%segment(l_seg)%specified) vh(i,J,k) = OBC%segment(l_seg)%normal_trans(i,J,k)
-        endif ; enddo
-      endif
     enddo ! k-loop
 
     if (present(vhbt) .or. set_BT_cont) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -669,12 +669,12 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
           else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
 
           du_lim = 0.499*((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k)))
-          if (du_max_CFL(I,j) * visc_rem(I,k) > du_lim) &
-            du_max_CFL(I,j) = du_lim / visc_rem(I,k)
+          if (du_max_CFL(I,j) * visc_rem_u_tmp(I,j,k) > du_lim) &
+            du_max_CFL(I,j) = du_lim / visc_rem_u_tmp(I,j,k)
 
           du_lim = 0.499*((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k)))
-          if (du_min_CFL(I,j) * visc_rem(I,k) < du_lim) &
-            du_min_CFL(I,j) = du_lim / visc_rem(I,k)
+          if (du_min_CFL(I,j) * visc_rem_u_tmp(I,j,k) < du_lim) &
+            du_min_CFL(I,j) = du_lim / visc_rem_u_tmp(I,j,k)
         enddo ; enddo ; enddo
       else
         do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
@@ -683,10 +683,10 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
             dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
           else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
 
-          if (du_max_CFL(I,j) * visc_rem(I,k) > dx_W*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
-            du_max_CFL(I,j) = (dx_W*CFL_dt - u(I,j,k)) / visc_rem(I,k)
-          if (du_min_CFL(I,j) * visc_rem(I,k) < -dx_E*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
-            du_min_CFL(I,j) = -(dx_E*CFL_dt + u(I,j,k)) / visc_rem(I,k)
+          if (du_max_CFL(I,j) * visc_rem_u_tmp(I,j,k) > dx_W*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
+            du_max_CFL(I,j) = (dx_W*CFL_dt - u(I,j,k)) / visc_rem_u_tmp(I,j,k)
+          if (du_min_CFL(I,j) * visc_rem_u_tmp(I,j,k) < -dx_E*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
+            du_min_CFL(I,j) = -(dx_E*CFL_dt + u(I,j,k)) / visc_rem_u_tmp(I,j,k)
         enddo ; enddo ; enddo
       endif
     else

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1595,6 +1595,7 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     uhtot_L(I,j) = 0.0 ; uhtot_R(I,j) = 0.0
   enddo ; enddo
 
+  ! short circuit if none should be updated
   if (.not.domore) then
     do k=1,nz ; do I=ish-1,ieh
       BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
@@ -1604,9 +1605,7 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     return
   endif
 
-  do j=jsh,jeh
-
-  do k=1,nz ; do I=ish-1,ieh ; if (do_I(I,j)) then
+  do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh ; if (do_I(I,j)) then
     visc_rem_lim = max(visc_rem(I,j,k), min_visc_rem*visc_rem_max(I,j))
     if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
       if (u(I,j,k) + duR(I,j)*visc_rem_lim > -du_CFL(I,j)*visc_rem(I,j,k)) &
@@ -1614,7 +1613,9 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
       if (u(I,j,k) + duL(I,j)*visc_rem_lim < du_CFL(I,j)*visc_rem(I,j,k)) &
         duL(I,j) = -(u(I,j,k) - du_CFL(I,j)*visc_rem(I,j,k)) / visc_rem_lim
     endif
-  endif ; enddo ; enddo
+  endif ; enddo ; enddo ; enddo
+
+  do j=jsh,jeh
 
   do k=1,nz
     do I=ish-1,ieh ; if (do_I(I,j)) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1675,7 +1675,7 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     endif ! present(vhbt) .or. set_BT_cont (redundant?)
     if (present(vhbt)) then
       ! Find dv and vh.
-      call meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, dv, &
+      call meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, dv, &
                              dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem_v, &
                              ish, ieh, jsh, jeh, do_I, por_face_areaV, vh, OBC=OBC)
 
@@ -2129,8 +2129,9 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
 
 end subroutine meridional_flux_thickness
 
+
 !> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
-subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
+subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
                              dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              ish, ieh, jsh, jeh, do_I_in, por_face_areaV, vh_3d, OBC)
   type(ocean_grid_type),             intent(in)  :: G    !< Ocean's grid structure.
@@ -2279,157 +2280,8 @@ subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv
     vh_3d(i,J,k) = vh_aux(i,j,k)
   enddo ; enddo ; enddo ; endif
 
-end subroutine meridional_flux_adjust_fused
-
-!> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
-subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
-                             dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             j, ish, ieh, do_I_in, por_face_areaV, vh_3d, OBC)
-  type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(in)    :: v    !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),&
-                           intent(in)    :: h_S  !< South edge thickness in the reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_N  !< North edge thickness in the reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZK_(GV)), intent(in) :: visc_rem
-                             !< Both the fraction of the momentum originally
-                             !! in a layer that remains after a time-step of viscosity, and the
-                             !! fraction of a time-step's worth of a barotropic acceleration that
-                             !! a layer experiences after viscosity is applied [nondim].
-                             !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G)), intent(in)    :: vhbt !< The summed volume flux through meridional faces
-                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)), intent(in)    :: dv_max_CFL !< Maximum acceptable value of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G)), intent(in)    :: dv_min_CFL !< Minimum acceptable value of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G)), intent(in)    :: vh_tot_0   !< The summed transport with 0 adjustment
-                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)), intent(in)    :: dvhdv_tot_0 !< The partial derivative of dv_err with
-                                                  !! dv at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G)), intent(out)   :: dv   !< The barotropic velocity adjustment [L T-1 ~> m s-1].
-  real,                     intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),  intent(in)    :: CS   !< This module's control structure.
-  integer,                  intent(in)    :: j    !< Spatial index.
-  integer,                  intent(in)    :: ish  !< Start of index range.
-  integer,                  intent(in)    :: ieh  !< End of index range.
-  logical, dimension(SZI_(G)), &
-                            intent(in)    :: do_I_in  !< A flag indicating which I values to work on.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                     intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                  optional, intent(inout) :: vh_3d !< Volume flux through meridional
-                             !! faces = v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
-  type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
-  ! Local variables
-  real, dimension(SZI_(G),SZK_(GV)) :: &
-    vh_aux, &  ! An auxiliary meridional volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
-    dvhdv      ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G)) :: &
-    vh_err, &  ! Difference between vhbt and the summed vh [H L2 T-1 ~> m3 s-1 or kg s-1].
-    vh_err_best, & ! The smallest value of vh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
-    v_new, &   ! The velocity with the correction added [L T-1 ~> m s-1].
-    dvhdv_tot,&! Summed partial derivative of vh with u [H L ~> m2 or kg m-1].
-    dv_min, &  ! Lower limit on dv correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
-    dv_max     ! Upper limit on dv correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
-  real :: dv_prev ! The previous value of dv [L T-1 ~> m s-1].
-  real :: ddv     ! The change in dv from the previous iteration [L T-1 ~> m s-1].
-  real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
-  real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
-  integer :: i, k, nz, itt, max_itts = 20
-  logical :: domore, do_I(SZI_(G))
-
-  nz = GV%ke
-
-  vh_aux(:,:) = 0.0 ; dvhdv(:,:) = 0.0
-
-  if (present(vh_3d)) then ; do k=1,nz ; do i=ish,ieh
-    vh_aux(i,k) = vh_3d(i,J,k)
-  enddo ; enddo ; endif
-
-  do i=ish,ieh
-    dv(i) = 0.0 ; do_I(i) = do_I_in(i)
-    dv_max(i) = dv_max_CFL(i) ; dv_min(i) = dv_min_CFL(i)
-    vh_err(i) = vh_tot_0(i) - vhbt(i) ; dvhdv_tot(i) = dvhdv_tot_0(i)
-    vh_err_best(i) = abs(vh_err(i))
-  enddo
-
-  do itt=1,max_itts
-    select case (itt)
-      case (:1) ; tol_eta = 1e-6 * CS%tol_eta
-      case (2)  ; tol_eta = 1e-4 * CS%tol_eta
-      case (3)  ; tol_eta = 1e-2 * CS%tol_eta
-      case default ; tol_eta = CS%tol_eta
-    end select
-    tol_vel = CS%tol_vel
-
-    do i=ish,ieh
-      if (vh_err(i) > 0.0) then ; dv_max(i) = dv(i)
-      elseif (vh_err(i) < 0.0) then ; dv_min(i) = dv(i)
-      else ; do_I(i) = .false. ; endif
-    enddo
-    domore = .false.
-    do i=ish,ieh ; if (do_I(i)) then
-      if ((dt * min(G%IareaT(i,j),G%IareaT(i,j+1))*abs(vh_err(i)) > tol_eta) .or. &
-          (CS%better_iter .and. ((abs(vh_err(i)) > tol_vel * dvhdv_tot(i)) .or. &
-                                 (abs(vh_err(i)) > vh_err_best(i))) )) then
-        !   Use Newton's method, provided it stays bounded.  Otherwise bisect
-        ! the value with the appropriate bound.
-        ddv = -vh_err(i) / dvhdv_tot(i)
-        dv_prev = dv(i)
-        dv(i) = dv(i) + ddv
-        if (abs(ddv) < 1.0e-15*abs(dv(i))) then
-          do_I(i) = .false. ! ddv is small enough to quit.
-        elseif (ddv > 0.0) then
-          if (dv(i) >= dv_max(i)) then
-            dv(i) = 0.5*(dv_prev + dv_max(i))
-            if (dv_max(i) - dv_prev < 1.0e-15*abs(dv(i))) do_I(i) = .false.
-          endif
-        else ! dvv(i) < 0.0
-          if (dv(i) <= dv_min(i)) then
-            dv(i) = 0.5*(dv_prev + dv_min(i))
-            if (dv_prev - dv_min(i) < 1.0e-15*abs(dv(i))) do_I(i) = .false.
-          endif
-        endif
-        if (do_I(i)) domore = .true.
-      else
-        do_I(i) = .false.
-      endif
-    endif ; enddo
-    if (.not.domore) exit
-
-    if ((itt < max_itts) .or. present(vh_3d)) then ; do k=1,nz
-      do i=ish,ieh ; v_new(i) = v(i,J,k) + dv(i) * visc_rem(i,k) ; enddo
-      call merid_flux_layer(v_new, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), &
-                            vh_aux(:,k), dvhdv(:,k), visc_rem(:,k), &
-                            dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k), OBC)
-    enddo ; endif
-
-    if (itt < max_itts) then
-      do i=ish,ieh
-        vh_err(i) = -vhbt(i) ; dvhdv_tot(i) = 0.0
-      enddo
-      do k=1,nz ; do i=ish,ieh
-        vh_err(i) = vh_err(i) + vh_aux(i,k)
-        dvhdv_tot(i) = dvhdv_tot(i) + dvhdv(i,k)
-      enddo ; enddo
-      do i=ish,ieh
-        vh_err_best(i) = min(vh_err_best(i), abs(vh_err(i)))
-      enddo
-    endif
-  enddo ! itt-loop
-  ! If there are any faces which have not converged to within the tolerance,
-  ! so-be-it, or else use a final upwind correction?
-  ! This never seems to happen with 20 iterations as max_itt.
-
-  if (present(vh_3d)) then ; do k=1,nz ; do i=ish,ieh
-    vh_3d(i,J,k) = vh_aux(i,k)
-  enddo ; enddo ; endif
-
 end subroutine meridional_flux_adjust
+
 
 !> Sets of a structure that describes the meridional barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
@@ -2512,7 +2364,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, 
 
  ! Diagnose the zero-transport correction, dv0.
   do j=jsh-1,jeh ; do i=ish,ieh ; zeros(i,j) = 0.0 ; enddo ; enddo
-  call meridional_flux_adjust_fused(v, h_in, h_S, h_N, zeros, vh_tot_0, dvhdv_tot_0, dv0, &
+  call meridional_flux_adjust(v, h_in, h_S, h_N, zeros, vh_tot_0, dvhdv_tot_0, dv0, &
                          dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
                          ish, ieh, jsh, jeh, do_I, por_face_areaV)
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2940,27 +2940,26 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     endif
   endif ; enddo ; enddo ; enddo
 
+  do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh ; if (do_I(i,j)) then
+    v_L(i,j,k) = v(I,j,k) + dvL(i,j) * visc_rem(i,j,k)
+    v_R(i,j,k) = v(I,j,k) + dvR(i,j) * visc_rem(i,j,k)
+    v_0(i,j,k) = v(I,j,k) + dv0(i,j) * visc_rem(i,j,k)
+  endif ; enddo ; enddo ; enddo
+  call merid_flux_layer_fused(v_0, h_in, h_S, h_N, vh_0, dvhdv_0, &
+                        visc_rem, dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaV)
+  call merid_flux_layer_fused(v_L, h_in, h_S, h_N, vh_L, dvhdv_L, &
+                        visc_rem, dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaV)
+  call merid_flux_layer_fused(v_R, h_in, h_S, h_N, vh_R, dvhdv_R, &
+                        visc_rem, dt, G, GV, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaV)
+  do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh ; if (do_I(i,j)) then
+    FAmt_0(i,j) = FAmt_0(i,j) + dvhdv_0(i,j,k)
+    FAmt_L(i,j) = FAmt_L(i,j) + dvhdv_L(i,j,k)
+    FAmt_R(i,j) = FAmt_R(i,j) + dvhdv_R(i,j,k)
+    vhtot_L(i,j) = vhtot_L(i,j) + vh_L(i,j,k)
+    vhtot_R(i,j) = vhtot_R(i,j) + vh_R(i,j,k)
+  endif ; enddo ; enddo ; enddo
+
   do j = jsh-1, jeh
-  do k=1,nz
-    do i=ish,ieh ; if (do_I(i,j)) then
-      v_L(i,j,k) = v(I,j,k) + dvL(i,j) * visc_rem(i,j,k)
-      v_R(i,j,k) = v(I,j,k) + dvR(i,j) * visc_rem(i,j,k)
-      v_0(i,j,k) = v(I,j,k) + dv0(i,j) * visc_rem(i,j,k)
-    endif ; enddo
-    call merid_flux_layer(v_0(:,j,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_0(:,j,k), dvhdv_0(:,j,k), &
-                          visc_rem(:,j,k), dt, G, US, J, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaV(:,:,k))
-    call merid_flux_layer(v_L(:,j,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_L(:,j,k), dvhdv_L(:,j,k), &
-                          visc_rem(:,j,k), dt, G, US, J, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaV(:,:,k))
-    call merid_flux_layer(v_R(:,j,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_R(:,j,k), dvhdv_R(:,j,k), &
-                          visc_rem(:,j,k), dt, G, US, J, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaV(:,:,k))
-    do i=ish,ieh ; if (do_I(i,j)) then
-      FAmt_0(i,j) = FAmt_0(i,j) + dvhdv_0(i,j,k)
-      FAmt_L(i,j) = FAmt_L(i,j) + dvhdv_L(i,j,k)
-      FAmt_R(i,j) = FAmt_R(i,j) + dvhdv_R(i,j,k)
-      vhtot_L(i,j) = vhtot_L(i,j) + vh_L(i,j,k)
-      vhtot_R(i,j) = vhtot_R(i,j) + vh_R(i,j,k)
-    endif ; enddo
-  enddo
   do i=ish,ieh ; if (do_I(i,j)) then
     FA_0 = FAmt_0(i,j) ; FA_avg = FAmt_0(i,j)
     if ((dvL(i,j) - dv0(i,j)) /= 0.0) &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -399,20 +399,14 @@ subroutine continuity_zonal_convergence(h, uh, dt, G, GV, LB, hin, hmin)
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
 
   if (present(hin)) then
-    !$omp target teams distribute parallel do collapse(3) &
-    !$omp   map(to: hin(ish:ieh, :, :), G, G%IareaT(ish:ieh, jsh:jeh), uh(ish-1:ieh, :, :)) &
-    !$omp   map(from: h(ish:ieh, :, :))
-    do k=1,nz ; do j=jsh,jeh ; do i=ish, ieh
+    do concurrent (k=1:nz, j=jsh:jeh, i=ish:ieh)
       h(i,j,k) = max( hin(i,j,k) - dt * G%IareaT(i,j) * (uh(I,j,k) - uh(I-1,j,k)), h_min )
-    enddo ; enddo ; enddo
+    enddo
   else
     ! untested
-    !$omp target teams distribute parallel do collapse(3) &
-    !$omp   map(to: G, G%IareaT(ish:ieh, jsh:jeh), uh(ish-1:ieh, :, :)) &
-    !$omp   map(tofrom: h(ish:ieh, :, :))
-    do k=1,nz ; do j=jsh,jeh ; do i=ish, ieh
+    do concurrent (k=1:nz, j=jsh:jeh, i=ish:ieh)
       h(i,j,k) = max( h(i,j,k) - dt * G%IareaT(i,j) * (uh(I,j,k) - uh(I-1,j,k)), h_min )
-    enddo ; enddo ; enddo
+    enddo
   endif
 
   call cpu_clock_end(id_clock_update)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -634,6 +634,18 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
       if (OBC%segment(l_seg)%specified) uh(I,j,k) = OBC%segment(l_seg)%normal_trans(I,j,k)
     endif ; enddo ; enddo ; enddo
   endif
+
+  if (present(uhbt) .or. set_BT_cont) then
+    if (use_visc_rem.and.CS%use_visc_rem_max) then
+      visc_rem_max(:, :) = 0.0
+      do k=1,nz ; do j=jsh,jeh ; do i=ish-1,ieh
+        visc_rem_max(I,j) = max(visc_rem_max(I,j), visc_rem_u(I,j,k))
+      enddo ; enddo ; enddo
+    else
+      visc_rem_max(:, :) = 1.0
+    endif
+  endif
+
   do j=jsh,jeh
     ! init visc_rem. This will be parted out later
     do k=1,nz
@@ -643,14 +655,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     enddo
 
     if (present(uhbt) .or. set_BT_cont) then
-      if (use_visc_rem .and. CS%use_visc_rem_max) then
-        visc_rem_max(:,j) = 0.0
-        do k=1,nz ; do I=ish-1,ieh
-          visc_rem_max(I,j) = max(visc_rem_max(I,j), visc_rem_u(I,j,k))
-        enddo ; enddo
-      else
-        visc_rem_max(:,j) = 1.0
-      endif
       !   Set limits on du that will keep the CFL number between -1 and 1.
       ! This should be adequate to keep the root bracketed in all cases.
       do I=ish-1,ieh

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1324,7 +1324,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
     if (.not.domore) exit
 
     if ((itt < max_itts) .or. present(uh_3d)) then
-      do concurrent (k=1:nz, j=jsh:jeh, I=ish-1:ieh)
+      do concurrent (j=jsh:jeh, k=1:nz, I=ish-1:ieh)
         u_new(I,j,k) = u(I,j,k) + du(I,j) * visc_rem(I,j,k)
       enddo
       call zonal_flux_layer(u_new, h_in, h_W, h_E, &
@@ -1333,15 +1333,17 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
     endif
 
     if (itt < max_itts) then
-      do concurrent (j=jsh:jeh, I=ish-1:ieh)
-        uh_err(I,j) = -uhbt(I,j) ; duhdu_tot(i,j) = 0.0
-      enddo
-      do k=1,nz ; do concurrent (j=jsh:jeh, I=ish-1:ieh)
-        uh_err(I,j) = uh_err(I,j) + uh_aux(I,j,k)
-        duhdu_tot(I,j) = duhdu_tot(I,j) + duhdu(I,j,k)
-      enddo ; enddo
-      do concurrent (j=jsh:jeh, I=ish-1:ieh)
-        uh_err_best(I,j) = min(uh_err_best(I,j), abs(uh_err(I,j)))
+      do concurrent (j=jsh:jeh)
+        do I=ish-1,ieh
+          uh_err(I,j) = -uhbt(I,j) ; duhdu_tot(i,j) = 0.0
+        enddo
+        do k=1,nz ; do I=ish-1,ieh
+          uh_err(I,j) = uh_err(I,j) + uh_aux(I,j,k)
+          duhdu_tot(I,j) = duhdu_tot(I,j) + duhdu(I,j,k)
+        enddo ; enddo
+        do I=ish-1,ieh
+          uh_err_best(I,j) = min(uh_err_best(I,j), abs(uh_err(I,j)))
+        enddo
       enddo
     endif
   enddo ! itt-loop

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1551,8 +1551,7 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     uhtot_R       ! and easterly (uhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
     u_L, u_R, &   ! The westerly (u_L), easterly (u_R), and zero-barotropic
-    u_0           ! transport (u_0) layer test velocities [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G)) :: &
+    u_0, &        ! transport (u_0) layer test velocities [L T-1 ~> m s-1].
     duhdu_L, &    ! The effective layer marginal face areas with the westerly
     duhdu_R, &    ! (_L), easterly (_R), and zero-barotropic (_0) test
     duhdu_0, &    ! velocities [H L ~> m2 or kg m-1].
@@ -1622,21 +1621,22 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     u_0(I,j,k) = u(I,j,k) + du0(I,j) * visc_rem(I,j,k)
   endif ; enddo ; enddo ; enddo
 
+  call zonal_flux_layer_fused(u_0, h_in, h_W, h_E, uh_0, duhdu_0, &
+                        visc_rem, dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, gv=gv)
+  call zonal_flux_layer_fused(u_L, h_in, h_W, h_E, uh_L, duhdu_L, &
+                        visc_rem, dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, gv=gv)
+  call zonal_flux_layer_fused(u_R, h_in, h_W, h_E, uh_R, duhdu_R, &
+                        visc_rem, dt, G, US, ish, ieh, jsh, jeh, nz, do_I, CS%vol_CFL, por_face_areaU, gv=gv)
+
   do j=jsh,jeh
 
   do k=1,nz
-    call zonal_flux_layer(u_0(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_0, duhdu_0, &
-                          visc_rem(:,j,k), dt, G, US, j, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaU(:,j,k))
-    call zonal_flux_layer(u_L(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_L, duhdu_L, &
-                          visc_rem(:,j,k), dt, G, US, j, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaU(:,j,k))
-    call zonal_flux_layer(u_R(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_R, duhdu_R, &
-                          visc_rem(:,j,k), dt, G, US, j, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaU(:,j,k))
     do I=ish-1,ieh ; if (do_I(I,j)) then
-      FAmt_0(I,j) = FAmt_0(I,j) + duhdu_0(I)
-      FAmt_L(I,j) = FAmt_L(I,j) + duhdu_L(I)
-      FAmt_R(I,j) = FAmt_R(I,j) + duhdu_R(I)
-      uhtot_L(I,j) = uhtot_L(I,j) + uh_L(I)
-      uhtot_R(I,j) = uhtot_R(I,j) + uh_R(I)
+      FAmt_0(I,j) = FAmt_0(I,j) + duhdu_0(I,j,k)
+      FAmt_L(I,j) = FAmt_L(I,j) + duhdu_L(I,j,k)
+      FAmt_R(I,j) = FAmt_R(I,j) + duhdu_R(I,j,k)
+      uhtot_L(I,j) = uhtot_L(I,j) + uh_L(I,j,k)
+      uhtot_R(I,j) = uhtot_R(I,j) + uh_R(I,j,k)
     endif ; enddo
   enddo
   do I=ish-1,ieh ; if (do_I(I,j)) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -622,12 +622,18 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
 
   ! a better solution is needed!
   if (.not.use_visc_rem) then
-    visc_rem_u_tmp(:, :, :) = 1.0
+    do k=1,nz ; do j=jsh,jeh ; do i=ish-1,ieh
+      visc_rem_u_tmp(i,j,k) = 1.0
+    enddo ; enddo ; enddo
   else
-    visc_rem_u_tmp(:, :, :) = visc_rem_u(:, :, :)
+    do k=1,nz ; do j=jsh,jeh ; do i=ish-1,ieh
+      visc_rem_u_tmp(i,j,k) = visc_rem_u(i,j,k)
+    enddo ; enddo ; enddo
   end if
 
-  do_I(:, :) = .true.
+  do j=jsh,jeh ; do i=ish-1,ieh
+    do_I(i, j) = .true.
+  enddo ; enddo
   
   ! Set uh and duhdu.
   call zonal_flux_layer(u, h_in, h_W, h_E, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1505,51 +1505,58 @@ end subroutine zonal_flux_adjust
 subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, &
                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaU)
-  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)    :: u    !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to
-                                                                   !! calculate fluxes [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_W  !< West edge thickness in the
-                                                                   !! reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_E  !< East edge thickness in the
-                                                                   !! reconstruction [H ~> m or kg m-2].
-  type(BT_cont_type),                        intent(inout) :: BT_cont !< A structure with elements
+  type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: u    !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h_W  !< West edge thickness in the reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h_E  !< East edge thickness in the reconstruction [H ~> m or kg m-2].
+  type(BT_cont_type),      intent(inout) :: BT_cont !< A structure with elements
                        !! that describe the effective open face areas as a function of barotropic flow.
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: uh_tot_0    !< The summed transport
-                       !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: duhdu_tot_0 !< The partial derivative
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(in)    :: uh_tot_0    !< The summed transport with 0 adjustment 
+                                                        !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(in)    :: duhdu_tot_0 !< The partial derivative
                        !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: du_max_CFL  !< Maximum acceptable
-                       !! value of du [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: du_min_CFL  !< Minimum acceptable
-                       !! value of du [L T-1 ~> m s-1].
-  real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)),        intent(in)    :: visc_rem !< Both the fraction of the
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(in)    :: du_max_CFL  !< Maximum acceptable value of du [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(in)    :: du_min_CFL  !< Minimum acceptable value of du [L T-1 ~> m s-1].
+  real,                    intent(in)    :: dt   !< Time increment [T ~> s].
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
+  type(continuity_PPM_CS), intent(in)    :: CS   !< This module's control structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: visc_rem !< Both the fraction of the
                        !! momentum originally in a layer that remains after a time-step of viscosity, and
                        !! the fraction of a time-step's worth of a barotropic acceleration that a layer
                        !! experiences after viscosity is applied [nondim].
                        !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim].
-  integer,                                   intent(in)    :: ish, jsh      !< Start of index range.
-  integer,                                   intent(in)    :: ieh, jeh      !< End of index range.
-  logical, dimension(SZIB_(G),SZJ_(G)),      intent(in)    :: do_I     !< A logical flag indicating
-                       !! which I values to work on.
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
-                                    intent(in) :: por_face_areaU !< fractional open area of U-faces [nondim]
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim].
+  integer,                 intent(in)    :: ish      !< Start of i index range.
+  integer,                 intent(in)    :: ieh      !< End of i index range.
+  integer,                 intent(in)    :: jsh      !< Start of j index range.
+  integer,                 intent(in)    :: jeh      !< End of j index range.
+  logical, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(in)    :: do_I     !< A logical flag indicating which I values to work on.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: por_face_areaU !< fractional open area of U-faces [nondim]
   ! Local variables
-  real, dimension(SZIB_(G),SZJ_(G)) ::  &
-    du0, & ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
-    duL, duR, &   ! The barotropic velocity increments that give the westerly
-                  ! (duL) and easterly (duR) test velocities [L T-1 ~> m s-1].
-    zeros, &      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
-    du_CFL, &     ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G)) :: &
+    du0, &            ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
+    duL, duR, &       ! The barotropic velocity increments that give the westerly
+                      ! (duL) and easterly (duR) test velocities [L T-1 ~> m s-1].
+    zeros, &          ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
+    du_CFL, &         ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
     FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
-    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
-    uhtot_L, &    ! The summed transport with the westerly (uhtot_L) and
-    uhtot_R       ! and easterly (uhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+    FAmt_0, &         ! test velocities [H L ~> m2 or kg m-1].
+    uhtot_L, &        ! The summed transport with the westerly (uhtot_L) and
+    uhtot_R           ! and easterly (uhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
     u_L, u_R, &   ! The westerly (u_L), easterly (u_R), and zero-barotropic
     u_0, &        ! transport (u_0) layer test velocities [L T-1 ~> m s-1].

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2820,62 +2820,64 @@ end subroutine meridional_flux_adjust
 subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
                              dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaV)
-  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)   :: v    !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to calculate fluxes,
-                                                                   !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_S  !< South edge thickness in the reconstruction,
-                                                                   !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_N  !< North edge thickness in the reconstruction,
-                                                                   !! [H ~> m or kg m-2].
-  type(BT_cont_type),                        intent(inout) :: BT_cont !< A structure with elements
+  type(ocean_grid_type),                      intent(in)    :: G    !< Ocean's grid structure.
+  type(verticalGrid_type),                    intent(in)    :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)    :: v    !< Meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_in !< Layer thickness used to calculate fluxes,
+                                                                    !! [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_S  !< South edge thickness in the reconstruction,
+                                                                    !! [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_N  !< North edge thickness in the reconstruction,
+                                                                    !! [H ~> m or kg m-2].
+  type(BT_cont_type),                         intent(inout) :: BT_cont !< A structure with elements
                        !! that describe the effective open face areas as a function of barotropic flow.
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: vh_tot_0    !< The summed transport
+  real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: vh_tot_0 !< The summed transport
                        !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: dvhdv_tot_0 !< The partial derivative
+  real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: dvhdv_tot_0 !< The partial derivative
                        !! of du_err with dv at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: dv_max_CFL !< Maximum acceptable value
-                                                                   !!  of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: dv_min_CFL !< Minimum acceptable value
-                                                                   !!  of dv [L T-1 ~> m s-1].
-  real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)),intent(in)    :: visc_rem !< Both the fraction of the
+  real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: dv_max_CFL !< Maximum acceptable value
+                                                                          !!  of dv [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: dv_min_CFL !< Minimum acceptable value
+                                                                          !!  of dv [L T-1 ~> m s-1].
+  real,                                       intent(in)    :: dt   !< Time increment [T ~> s].
+  type(unit_scale_type),                      intent(in)    :: US   !< A dimensional unit scaling type
+  type(continuity_PPM_CS),                    intent(in)    :: CS   !< This module's control structure.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)    :: visc_rem !< Both the fraction of the
                        !! momentum originally in a layer that remains after a time-step
                        !! of viscosity, and the fraction of a time-step's worth of a barotropic
                        !! acceleration that a layer experiences after viscosity is applied [nondim].
                        !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim]
-  integer,                                   intent(in)    :: ish, jsh      !< Start of index range.
-  integer,                                   intent(in)    :: ieh, jeh      !< End of index range.
-  logical, dimension(SZI_(G),SZJB_(G)),       intent(in)    :: do_I     !< A logical flag indicating
-                       !! which I values to work on.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                                intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
+  real, dimension(SZI_(G),SZJB_(G)),          intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim]
+  integer,                                    intent(in)    :: ish  !< Start of i index range.
+  integer,                                    intent(in)    :: ieh  !< End of i index range.
+  integer,                                    intent(in)    :: jsh  !< Start of j index range.
+  integer,                                    intent(in)    :: jeh  !< End of j index range.
+  logical, dimension(SZI_(G),SZJB_(G)),       intent(in)    :: do_I !< A logical flag indicating
+                                                                    !! which I values to work on.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)),  intent(in)    :: por_face_areaV !< fractional open area of V-faces 
+                                                                              !! [nondim]
   ! Local variables
   real, dimension(SZI_(G),SZJB_(G)) :: &
-    dv0, &        ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
-    dvL, dvR, &   ! The barotropic velocity increments that give the southerly
-                  ! (dvL) and northerly (dvR) test velocities [L T-1 ~> m s-1].
-    dv_CFL, &     ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
-    zeros, &      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
-    FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
-    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
-    vhtot_L, &    ! The summed transport with the southerly (vhtot_L) and
-    vhtot_R       ! and northerly (vhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+    dv0, &             ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
+    dvL, dvR, &        ! The barotropic velocity increments that give the southerly
+                       ! (dvL) and northerly (dvR) test velocities [L T-1 ~> m s-1].
+    dv_CFL, &          ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
+    zeros, &           ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
+    FAmt_L, FAmt_R, &  ! The summed effective marginal face areas for the 3
+    FAmt_0, &          ! test velocities [H L ~> m2 or kg m-1].
+    vhtot_L, &         ! The summed transport with the southerly (vhtot_L) and
+    vhtot_R            ! and northerly (vhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &    
-    v_L, v_R, &   ! The southerly (v_L), northerly (v_R), and zero-barotropic
-    v_0, &        ! transport (v_0) layer test velocities [L T-1 ~> m s-1].
-    dvhdv_L, &    ! The effective layer marginal face areas with the southerly
-    dvhdv_R, &    ! (_L), northerly (_R), and zero-barotropic (_0) test
-    dvhdv_0, &    ! velocities [H L ~> m2 or kg m-1].
-    vh_L, vh_R, & ! The layer transports with the southerly (_L), northerly (_R)
-    vh_0       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real :: FA_0    ! The effective face area with 0 barotropic transport [H L ~> m2 or kg m-1].
-  real :: FA_avg  ! The average effective face area [H L ~> m2 or kg m-1], nominally given by
-                  ! the realized transport divided by the barotropic velocity.
+    v_L, v_R, &        ! The southerly (v_L), northerly (v_R), and zero-barotropic
+    v_0, &             ! transport (v_0) layer test velocities [L T-1 ~> m s-1].
+    dvhdv_L, &         ! The effective layer marginal face areas with the southerly
+    dvhdv_R, &         ! (_L), northerly (_R), and zero-barotropic (_0) test
+    dvhdv_0, &         ! velocities [H L ~> m2 or kg m-1].
+    vh_L, vh_R, &      ! The layer transports with the southerly (_L), northerly (_R)
+    vh_0               ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real :: FA_0         ! The effective face area with 0 barotropic transport [H L ~> m2 or kg m-1].
+  real :: FA_avg       ! The average effective face area [H L ~> m2 or kg m-1], nominally given by
+                       ! the realized transport divided by the barotropic velocity.
   real :: visc_rem_lim ! The larger of visc_rem and min_visc_rem [nondim]  This
                        ! limiting is necessary to keep the inverse of visc_rem
                        ! from leading to large CFL numbers.
@@ -2883,9 +2885,9 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
                        ! in finding the barotropic velocity that changes the
                        ! flow direction [nondim].  This is necessary to keep the inverse
                        ! of visc_rem from leading to large CFL numbers.
-  real :: CFL_min ! A minimal increment in the CFL to try to ensure that the
-                  ! flow is truly upwind [nondim]
-  real :: Idt     ! The inverse of the time step [T-1 ~> s-1].
+  real :: CFL_min      ! A minimal increment in the CFL to try to ensure that the
+                       ! flow is truly upwind [nondim]
+  real :: Idt          ! The inverse of the time step [T-1 ~> s-1].
   logical :: domore
   integer :: i, j, k, nz
 
@@ -2898,7 +2900,7 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
                          dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
                          ish, ieh, jsh, jeh, do_I, por_face_areaV)
 
-  !   Determine the southerly- and northerly- fluxes.  Choose a sufficiently
+  ! Determine the southerly- and northerly- fluxes. Choose a sufficiently
   ! negative velocity correction for the northerly-flux, and a sufficiently
   ! positive correction for the southerly-flux.
   domore = .false.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1086,6 +1086,12 @@ subroutine zonal_flux_thickness(u, h, h_W, h_E, h_u, dt, G, GV, US, LB, vol_CFL,
   integer :: i, j, k, ish, ieh, jsh, jeh, nz, n
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
 
+  !$omp target enter data &
+  !$omp   map(to: u(ish-1:ieh, :, :), G, G%dy_Cu(ish-1:ieh, jsh:jeh), G%IareaT(ish-1:ieh+1, jsh:jeh), &
+  !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), h(ish-1:ieh+1, :, :), h_W(ish-1:ieh+1, :, :), &
+  !$omp       h_E(ish-1:ieh+1, :, :), por_face_areaU(ish-1:ieh, :, :)) &
+  !$omp   map(alloc: h_u(ish-1:ieh, :, :))
+
   !$omp target teams distribute parallel do collapse(3) &
   !$omp   private(CFL, curv_3, h_avg, h_marg) &
   !$omp   map(to: u(ish-1:ieh, :, :), G, G%dy_Cu(ish-1:ieh, jsh:jeh), G%IareaT(ish-1:ieh+1, jsh:jeh), &
@@ -1182,6 +1188,12 @@ subroutine zonal_flux_thickness(u, h, h_W, h_E, h_u, dt, G, GV, US, LB, vol_CFL,
       endif
     enddo
   endif
+
+  !$omp target exit data &
+  !$omp   map(from: h_u(ish-1:ieh, :, :)) &
+  !$omp   map(release: u(ish-1:ieh, :, :), G, G%dy_Cu(ish-1:ieh, jsh:jeh), G%IareaT(ish-1:ieh+1, jsh:jeh), &
+  !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), h(ish-1:ieh+1, :, :), h_W(ish-1:ieh+1, :, :), &
+  !$omp       h_E(ish-1:ieh+1, :, :), por_face_areaU(ish-1:ieh, :, :))
 
 end subroutine zonal_flux_thickness
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -662,7 +662,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     end if
 
     ! Set uh and duhdu.
-    !DIR$ FORCEINLINE
     do concurrent (k=1:nz , I=ish-1:ieh)
       call zonal_flux_layere(u(I,j,k), h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), &
                             h_E(I,j,k), h_E(I+1,j,k), uh(I,j,k), duhdu(I,j,k), visc_rem_u_tmp(I,j,k), &
@@ -670,7 +669,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
                             G%IdxT(i+1,j), dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
     enddo
     if (local_open_BC) then
-      !DIR$ FORCEINLINE
       do concurrent (k=1:nz, I=ish-1:ieh)
         call zonal_flux_layere_OBC(u(I,j,k), h_in, uh(I,j,k), duhdu(I,j,k), visc_rem_u_tmp(I,j,k), &
                                   G, GV, I, j, k, por_face_areaU(I,j,k), OBC)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -687,10 +687,10 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
       if (use_visc_rem.and.CS%use_visc_rem_max) then
         ! poor performance for nvfortran + do concurrent if k is inside loop
         do concurrent (I=ish-1:ieh)
-          visc_rem_max(I,j) = visc_rem_u(I,j,1)
+          visc_rem_max(I,j) = visc_rem_u_tmp(I,j,1)
         enddo
         do k=2,nz ; do concurrent (I=ish-1:ieh)
-          visc_rem_max(I,j) = max(visc_rem_max(I,j), visc_rem_u(I,j,k))
+          visc_rem_max(I,j) = max(visc_rem_max(I,j), visc_rem_u_tmp(I,j,k))
         enddo ; enddo
       else
         do concurrent (i=ish-1:ieh)
@@ -882,10 +882,10 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   if  (set_BT_cont) then ; if (allocated(BT_cont%h_u)) then
     if (present(u_cor)) then
       call zonal_flux_thickness(u_cor, h_in, h_W, h_E, BT_cont%h_u, dt, G, GV, US, LB, &
-                                CS%vol_CFL, CS%marginal_faces, OBC, por_face_areaU, visc_rem_u)
+                                CS%vol_CFL, CS%marginal_faces, OBC, por_face_areaU, visc_rem_u_tmp)
     else
       call zonal_flux_thickness(u, h_in, h_W, h_E, BT_cont%h_u, dt, G, GV, US, LB, &
-                                CS%vol_CFL, CS%marginal_faces, OBC, por_face_areaU, visc_rem_u)
+                                CS%vol_CFL, CS%marginal_faces, OBC, por_face_areaU, visc_rem_u_tmp)
     endif
   endif ; endif
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -802,7 +802,7 @@ subroutine present_uhbt_or_set_BT_cont(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0,
                                        uh, u_cor, du_cor, BT_cont, dt, set_BT_cont, &
                                        local_specified_BC, local_Flather_OBC, local_open_BC, ish, &
                                        ieh, jsh, jeh, nz, G, GV, US, CS, OBC, LB)
-  type(ocean_grid_type), intent(in):: G
+  type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                            intent(in)    :: u    !< Zonal velocity [L T-1 ~> m s-1].
@@ -813,19 +813,19 @@ subroutine present_uhbt_or_set_BT_cont(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0,
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in)    :: h_E !< Eastern edge thicknesses [H ~> m or kg m-2].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: uh_tot_0 !< Summed transport with no barotropic correction 
+                           intent(in)    :: uh_tot_0 !< Summed transport with no barotropic correction
                                                      !! [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: duhdu_tot_0 !< Summed partial derivative of uh with u 
+                           intent(in)    :: duhdu_tot_0 !< Summed partial derivative of uh with u
                                                         !! [H L ~> m2 or kg m-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(inout) :: du !< Corrective barotropic change in the velocity to give uhbt 
+                           intent(inout) :: du !< Corrective barotropic change in the velocity to give uhbt
                                                !! [L T-1 ~> m s-1].
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: du_max_CFL !< Upper limit on du correction to avoid CFL violations 
+                           intent(in)    :: du_max_CFL !< Upper limit on du correction to avoid CFL violations
                                                        !! [L T-1 ~> m s-1]
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: du_min_CFL !< Lower limit on du correction to avoid CFL violations 
+                           intent(in)    :: du_min_CFL !< Lower limit on du correction to avoid CFL violations
                                                        !![L T-1 ~> m s-1]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                            intent(inout) :: uh   !< Volume flux through zonal faces = u*h*dy
@@ -837,33 +837,34 @@ subroutine present_uhbt_or_set_BT_cont(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0,
                      !! acceleration that a layer experiences after viscosity is applied [nondim].
                      !! Visc_rem_u is between 0 (at the bottom) and 1 (far above the bottom).
   real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: visc_rem_max
+                           intent(in)    :: visc_rem_max !< The column maximum of visc_rem [nondim].
   real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
                            intent(in)    :: por_face_areaU !< fractional open area of U-faces [nondim]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                 optional, intent(out)   :: u_cor
-                     !< The zonal velocities (u with a barotropic correction)
-                     !! that give uhbt as the depth-integrated transport [L T-1 ~> m s-1]
+                 optional, intent(out)   :: u_cor !< The zonal velocities (u with a barotropic correction)
+                                      !! that give uhbt as the depth-integrated transport [L T-1 ~> m s-1]
   real, dimension(SZIB_(G),SZJ_(G)), &
                  optional, intent(out)   :: du_cor !< The zonal velocity increments from u that give uhbt
                                                  !! as the depth-integrated transports [L T-1 ~> m s-1].
   type(BT_cont_type), optional, pointer  :: BT_cont !< A structure with elements that describe the
                      !! effective open face areas as a function of barotropic flow.
-  logical, intent(in):: set_BT_cont
-  logical, intent(in):: local_specified_BC
-  logical, intent(in):: local_Flather_OBC
-  logical, intent(in):: local_open_BC
-  real, dimension(SZIB_(G),SZJ_(G)), optional, intent(in):: uhbt
-  integer, intent(in):: ish
-  integer, intent(in):: ieh
-  integer, intent(in):: jsh
-  integer, intent(in):: jeh
-  integer, intent(in):: nz
-  real,                    intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS), intent(in)    :: CS   !< This module's control structure.
-  type(ocean_OBC_type), pointer:: OBC
-  type(cont_loop_bounds_type), intent(in) :: LB
+  logical,                 intent(in)    :: set_BT_cont !< Whether to update BT_cont member arrays.
+  logical,                 intent(in)    :: local_specified_BC !< Whether specified u BCs exist globally.
+  logical,                 intent(in)    :: local_Flather_OBC !< Whether Flather u BCs exist globally.
+  logical,                 intent(in)    :: local_open_BC !< Whether open u BCs exist globally.
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                 optional, intent(in)    :: uhbt !< The summed volume flux through zonal faces
+                                                 !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  integer,                 intent(in)    :: ish !< Start of i index range.
+  integer,                 intent(in)    :: ieh !< End of i index range.
+  integer,                 intent(in)    :: jsh !< Start of j index range.
+  integer,                 intent(in)    :: jeh !< End of j index range.
+  integer,                 intent(in)    :: nz  !< Extent of k index range.
+  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
+  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
+  type(continuity_PPM_CS), intent(in)    :: CS  !< This module's control structure.
+  type(ocean_OBC_type),      pointer     :: OBC !< Open boundaries control structure.
+  type(cont_loop_bounds_type), intent(in) :: LB !< Loop boundary variable.
   ! Local variables
   logical, dimension(SZIB_(G), SZJ_(G)) :: do_I
   logical, dimension(SZIB_(G), SZJ_(G)) :: simple_OBC_pt  ! Indicates points in a row with specified transport OBCs
@@ -1062,33 +1063,41 @@ end subroutine zonal_BT_mass_flux
 elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh, duhdu, visc_rem, &
                                       G_dy_Cu, G_IareaT, G_IareaT_p1, G_IdxT, G_IdxT_p1, dt, G, GV, &
                                       US, vol_CFL, por_face_areaU)
-  type(ocean_grid_type),    intent(in)    :: G        !< Ocean's grid structure.
-  type(verticalGrid_type),  intent(in)    :: GV       !< Ocean's vertical grid structure.
-  real,                     intent(in)    :: u        !< Zonal velocity [L T-1 ~> m s-1].
-  real,                     intent(in)    :: visc_rem !< Both the fraction of the
+  type(ocean_grid_type),   intent(in)  :: G        !< Ocean's grid structure.
+  type(verticalGrid_type), intent(in)  :: GV       !< Ocean's vertical grid structure.
+  real,                    intent(in)  :: u        !< Zonal velocity [L T-1 ~> m s-1].
+  real,                    intent(in)  :: visc_rem !< Both the fraction of the
                         !! momentum originally in a layer that remains after a time-step
                         !! of viscosity, and the fraction of a time-step's worth of a barotropic
                         !! acceleration that a layer experiences after viscosity is applied [nondim].
                         !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real,                      intent(in)    :: h, h_p1        !< Layer thickness [H ~> m or kg m-2].
-  real,                      intent(in)    :: h_W, h_W_p1      !< West edge thickness [H ~> m or kg m-2].
-  real,                      intent(in)    :: h_E, h_E_p1      !< East edge thickness [H ~> m or kg m-2].
-  real,                     intent(out) :: uh       !< Zonal mass or volume
-                                                      !! transport [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real,                     intent(out) :: duhdu    !< Partial derivative of uh
-                                                      !! with u [H L ~> m2 or kg m-1].
-  real,                     intent(in)    :: dt       !< Time increment [T ~> s]
-  type(unit_scale_type),    intent(in)    :: US       !< A dimensional unit scaling type.
-  logical,                  intent(in)    :: vol_CFL  !< If true, rescale the
-  real,                     intent(in)    :: por_face_areaU !< fractional open area of U-faces
-                                                            !! [nondim].
-  real,                     intent(in)    :: G_dy_Cu, G_IareaT, G_IareaT_p1, G_IdxT, G_IdxT_p1
-          !! ratio of face areas to the cell areas when estimating the CFL number.
+  real,                    intent(in)  :: h        !< Layer thickness [H ~> m or kg m-2].
+  real,                    intent(in)  :: h_p1     !< Layer thickness - offset by 1 [ H ~> m or kg m-2].
+  real,                    intent(in)  :: h_W      !< West edge thickness [H ~> m or kg m-2].
+  real,                    intent(in)  :: h_W_p1   !< West edge thickness - offset by 1 [H ~> m or kg m-2].
+  real,                    intent(in)  :: h_E      !< East edge thickness [H ~> m or kg m-2].
+  real,                    intent(in)  :: h_E_p1   !< East edge thickness - offset by 1 [H ~> m or kg m-2].
+  real,                    intent(out) :: uh       !< Zonal mass or volume transport
+                                                   !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real,                    intent(out) :: duhdu    !< Partial derivative of uh
+                                                   !! with u [H L ~> m2 or kg m-1].
+  real,                    intent(in)  :: dt       !< Time increment [T ~> s]
+  type(unit_scale_type),   intent(in)  :: US       !< A dimensional unit scaling type.
+  logical,                 intent(in)  :: vol_CFL  !< If true, rescale the ratio of face areas to the
+                                                   !! cell areas when estimating the CFL number.
+  real,                    intent(in)  :: por_face_areaU !< fractional open area of U-faces [nondim].
+  real,                    intent(in)  :: G_dy_Cu  !< The grid cell's unblocked lengths of the u-faces
+                                                   !! of the h-cell [L ~> m].
+  real,                    intent(in)  :: G_IareaT !< The grid cell's 1/areaT [L-2 ~> m-2].
+  real,                    intent(in)  :: G_IareaT_p1 !< The grid cell's 1/areaT - offset by 1 [L-2 ~> m-2].
+  real,                    intent(in)  :: G_IdxT   !< The grid cell's 1/dxT [L-1 ~> m-1].
+  real,                    intent(in)  :: G_IdxT_p1 !< The grid cell's 1/dxT - offset by 1 [L-1 ~> m-1].
   ! Local variables
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim]
   real :: curv_3 ! A measure of the thickness curvature over a grid length [H ~> m or kg m-2]
   real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
-  real :: tmp, dh
+  real :: tmp ! temporary variable to store precalculted values
+  real :: dh ! h differential between E/W
 
   ! Set new values of uh and duhdu.
   tmp = G_dy_Cu * por_face_areaU ! precalculate things
@@ -1413,18 +1422,20 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
                        !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
   real, dimension(SZIB_(G),SZJ_(G)),          intent(inout) :: du !<
                        !! The barotropic velocity adjustment [L T-1 ~> m s-1].
-  real,                                       intent(in)    :: dt        !< Time increment [T ~> s].
-  type(unit_scale_type),                      intent(in)    :: US        !< A dimensional unit scaling type.
-  type(continuity_PPM_CS),                    intent(in)    :: CS        !< This module's control structure.
-  integer,                                    intent(in)    :: ish, jsh  !< Start of index range.
-  integer,                                    intent(in)    :: ieh, jeh  !< End of index range.
-  logical, dimension(SZIB_(G),SZJ_(G)),       intent(in)    :: do_I_in   !< A logical flag
-                       !! indicating which I values to work on.
+  real,                                       intent(in)    :: dt  !< Time increment [T ~> s].
+  type(unit_scale_type),                      intent(in)    :: US  !< A dimensional unit scaling type.
+  type(continuity_PPM_CS),                    intent(in)    :: CS  !< This module's control structure.
+  integer,                                    intent(in)    :: ish !< Start of i index range.
+  integer,                                    intent(in)    :: jsh !< Start of j index range.
+  integer,                                    intent(in)    :: ieh !< End of i index range.
+  integer,                                    intent(in)    :: jeh !< End of j index range.
+  logical, dimension(SZIB_(G),SZJ_(G)),       intent(in)    :: do_I_in !< A logical flag indicating
+                                                                       !! which I values to work on.
   real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), intent(in)   :: por_face_areaU !< fractional open area
                                                                               !! of U-faces [nondim].
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                                     optional, intent(inout) :: uh_3d !< Volume flux through zonal
-                       !! faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
+                                                 !! faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
   type(ocean_OBC_type),             optional, pointer       :: OBC !< Open boundaries control structure.
   ! Local variables
   real :: &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2959,8 +2959,7 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     vhtot_R(i,j) = vhtot_R(i,j) + vh_R(i,j,k)
   endif ; enddo ; enddo ; enddo
 
-  do j = jsh-1, jeh
-  do i=ish,ieh ; if (do_I(i,j)) then
+  do j = jsh-1,jeh ; do i=ish,ieh ; if (do_I(i,j)) then
     FA_0 = FAmt_0(i,j) ; FA_avg = FAmt_0(i,j)
     if ((dvL(i,j) - dv0(i,j)) /= 0.0) &
       FA_avg = vhtot_L(i,j) / (dvL(i,j) - dv0(i,j))
@@ -2986,9 +2985,7 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
     BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
     BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
-  endif ; enddo
-
-  enddo
+  endif ; enddo ; enddo
 
 end subroutine set_merid_BT_cont_fused
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2892,6 +2892,24 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, 
   nz = GV%ke ; Idt = 1.0 / dt
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
+  !$omp target enter data &
+  !$omp   map(to: G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%dyCv(ish:ieh, jsh-1:jeh), &
+  !$omp       G%IdyT(ish:ieh, jsh-1:jeh+1), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
+  !$omp       h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), BT_cont, vh_tot_0(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot_0(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
+  !$omp       dv_min_CFL(ish:ieh, jsh-1:jeh), CS, visc_rem(ish:ieh, :, :), &
+  !$omp       visc_rem_max(ish:ieh, jsh-1:jeh), do_I(ish:ieh, jsh-1:jeh), &
+  !$omp       por_face_areaV(ish:ieh, :, :)) &
+  !$omp   map(alloc: BT_cont%FA_v_S0(ish:ieh, jsh-1:jeh), BT_cont%FA_v_SS(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%vBT_SS(ish:ieh, jsh-1:jeh), BT_cont%FA_v_N0(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%FA_v_NN(ish:ieh, jsh-1:jeh), BT_cont%vBT_NN(ish:ieh, jsh-1:jeh), &
+  !$omp       dv0(ish:ieh, jsh-1:jeh), dvL(ish:ieh, jsh-1:jeh), dvR(ish:ieh, jsh-1:jeh), &
+  !$omp       dv_CFL(ish:ieh, jsh-1:jeh), zeros(ish:ieh, jsh-1:jeh), FAmt_L(ish:ieh, jsh-1:jeh), &
+  !$omp       FAmt_R(ish:ieh, jsh-1:jeh), FAmt_0(ish:ieh, jsh-1:jeh), vhtot_L(ish:ieh, jsh-1:jeh), &
+  !$omp       vhtot_R(ish:ieh, jsh-1:jeh), v_L(ish:ieh, :, :), v_R(ish:ieh, :, :), &
+  !$omp       v_0(ish:ieh, :, :), dvhdv_L(ish:ieh, :, :), dvhdv_R(ish:ieh, :, :), &
+  !$omp       dvhdv_0(ish:ieh, :, :), vh_L(ish:ieh, :, :), vh_R(ish:ieh, :, :), vh_0(ish:ieh, :, :))
+
  ! Diagnose the zero-transport correction, dv0.
   !$omp target teams distribute parallel do collapse(2) &
   !$omp   map(from: zeros(ish:ieh, jsh-1:jeh))
@@ -3014,6 +3032,23 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, 
     BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
     BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
   endif ; enddo ; enddo
+
+  !$omp target exit data &
+  !$omp   map(from: BT_cont%FA_v_S0(ish:ieh, jsh-1:jeh), BT_cont%FA_v_SS(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%vBT_SS(ish:ieh, jsh-1:jeh), BT_cont%FA_v_N0(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%FA_v_NN(ish:ieh, jsh-1:jeh), BT_cont%vBT_NN(ish:ieh, jsh-1:jeh)) &
+  !$omp   map(release: G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%dyCv(ish:ieh, jsh-1:jeh), &
+  !$omp       G%IdyT(ish:ieh, jsh-1:jeh+1), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
+  !$omp       h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), BT_cont, vh_tot_0(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot_0(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
+  !$omp       dv_min_CFL(ish:ieh, jsh-1:jeh), CS, visc_rem(ish:ieh, :, :), &
+  !$omp       visc_rem_max(ish:ieh, jsh-1:jeh), do_I(ish:ieh, jsh-1:jeh), &
+  !$omp       por_face_areaV(ish:ieh, :, :), dv0(ish:ieh, jsh-1:jeh), dvL(ish:ieh, jsh-1:jeh), &
+  !$omp       dvR(ish:ieh, jsh-1:jeh), dv_CFL(ish:ieh, jsh-1:jeh), zeros(ish:ieh, jsh-1:jeh), &
+  !$omp       FAmt_L(ish:ieh, jsh-1:jeh), FAmt_R(ish:ieh, jsh-1:jeh), FAmt_0(ish:ieh, jsh-1:jeh), &
+  !$omp       vhtot_L(ish:ieh, jsh-1:jeh), vhtot_R(ish:ieh, jsh-1:jeh), v_L(ish:ieh, :, :), &
+  !$omp       v_R(ish:ieh, :, :), v_0(ish:ieh, :, :), dvhdv_L(ish:ieh, :, :), dvhdv_R(ish:ieh, :, :), &
+  !$omp       dvhdv_0(ish:ieh, :, :), vh_L(ish:ieh, :, :), vh_R(ish:ieh, :, :), vh_0(ish:ieh, :, :))
 
 end subroutine set_merid_BT_cont
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2874,7 +2874,7 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
     vhtot_L, &    ! The summed transport with the southerly (vhtot_L) and
     vhtot_R       ! and northerly (vhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)) :: &
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &    
     v_L, v_R, &   ! The southerly (v_L), northerly (v_R), and zero-barotropic
     v_0, &        ! transport (v_0) layer test velocities [L T-1 ~> m s-1].
     dvhdv_L, &    ! The effective layer marginal face areas with the southerly
@@ -2943,22 +2943,22 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
   do j = jsh-1, jeh
   do k=1,nz
     do i=ish,ieh ; if (do_I(i,j)) then
-      v_L(i) = v(I,j,k) + dvL(i,j) * visc_rem(i,j,k)
-      v_R(i) = v(I,j,k) + dvR(i,j) * visc_rem(i,j,k)
-      v_0(i) = v(I,j,k) + dv0(i,j) * visc_rem(i,j,k)
+      v_L(i,j,k) = v(I,j,k) + dvL(i,j) * visc_rem(i,j,k)
+      v_R(i,j,k) = v(I,j,k) + dvR(i,j) * visc_rem(i,j,k)
+      v_0(i,j,k) = v(I,j,k) + dv0(i,j) * visc_rem(i,j,k)
     endif ; enddo
-    call merid_flux_layer(v_0, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_0, dvhdv_0, &
+    call merid_flux_layer(v_0(:,j,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_0(:,j,k), dvhdv_0(:,j,k), &
                           visc_rem(:,j,k), dt, G, US, J, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaV(:,:,k))
-    call merid_flux_layer(v_L, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_L, dvhdv_L, &
+    call merid_flux_layer(v_L(:,j,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_L(:,j,k), dvhdv_L(:,j,k), &
                           visc_rem(:,j,k), dt, G, US, J, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaV(:,:,k))
-    call merid_flux_layer(v_R, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_R, dvhdv_R, &
+    call merid_flux_layer(v_R(:,j,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_R(:,j,k), dvhdv_R(:,j,k), &
                           visc_rem(:,j,k), dt, G, US, J, ish, ieh, do_I(:,j), CS%vol_CFL, por_face_areaV(:,:,k))
     do i=ish,ieh ; if (do_I(i,j)) then
-      FAmt_0(i,j) = FAmt_0(i,j) + dvhdv_0(i)
-      FAmt_L(i,j) = FAmt_L(i,j) + dvhdv_L(i)
-      FAmt_R(i,j) = FAmt_R(i,j) + dvhdv_R(i)
-      vhtot_L(i,j) = vhtot_L(i,j) + vh_L(i)
-      vhtot_R(i,j) = vhtot_R(i,j) + vh_R(i)
+      FAmt_0(i,j) = FAmt_0(i,j) + dvhdv_0(i,j,k)
+      FAmt_L(i,j) = FAmt_L(i,j) + dvhdv_L(i,j,k)
+      FAmt_R(i,j) = FAmt_R(i,j) + dvhdv_R(i,j,k)
+      vhtot_L(i,j) = vhtot_L(i,j) + vh_L(i,j,k)
+      vhtot_R(i,j) = vhtot_R(i,j) + vh_R(i,j,k)
     endif ; enddo
   enddo
   do i=ish,ieh ; if (do_I(i,j)) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -664,14 +664,14 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     end if
   
     ! Set uh and duhdu.
-    !DIR$ FORCEINLINE
+    !!DIR$ FORCEINLINE
     do concurrent (k=1:nz , I=ish-1:ieh)
       call zonal_flux_layere(u(I,j,k), h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), h_E(I+1,j,k), &
                             uh(I,j,k), duhdu(I,j,k), visc_rem_u_tmp(I,j,k), G%dy_Cu(I,j), G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), &
                             dt, G, GV, US, CS%vol_CFL, por_face_areaU(I,j,k))
     enddo
     if (local_open_BC) then
-      !DIR$ FORCEINLINE
+      !!DIR$ FORCEINLINE
       do concurrent (k=1:nz, I=ish-1:ieh)
         call zonal_flux_layere_OBC(u(I,j,k), h_in, uh(I,j,k), duhdu(I,j,k), visc_rem_u_tmp(I,j,k), &
                                   G, GV, I, j, k, por_face_areaU(I,j,k), OBC)
@@ -1005,30 +1005,34 @@ elemental subroutine zonal_flux_layere(u, h, h_p1, h_W, h_W_p1, h_E, h_E_p1, uh,
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim]
   real :: curv_3 ! A measure of the thickness curvature over a grid length [H ~> m or kg m-2]
   real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
-  real :: tmp, dh
+  real :: tmp, dh, c1, c2, c3
+
+  !DIR$ ATTRIBUTES FORCEINLINE :: zonal_flux_layere
 
   ! Set new values of uh and duhdu.
   tmp = G_dy_Cu * por_face_areaU ! precalculate things
+  CFL = abs(u*dt) ! increases inlining likelihood
   if (u > 0.0) then
-    if (vol_CFL) then ; CFL = (u * dt) * (G_dy_Cu * G_IareaT)
-    else ; CFL = u * dt * G_IdxT ; endif
-    curv_3 = (h_W + h_E) - 2.0*h
-    dh = h_W - h_E
-    uh = tmp * u * &
-        (h_E + CFL * (0.5*dh + curv_3*(CFL - 1.5)))
-    h_marg = h_E + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
+    CFL = CFL * merge(G_dy_Cu * G_IareaT, G_IdxT, vol_CFL)
+    c1 = h_E
+    c2 = h_W
+    c3 = h
   elseif (u < 0.0) then
-    if (vol_CFL) then ; CFL = (-u * dt) * (G_dy_Cu * G_IareaT_p1)
-    else ; CFL = -u * dt * G_IdxT_p1 ; endif
-    curv_3 = (h_W_p1 + h_E_p1) - 2.0*h_p1
-    dh = h_E_p1-h_W_p1
-    uh = tmp * u * &
-        (h_W_p1 + CFL * (0.5*dh + curv_3*(CFL - 1.5)))
-    h_marg = h_W_p1 + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
+    CFL = CFL * merge(G_dy_Cu * G_IareaT_p1, G_IdxT_p1, vol_CFL)
+    c1 = h_W_p1
+    c2 = h_E_p1
+    c3 = h_p1
   else
-    uh = 0.0
-    h_marg = 0.5 * (h_W_p1 + h_E)
+    CFL = 0.0
+    c1 = 0.5 * (h_W_p1 + h_E)
+    c2 = 0.0
+    c3 = 0.0
   endif
+  curv_3 = (c2 + c1) - 2.0*c3
+  dh = (c2 - c1)
+  uh = tmp * u * &
+        (c1 + CFL * (0.5*dh + curv_3*(CFL - 1.5)))
+  h_marg = c1 + CFL * (dh + 3.0*curv_3*(CFL-1.0))
   duhdu = tmp * h_marg * visc_rem
 
 end subroutine zonal_flux_layere

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -363,20 +363,22 @@ subroutine continuity_zonal_convergence(h, uh, dt, G, GV, LB, hin, hmin)
   real,              optional, intent(in)    :: hmin !< The minimum layer thickness [H ~> m or kg m-2]
 
   real :: h_min  ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
-  integer :: i, j, k
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz
 
   call cpu_clock_begin(id_clock_update)
 
   h_min = 0.0 ; if (present(hmin)) h_min = hmin
 
+  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
+
   if (present(hin)) then
-    !$OMP parallel do default(shared)
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do k=1,nz ; do j=jsh,jeh ; do i=ish, ieh
       h(i,j,k) = max( hin(i,j,k) - dt * G%IareaT(i,j) * (uh(I,j,k) - uh(I-1,j,k)), h_min )
     enddo ; enddo ; enddo
   else
+    ! untested
     !$OMP parallel do default(shared)
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do k=1,nz ; do j=jsh,jeh ; do i=ish, ieh
       h(i,j,k) = max( h(i,j,k) - dt * G%IareaT(i,j) * (uh(I,j,k) - uh(I-1,j,k)), h_min )
     enddo ; enddo ; enddo
   endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -657,6 +657,10 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
       du_min_CFL(I,j) = -2.0 * (CFL_dt * dx_E) * I_vrm
       uh_tot_0(I,j) = 0.0 ; duhdu_tot_0(I,j) = 0.0
     enddo ; enddo
+    do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
+      duhdu_tot_0(I,j) = duhdu_tot_0(I,j) + duhdu(I, j, k)
+      uh_tot_0(I,j) = uh_tot_0(I,j) + uh(I,j,k)
+    enddo ; enddo ; enddo
   endif
 
   do j=jsh,jeh
@@ -668,10 +672,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     enddo
 
     if (present(uhbt) .or. set_BT_cont) then
-      do k=1,nz ; do I=ish-1,ieh
-        duhdu_tot_0(I,j) = duhdu_tot_0(I,j) + duhdu(I, j, k)
-        uh_tot_0(I,j) = uh_tot_0(I,j) + uh(I,j,k)
-      enddo ; enddo
       if (use_visc_rem) then
         if (CS%aggress_adjust) then
           do k=1,nz ; do I=ish-1,ieh

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -456,7 +456,6 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
       h_W(i,j,k) = h_in(i,j,k) ; h_E(i,j,k) = h_in(i,j,k)
     enddo ; enddo ; enddo
   else
-    !$OMP parallel do default(shared)
     call PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, &
                               2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
   endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2133,42 +2133,44 @@ end subroutine meridional_flux_thickness
 subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
                              dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              ish, ieh, jsh, jeh, do_I_in, por_face_areaV, vh_3d, OBC)
-  type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
+  type(ocean_grid_type),             intent(in)  :: G    !< Ocean's grid structure.
+  type(verticalGrid_type),           intent(in)  :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(in)    :: v    !< Meridional velocity [L T-1 ~> m s-1].
+                                     intent(in)  :: v    !< Meridional velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
+                                     intent(in)  :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),&
-                           intent(in)    :: h_S  !< South edge thickness in the reconstruction [H ~> m or kg m-2].
+                                     intent(in)  :: h_S  !< South edge thickness in the reconstruction [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_N  !< North edge thickness in the reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: visc_rem
-                             !< Both the fraction of the momentum originally
+                                     intent(in)  :: h_N  !< North edge thickness in the reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                                     intent(in)  :: visc_rem !< Both the fraction of the momentum originally
                              !! in a layer that remains after a time-step of viscosity, and the
                              !! fraction of a time-step's worth of a barotropic acceleration that
                              !! a layer experiences after viscosity is applied [nondim].
                              !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G),SZJB_(G)), intent(in)    :: vhbt !< The summed volume flux through meridional faces
-                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G)), intent(in)    :: dv_max_CFL !< Maximum acceptable value of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G)), intent(in)    :: dv_min_CFL !< Minimum acceptable value of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G)), intent(in)    :: vh_tot_0   !< The summed transport with 0 adjustment
-                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G)), intent(in)    :: dvhdv_tot_0 !< The partial derivative of dv_err with
-                                                  !! dv at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G),SZJB_(G)), intent(out)   :: dv   !< The barotropic velocity adjustment [L T-1 ~> m s-1].
-  real,                     intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),  intent(in)    :: CS   !< This module's control structure.
-  integer,                  intent(in)    :: ish, jsh  !< Start of index range.
-  integer,                  intent(in)    :: ieh, jeh  !< End of index range.
+  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: vhbt !< The summed volume flux through meridional faces
+                                                         !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: dv_max_CFL !< Maximum acceptable value of dv [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: dv_min_CFL !< Minimum acceptable value of dv [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: vh_tot_0   !< The summed transport with 0 adjustment
+                                                               !! [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: dvhdv_tot_0 !< The partial derivative of dv_err with
+                                                                !! dv at 0 adjustment [H L ~> m2 or kg m-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(out) :: dv         !< The barotropic velocity adjustment [L T-1 ~> m s-1].
+  real,                              intent(in)  :: dt         !< Time increment [T ~> s].
+  type(unit_scale_type),             intent(in)  :: US         !< A dimensional unit scaling type
+  type(continuity_PPM_CS),           intent(in)  :: CS         !< This module's control structure.
+  integer,                           intent(in)  :: ish        !< Start of i index range.
+  integer,                           intent(in)  :: ieh        !< End of i index range.
+  integer,                           intent(in)  :: jsh        !< Start of j index range.
+  integer,                           intent(in)  :: jeh        !< End of j index range.
   logical, dimension(SZI_(G),SZJB_(G)), &
-                            intent(in)    :: do_I_in  !< A flag indicating which I values to work on.
+                                     intent(in)  :: do_I_in  !< A flag indicating which I values to work on.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                     intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
+                                     intent(in)  :: por_face_areaV !< fractional open area of V-faces [nondim]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                  optional, intent(inout) :: vh_3d !< Volume flux through meridional
+                         optional, intent(inout) :: vh_3d !< Volume flux through meridional
                              !! faces = v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
   type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
   ! Local variables

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -738,6 +738,15 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
       enddo ; enddo ; endif
     endif
 
+    if (present(uhbt)) then
+      ! Find du and uh.
+      do j=jsh,jeh
+        call zonal_flux_adjust_fused(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, du, &
+                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem_u, &
+                              j, ish, ieh, do_I, por_face_areaU, uh, OBC=OBC)
+      enddo
+    endif
+
   endif
 
   do j=jsh,jeh
@@ -751,10 +760,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     if (present(uhbt) .or. set_BT_cont) then
 
       if (present(uhbt)) then
-        ! Find du and uh.
-        call zonal_flux_adjust(u, h_in, h_W, h_E, uhbt(:,j), uh_tot_0(:,j), duhdu_tot_0(:,j), du(:,j), &
-                               du_max_CFL(:,j), du_min_CFL(:,j), dt, G, GV, US, CS, visc_rem, &
-                               j, ish, ieh, do_I(:, j), por_face_areaU, uh, OBC=OBC)
 
         if (present(u_cor)) then ; do k=1,nz
           do I=ish-1,ieh ; u_cor(I,j,k) = u(I,j,k) + du(I,j) * visc_rem(I,k) ; enddo
@@ -1183,6 +1188,159 @@ subroutine zonal_flux_thickness(u, h, h_W, h_E, h_u, dt, G, GV, US, LB, vol_CFL,
   endif
 
 end subroutine zonal_flux_thickness
+
+!> Returns the barotropic velocity adjustment that gives the
+!! desired barotropic (layer-summed) transport.
+subroutine zonal_flux_adjust_fused(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
+                             du, du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
+                             j, ish, ieh, do_I_in, por_face_areaU, uh_3d, OBC)
+
+  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
+  type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)   :: u    !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to
+                                                                   !! calculate fluxes [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_W  !< West edge thickness in the
+                                                                   !! reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_E  !< East edge thickness in the
+                                                                   !! reconstruction [H ~> m or kg m-2].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)),        intent(in)    :: visc_rem !< Both the fraction of the
+                       !! momentum originally in a layer that remains after a time-step of viscosity, and
+                       !! the fraction of a time-step's worth of a barotropic acceleration that a layer
+                       !! experiences after viscosity is applied [nondim].
+                       !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
+  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: uhbt !< The summed volume flux
+                       !! through zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
+
+  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: du_max_CFL  !< Maximum acceptable
+                       !! value of du [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: du_min_CFL  !< Minimum acceptable
+                       !! value of du [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: uh_tot_0    !< The summed transport
+                       !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZIB_(G),SZJ_(G)),                 intent(in)    :: duhdu_tot_0 !< The partial derivative
+                       !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
+  real, dimension(SZIB_(G),SZJ_(G)),                 intent(inout)   :: du !<
+                       !! The barotropic velocity adjustment [L T-1 ~> m s-1].
+  real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
+  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
+  type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
+  integer,                                   intent(in)    :: j    !< Spatial index.
+  integer,                                   intent(in)    :: ish  !< Start of index range.
+  integer,                                   intent(in)    :: ieh  !< End of index range.
+  logical, dimension(SZIB_(G),SZJ_(G)),              intent(in)    :: do_I_in     !<
+                       !! A logical flag indicating which I values to work on.
+  real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
+                                      intent(in) :: por_face_areaU !< fractional open area of U-faces [nondim]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), optional, intent(inout) :: uh_3d !<
+                       !! Volume flux through zonal faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
+  type(ocean_OBC_type),            optional, pointer       :: OBC !< Open boundaries control structure.
+  ! Local variables
+  real, dimension(SZIB_(G),SZK_(GV)) :: &
+    uh_aux, &  ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
+    duhdu      ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
+  real, dimension(SZIB_(G)) :: &
+    uh_err, &  ! Difference between uhbt and the summed uh [H L2 T-1 ~> m3 s-1 or kg s-1].
+    uh_err_best, & ! The smallest value of uh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
+    u_new, &   ! The velocity with the correction added [L T-1 ~> m s-1].
+    duhdu_tot,&! Summed partial derivative of uh with u [H L ~> m2 or kg m-1].
+    du_min, &  ! Lower limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
+    du_max     ! Upper limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
+  real :: du_prev ! The previous value of du [L T-1 ~> m s-1].
+  real :: ddu     ! The change in du from the previous iteration [L T-1 ~> m s-1].
+  real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
+  real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
+  integer :: i, k, nz, itt, max_itts = 20
+  logical :: domore, do_I(SZIB_(G))
+
+  nz = GV%ke
+
+  uh_aux(:,:) = 0.0 ; duhdu(:,:) = 0.0
+
+  if (present(uh_3d)) then ; do k=1,nz ; do I=ish-1,ieh
+    uh_aux(i,k) = uh_3d(I,j,k)
+  enddo ; enddo ; endif
+
+  do I=ish-1,ieh
+    du(I,j) = 0.0 ; do_I(I) = do_I_in(I,j)
+    du_max(I) = du_max_CFL(I,j) ; du_min(I) = du_min_CFL(I,j)
+    uh_err(I) = uh_tot_0(I,j) - uhbt(I,j) ; duhdu_tot(I) = duhdu_tot_0(I,j)
+    uh_err_best(I) = abs(uh_err(I))
+  enddo
+
+  do itt=1,max_itts
+    select case (itt)
+      case (:1) ; tol_eta = 1e-6 * CS%tol_eta
+      case (2)  ; tol_eta = 1e-4 * CS%tol_eta
+      case (3)  ; tol_eta = 1e-2 * CS%tol_eta
+      case default ; tol_eta = CS%tol_eta
+    end select
+    tol_vel = CS%tol_vel
+
+    do I=ish-1,ieh
+      if (uh_err(I) > 0.0) then ; du_max(I) = du(I,j)
+      elseif (uh_err(I) < 0.0) then ; du_min(I) = du(I,j)
+      else ; do_I(I) = .false. ; endif
+    enddo
+    domore = .false.
+    do I=ish-1,ieh ; if (do_I(I)) then
+      if ((dt * min(G%IareaT(i,j),G%IareaT(i+1,j))*abs(uh_err(I)) > tol_eta) .or. &
+          (CS%better_iter .and. ((abs(uh_err(I)) > tol_vel * duhdu_tot(I)) .or. &
+                                 (abs(uh_err(I)) > uh_err_best(I))) )) then
+      !   Use Newton's method, provided it stays bounded.  Otherwise bisect
+      ! the value with the appropriate bound.
+        ddu = -uh_err(I) / duhdu_tot(I)
+        du_prev = du(I,j)
+        du(I,j) = du(I,j) + ddu
+        if (abs(ddu) < 1.0e-15*abs(du(I,j))) then
+          do_I(I) = .false. ! ddu is small enough to quit.
+        elseif (ddu > 0.0) then
+          if (du(I,j) >= du_max(I)) then
+            du(I,j) = 0.5*(du_prev + du_max(I))
+            if (du_max(I) - du_prev < 1.0e-15*abs(du(I,j))) do_I(I) = .false.
+          endif
+        else ! ddu < 0.0
+          if (du(I,j) <= du_min(I)) then
+            du(I,j) = 0.5*(du_prev + du_min(I))
+            if (du_prev - du_min(I) < 1.0e-15*abs(du(I,j))) do_I(I) = .false.
+          endif
+        endif
+        if (do_I(I)) domore = .true.
+      else
+        do_I(I) = .false.
+      endif
+    endif ; enddo
+    if (.not.domore) exit
+
+    if ((itt < max_itts) .or. present(uh_3d)) then ; do k=1,nz
+      do I=ish-1,ieh ; u_new(I) = u(I,j,k) + du(I,j) * visc_rem(I,j,k) ; enddo
+      call zonal_flux_layer(u_new, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), &
+                            uh_aux(:,k), duhdu(:,k), visc_rem(:,j,k), &
+                            dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, por_face_areaU(:,j,k), OBC)
+    enddo ; endif
+
+    if (itt < max_itts) then
+      do I=ish-1,ieh
+        uh_err(I) = -uhbt(I,j) ; duhdu_tot(I) = 0.0
+      enddo
+      do k=1,nz ; do I=ish-1,ieh
+        uh_err(I) = uh_err(I) + uh_aux(I,k)
+        duhdu_tot(I) = duhdu_tot(I) + duhdu(I,k)
+      enddo ; enddo
+      do I=ish-1,ieh
+        uh_err_best(I) = min(uh_err_best(I), abs(uh_err(I)))
+      enddo
+    endif
+  enddo ! itt-loop
+  ! If there are any faces which have not converged to within the tolerance,
+  ! so-be-it, or else use a final upwind correction?
+  ! This never seems to happen with 20 iterations as max_itt.
+
+  if (present(uh_3d)) then ; do k=1,nz ; do I=ish-1,ieh
+    uh_3d(I,j,k) = uh_aux(I,k)
+  enddo ; enddo ; endif
+
+end subroutine zonal_flux_adjust_fused
 
 !> Returns the barotropic velocity adjustment that gives the
 !! desired barotropic (layer-summed) transport.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2302,7 +2302,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, 
       BT_cont%vBT_SS(i,J) = 0.0
       BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
       BT_cont%vBT_NN(i,J) = 0.0
-    enddo ; enddo
+    enddo ; enddo ; enddo
     return
   endif
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1461,6 +1461,25 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, 
   nz = GV%ke ; Idt = 1.0 / dt
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
+  !$omp target enter data &
+  !$omp   map(to: u(ish-1:ieh, :, :), h_W(ish-1:ieh+1, :, :), h_E(ish-1:ieh+1, :, :), &
+  !$omp       h_in(ish-1:ieh+1, :, :), uh_tot_0(ish-1:ieh, jsh:jeh), duhdu_tot_0(ish-1:ieh, jsh:jeh), &
+  !$omp       G, G%IareaT(ish-1:ieh+1, jsh:jeh), G%dy_Cu(ish-1:ieh, jsh:jeh), &
+  !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), G%dxCu(ish-1:ieh, jsh:jeh), BT_cont, &
+  !$omp       du_max_CFL(ish-1:ieh, jsh:jeh), du_min_CFL(ish-1:ieh, jsh:jeh), CS, &
+  !$omp       visc_rem(ish-1:ieh, :, :), visc_rem_max(ish-1:ieh, jsh:jeh), do_I(ish-1:ieh, jsh:jeh), &
+  !$omp       por_face_areaU(ish-1:ieh, :, :)) &
+  !$omp   map(alloc: zeros(ish-1:ieh, jsh:jeh), du0(ish-1:ieh, jsh:jeh), duL(ish-1:ieh, jsh:jeh), &
+  !$omp       duR(ish-1:ieh, jsh:jeh), du_CFL(ish-1:ieh, jsh:jeh), FAmt_L(ish-1:ieh, jsh:jeh), &
+  !$omp       FAmT_R(ish-1:ieh, jsh:jeh), FAmt_0(ish-1:ieh, jsh:jeh), uhtot_L(ish-1:ieh, jsh:jeh), &
+  !$omp       uhtot_R(ish-1:ieh, jsh:jeh), u_L(ish-1:ieh, :, :), u_R(ish-1:ieh, :, :), &
+  !$omp       u_0(ish-1:ieh, :, :), duhdu_L(ish-1:ieh, :, :), duhdu_R(ish-1:ieh, :, :), &
+  !$omp       duhdu_0(ish-1:ieh, :, :), uh_L(ish-1:ieh, :, :), uh_R(ish-1:ieh, :, :), &
+  !$omp       uh_0(ish-1:ieh, :, :), BT_cont%FA_u_W0(ish-1:ieh, jsh:jeh), &
+  !$omp       BT_cont%FA_u_WW(ish-1:ieh, jsh:jeh), BT_cont%FA_u_E0(ish-1:ieh, jsh:jeh), &
+  !$omp       BT_cont%FA_u_EE(ish-1:ieh, jsh:jeh), BT_cont%uBT_WW(ish-1:ieh, jsh:jeh), &
+  !$omp       BT_cont%uBT_EE(ish-1:ieh, jsh:jeh))
+
   ! Diagnose the zero-transport correction, du0.
   !$omp target teams distribute parallel do collapse(2) &
   !$omp   map(from: zeros(ish-1:ieh, jsh:jeh))
@@ -1594,6 +1613,23 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, 
   !$omp target update from(BT_cont%FA_u_W0(ish-1:ieh, jsh:jeh), BT_cont%FA_u_WW(ish-1:ieh, jsh:jeh), &
   !$omp       BT_cont%FA_u_E0(ish-1:ieh, jsh:jeh), BT_cont%FA_u_EE(ish-1:ieh, jsh:jeh), &
   !$omp       BT_cont%uBT_WW(ish-1:ieh, jsh:jeh), BT_cont%uBT_EE(ish-1:ieh, jsh:jeh))
+  !$omp target exit data &
+  !$omp   map(from: BT_cont%FA_u_W0(ish-1:ieh, jsh:jeh), BT_cont%FA_u_WW(ish-1:ieh, jsh:jeh), &
+  !$omp       BT_cont%FA_u_E0(ish-1:ieh, jsh:jeh), BT_cont%FA_u_EE(ish-1:ieh, jsh:jeh), &
+  !$omp       BT_cont%uBT_WW(ish-1:ieh, jsh:jeh), BT_cont%uBT_EE(ish-1:ieh, jsh:jeh)) &
+  !$omp   map(release: zeros(ish-1:ieh, jsh:jeh), u(ish-1:ieh, :, :), h_W(ish-1:ieh+1, :, :), &
+  !$omp       h_E(ish-1:ieh+1, :, :), h_in(ish-1:ieh+1, :, :), uh_tot_0(ish-1:ieh, jsh:jeh), &
+  !$omp       duhdu_tot_0(ish-1:ieh, jsh:jeh), du0(ish-1:ieh, jsh:jeh), duL(ish-1:ieh, jsh:jeh), &
+  !$omp       duR(ish-1:ieh, jsh:jeh), du_CFL(ish-1:ieh, jsh:jeh), FAmt_L(ish-1:ieh, jsh:jeh), &
+  !$omp       FAmT_R(ish-1:ieh, jsh:jeh), FAmt_0(ish-1:ieh, jsh:jeh), uhtot_L(ish-1:ieh, jsh:jeh), &
+  !$omp       uhtot_R(ish-1:ieh, jsh:jeh), u_L(ish-1:ieh, :, :), u_R(ish-1:ieh, :, :), &
+  !$omp       u_0(ish-1:ieh, :, :), duhdu_L(ish-1:ieh, :, :), duhdu_R(ish-1:ieh, :, :), &
+  !$omp       duhdu_0(ish-1:ieh, :, :), uh_L(ish-1:ieh, :, :), uh_R(ish-1:ieh, :, :), &
+  !$omp       uh_0(ish-1:ieh, :, :), G, G%IareaT(ish-1:ieh+1, jsh:jeh), G%dy_Cu(ish-1:ieh, jsh:jeh), &
+  !$omp       G%IdxT(ish-1:ieh+1, jsh:jeh), G%dxCu(ish-1:ieh, jsh:jeh), BT_cont, &
+  !$omp       du_max_CFL(ish-1:ieh, jsh:jeh), du_min_CFL(ish-1:ieh, jsh:jeh), CS, &
+  !$omp       visc_rem(ish-1:ieh, :, :), visc_rem_max(ish-1:ieh, jsh:jeh), do_I(ish-1:ieh, jsh:jeh), &
+  !$omp       por_face_areaU(ish-1:ieh, :, :))
 
 end subroutine set_zonal_BT_cont
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1911,6 +1911,21 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   I_dt = 1.0 / dt
   if (CS%aggress_adjust) CFL_dt = I_dt
 
+  !$omp target enter data &
+  !$omp   map(to: G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%IdyT(ish:ieh, jsh-1:jeh+1), &
+  !$omp       G%dyT(ish:ieh, jsh-1:jeh+1), G%dyT(ish:ieh, jsh-1:jeh+1), G%dyCv(ish:ieh, jsh-1:jeh), &
+  !$omp       G%mask2dCv(ish:ieh, jsh-1:jeh), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
+  !$omp       h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), CS, por_face_areaV(ish:ieh, :, :), &
+  !$omp       vhbt(ish:ieh, jsh-1:jeh), visc_rem_v(ish:ieh, :, :), BT_cont) &
+  !$omp   map(alloc: vh(ish:ieh, :, :), v_cor(ish:ieh, :, :), BT_cont%FA_v_S0(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%FA_v_SS(ish:ieh, jsh-1:jeh), BT_cont%vBT_SS(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%FA_v_N0(ish:ieh, jsh-1:jeh), BT_cont%FA_v_NN(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%vBT_NN(ish:ieh, jsh-1:jeh), dv_cor(ish:ieh, jsh-1:jeh), dvhdv(ish:ieh, :, :), &
+  !$omp       dv(ish:ieh, jsh-1:jeh), dv_min_CFL(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot_0(ish:ieh, jsh-1:jeh), vh_tot_0(ish:ieh, jsh-1:jeh), &
+  !$omp       visc_rem_max(ish:ieh, jsh-1:jeh), do_I(ish:ieh, jsh-1:jeh), FAvi(ish:ieh, jsh-1:jeh), &
+  !$omp       visc_rem_v_tmp(ish:ieh, :, :), simple_OBC_pt(ish:ieh, jsh:jeh))
+
   ! a better solution is needed
   if (.not.use_visc_rem) then
     !$omp target teams distribute parallel do collapse(3) &
@@ -2233,6 +2248,21 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     endif
     !$omp target update from(BT_cont%h_v)
   endif ; endif
+
+  !$omp target exit data &
+  !$omp   map(from: vh(ish:ieh, :, :), v_cor(ish:ieh, :, :), BT_cont%FA_v_S0(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%FA_v_SS(ish:ieh, jsh-1:jeh), BT_cont%vBT_SS(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%FA_v_N0(ish:ieh, jsh-1:jeh), BT_cont%FA_v_NN(ish:ieh, jsh-1:jeh), &
+  !$omp       BT_cont%vBT_NN(ish:ieh, jsh-1:jeh), dv_cor(ish:ieh, jsh-1:jeh)) &
+  !$omp   map(release: G, G%dx_Cv(ish:ieh, jsh-1:jeh), G%IdyT(ish:ieh, jsh-1:jeh+1), &
+  !$omp       G%dyT(ish:ieh, jsh-1:jeh+1), G%dyT(ish:ieh, jsh-1:jeh+1), G%dyCv(ish:ieh, jsh-1:jeh), &
+  !$omp       G%mask2dCv(ish:ieh, jsh-1:jeh), v(ish:ieh, :, :), h_in(ish:ieh, :, :), &
+  !$omp       h_S(ish:ieh, :, :), h_N(ish:ieh, :, :), CS, por_face_areaV(ish:ieh, :, :), &
+  !$omp       vhbt(ish:ieh, jsh-1:jeh), visc_rem_v(ish:ieh, :, :), dvhdv(ish:ieh, :, :), &
+  !$omp       dv(ish:ieh, jsh-1:jeh), dv_min_CFL(ish:ieh, jsh-1:jeh), dv_max_CFL(ish:ieh, jsh-1:jeh), &
+  !$omp       dvhdv_tot_0(ish:ieh, jsh-1:jeh), vh_tot_0(ish:ieh, jsh-1:jeh), &
+  !$omp       visc_rem_max(ish:ieh, jsh-1:jeh), do_I(ish:ieh, jsh-1:jeh), FAvi(ish:ieh, jsh-1:jeh), &
+  !$omp       visc_rem_v_tmp(ish:ieh, :, :), simple_OBC_pt(ish:ieh, jsh:jeh))
 
   call cpu_clock_end(id_clock_correct)
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2033,6 +2033,10 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
         enddo ; enddo ; enddo
       endif
     endif
+    do j=jsh-1,jeh ; do i=ish,ieh
+      dv_max_CFL(i,j) = max(dv_max_CFL(i,j),0.0)
+      dv_min_CFL(i,j) = min(dv_min_CFL(i,j),0.0)
+    enddo ; enddo
   endif
   
   !$OMP parallel do default(shared) private(do_I,dvhdv,dv,dv_max_CFL,dv_min_CFL,vh_tot_0, &
@@ -2047,10 +2051,6 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     enddo ! k-loop
 
     if (present(vhbt) .or. set_BT_cont) then
-      do i=ish,ieh
-        dv_max_CFL(i,j) = max(dv_max_CFL(i,j),0.0)
-        dv_min_CFL(i,j) = min(dv_min_CFL(i,j),0.0)
-      enddo
 
       any_simple_OBC = .false.
       if (present(vhbt) .or. set_BT_cont) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1896,7 +1896,7 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     dvhdv_tot_0, & ! Summed partial derivative of vh with v [H L ~> m2 or kg m-1].
     vh_tot_0, &   ! Summed transport with no barotropic correction [H L2 T-1 ~> m3 s-1 or kg s-1].
     visc_rem_max  ! The column maximum of visc_rem [nondim]
-  logical, dimension(SZI_(G),SZJ_(G)) :: do_I
+  logical, dimension(SZI_(G),SZJB_(G)) :: do_I
   real, dimension(SZI_(G),SZJB_(G)) :: FAvi  ! A list of sums of meridional face areas [H L ~> m2 or kg m-1].
   real :: FA_v    ! A sum of meridional face areas [H L ~> m2 or kg m-1].
   real, dimension(SZI_(G),SZK_(GV)) :: &
@@ -2172,7 +2172,7 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
   ! Local variables
   real :: vh(SZI_(G),SZJB_(G),SZK_(GV))      ! Volume flux through meridional faces = v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1]
   real ::  dvhdv(SZI_(G),SZJB_(G),SZK_(GV))  ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
-  logical, dimension(SZI_(G),SZJ_(G)) :: do_I
+  logical, dimension(SZI_(G),SZJB_(G)) :: do_I
   real :: ones(SZI_(G),SZJB_(G),SZK_(GV))    ! An array of 1's [nondim]
   integer :: i, j, k, ish, ieh, jsh, jeh, nz, l_seg
   logical :: local_specified_BC, OBC_in_row(SZJB_(G))
@@ -2249,7 +2249,7 @@ subroutine merid_flux_layer_fused(v, h, h_S, h_N, vh, dvhdv, visc_rem, dt, G, GV
   type(unit_scale_type),        intent(in)    :: US       !< A dimensional unit scaling type
   integer,                      intent(in)    :: ish,jsh      !< Start of index range.
   integer,                      intent(in)    :: ieh,jeh,nz      !< End of index range.
-  logical, dimension(SZI_(G),SZJ_(G)),  intent(in)    :: do_I     !< Which i values to work on.
+  logical, dimension(SZI_(G),SZJB_(G)),  intent(in)    :: do_I     !< Which i values to work on.
   logical,                      intent(in)    :: vol_CFL  !< If true, rescale the
          !! ratio of face areas to the cell areas when estimating the CFL number.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
@@ -2549,7 +2549,7 @@ subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv
   type(continuity_PPM_CS),  intent(in)    :: CS   !< This module's control structure.
   integer,                  intent(in)    :: ish, jsh  !< Start of index range.
   integer,                  intent(in)    :: ieh, jeh  !< End of index range.
-  logical, dimension(SZI_(G),SZJ_(G)), &
+  logical, dimension(SZI_(G),SZJB_(G)), &
                             intent(in)    :: do_I_in  !< A flag indicating which I values to work on.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                      intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
@@ -2573,7 +2573,7 @@ subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv
   real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
   real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
   integer :: i, j, k, nz, itt, max_itts = 20
-  logical :: domore, do_I(SZI_(G),SZJ_(G))
+  logical :: domore, do_I(SZI_(G),SZJB_(G))
 
   nz = GV%ke
 
@@ -2850,7 +2850,7 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
   real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim]
   integer,                                   intent(in)    :: ish, jsh      !< Start of index range.
   integer,                                   intent(in)    :: ieh, jeh      !< End of index range.
-  logical, dimension(SZI_(G),SZJ_(G)),       intent(in)    :: do_I     !< A logical flag indicating
+  logical, dimension(SZI_(G),SZJB_(G)),       intent(in)    :: do_I     !< A logical flag indicating
                        !! which I values to work on.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                                 intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2302,7 +2302,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, 
       BT_cont%vBT_SS(i,J) = 0.0
       BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
       BT_cont%vBT_NN(i,J) = 0.0
-    enddo ; enddo ; enddo
+    enddo ; enddo
     return
   endif
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1609,12 +1609,12 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
             dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(I,j), 1000.0*G%dyT(i,j+1))
           else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
           dv_lim = 0.499*((dy_S*I_dt - v(i,J,k)) + MIN(0.0,v(i,J-1,k)))
-          if (dv_max_CFL(i,j) * visc_rem(i,k) > dv_lim) &
-            dv_max_CFL(i,j) = dv_lim / visc_rem(i,k)
+          if (dv_max_CFL(i,j) * visc_rem_v_tmp(I,j,k) > dv_lim) &
+            dv_max_CFL(i,j) = dv_lim / visc_rem_v_tmp(I,j,k)
 
           dv_lim = 0.499*((-dy_N*CFL_dt - v(i,J,k)) + MAX(0.0,v(i,J+1,k)))
-          if (dv_min_CFL(i,j) * visc_rem(i,k) < dv_lim) &
-            dv_min_CFL(i,j) = dv_lim / visc_rem(i,k)
+          if (dv_min_CFL(i,j) * visc_rem_v_tmp(I,j,k) < dv_lim) &
+            dv_min_CFL(i,j) = dv_lim / visc_rem_v_tmp(I,j,k)
         enddo ; enddo ; enddo
       else
         do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh
@@ -1622,10 +1622,10 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
             dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(I,j), 1000.0*G%dyT(i,j))
             dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(I,j), 1000.0*G%dyT(i,j+1))
           else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
-          if (dv_max_CFL(i,j) * visc_rem(i,k) > dy_S*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
-            dv_max_CFL(i,j) = (dy_S*CFL_dt - v(i,J,k)) / visc_rem(i,k)
-          if (dv_min_CFL(i,j) * visc_rem(i,k) < -dy_N*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
-            dv_min_CFL(i,j) = -(dy_N*CFL_dt + v(i,J,k)) / visc_rem(i,k)
+          if (dv_max_CFL(i,j) * visc_rem_v_tmp(I,j,k) > dy_S*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
+            dv_max_CFL(i,j) = (dy_S*CFL_dt - v(i,J,k)) / visc_rem_v_tmp(I,j,k)
+          if (dv_min_CFL(i,j) * visc_rem_v_tmp(I,j,k) < -dy_N*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
+            dv_min_CFL(i,j) = -(dy_N*CFL_dt + v(i,J,k)) / visc_rem_v_tmp(I,j,k)
         enddo ; enddo ; enddo
       endif
     else

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -457,10 +457,8 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
     enddo ; enddo ; enddo
   else
     !$OMP parallel do default(shared)
-    do k=1,nz
-      call PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, &
-                                2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
-    enddo
+    call PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, &
+                              2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
   endif
 
   call cpu_clock_end(id_clock_reconstruct)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2930,9 +2930,7 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     return
   endif
 
-  do j = jsh-1, jeh
-
-  do k=1,nz ; do i=ish,ieh ; if (do_I(i,j)) then
+  do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh ; if (do_I(i,j)) then
     visc_rem_lim = max(visc_rem(i,j,k), min_visc_rem*visc_rem_max(i,j))
     if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
       if (v(i,J,k) + dvR(i,j)*visc_rem_lim > -dv_CFL(i,j)*visc_rem(i,j,k)) &
@@ -2940,7 +2938,9 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
       if (v(i,J,k) + dvL(i,j)*visc_rem_lim < dv_CFL(i,j)*visc_rem(i,j,k)) &
         dvL(i,j) = -(v(i,J,k) - dv_CFL(i,j)*visc_rem(i,j,k)) / visc_rem_lim
     endif
-  endif ; enddo ; enddo
+  endif ; enddo ; enddo ; enddo
+
+  do j = jsh-1, jeh
   do k=1,nz
     do i=ish,ieh ; if (do_I(i,j)) then
       v_L(i) = v(I,j,k) + dvL(i,j) * visc_rem(i,j,k)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2054,11 +2054,9 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     endif
     if (present(vhbt)) then
       ! Find dv and vh.
-      do j=jsh-1,jeh
       call meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, dv, &
                              dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem_v, &
-                             j, ish, ieh, do_I, por_face_areaV, vh, OBC=OBC)
-      enddo
+                             ish, ieh, jsh, jeh, do_I, por_face_areaV, vh, OBC=OBC)
     endif
   endif
   
@@ -2524,7 +2522,7 @@ end subroutine meridional_flux_thickness
 !> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
 subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
                              dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             j, ish, ieh, do_I_in, por_face_areaV, vh_3d, OBC)
+                             ish, ieh, jsh, jeh, do_I_in, por_face_areaV, vh_3d, OBC)
   type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
@@ -2553,9 +2551,8 @@ subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv
   real,                     intent(in)    :: dt   !< Time increment [T ~> s].
   type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
   type(continuity_PPM_CS),  intent(in)    :: CS   !< This module's control structure.
-  integer,                  intent(in)    :: j    !< Spatial index.
-  integer,                  intent(in)    :: ish  !< Start of index range.
-  integer,                  intent(in)    :: ieh  !< End of index range.
+  integer,                  intent(in)    :: ish, jsh  !< Start of index range.
+  integer,                  intent(in)    :: ieh, jeh  !< End of index range.
   logical, dimension(SZI_(G),SZJ_(G)), &
                             intent(in)    :: do_I_in  !< A flag indicating which I values to work on.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -2579,10 +2576,12 @@ subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv
   real :: ddv     ! The change in dv from the previous iteration [L T-1 ~> m s-1].
   real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
   real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
-  integer :: i, k, nz, itt, max_itts = 20
+  integer :: i, j, k, nz, itt, max_itts = 20
   logical :: domore, do_I(SZI_(G))
 
   nz = GV%ke
+
+  do j=jsh-1,jeh
 
   vh_aux(:,:) = 0.0 ; dvhdv(:,:) = 0.0
 
@@ -2668,6 +2667,8 @@ subroutine meridional_flux_adjust_fused(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv
   if (present(vh_3d)) then ; do k=1,nz ; do i=ish,ieh
     vh_3d(i,J,k) = vh_aux(i,k)
   enddo ; enddo ; endif
+
+  enddo
 
 end subroutine meridional_flux_adjust_fused
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -717,6 +717,10 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
         enddo ; enddo ; enddo
       endif
     endif
+    do j=jsh,jeh ; do I=ish-1,ieh
+      du_max_CFL(I,j) = max(du_max_CFL(I,j),0.0)
+      du_min_CFL(I,j) = min(du_min_CFL(I,j),0.0)
+    enddo ; enddo
 
   endif
 
@@ -729,25 +733,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     enddo
 
     if (present(uhbt) .or. set_BT_cont) then
-      do I=ish-1,ieh
-        du_max_CFL(I,j) = max(du_max_CFL(I,j),0.0)
-        du_min_CFL(I,j) = min(du_min_CFL(I,j),0.0)
-      enddo
-
-      any_simple_OBC = .false.
-      if (present(uhbt) .or. set_BT_cont) then
-        if (local_specified_BC .or. local_Flather_OBC) then ; do I=ish-1,ieh
-          l_seg = abs(OBC%segnum_u(I,j))
-
-          ! Avoid reconciling barotropic/baroclinic transports if transport is specified
-          simple_OBC_pt(I) = .false.
-          if (l_seg /= OBC_NONE) simple_OBC_pt(I) = OBC%segment(l_seg)%specified
-          do_I(I, j) = .not.simple_OBC_pt(I)
-          any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(I)
-        enddo ; else ; do I=ish-1,ieh
-          do_I(I, j) = .true.
-        enddo ; endif
-      endif
 
       if (present(uhbt)) then
         ! Find du and uh.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1653,21 +1653,12 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   if (CS%aggress_adjust) CFL_dt = I_dt
 
   !$omp target enter data &
-  !$omp   map(to: G, G%dx_Cv, G%IdyT, &
-  !$omp       G%dyT, G%dyCv, &
-  !$omp       G%mask2dCv, G%areaT, &
-  !$omp       G%IareaT, v, h_in, &
-  !$omp       h_S, h_N, CS, por_face_areaV, &
-  !$omp       vhbt, visc_rem_v, BT_cont) &
-  !$omp   map(alloc: vh, v_cor, BT_cont%FA_v_S0, &
-  !$omp       BT_cont%FA_v_SS, BT_cont%vBT_SS, &
-  !$omp       BT_cont%FA_v_N0, BT_cont%FA_v_NN, &
-  !$omp       BT_cont%vBT_NN, BT_cont%h_v, &
-  !$omp       dv_cor, dvhdv, dv, &
-  !$omp       dv_min_CFL, dv_max_CFL, &
-  !$omp       dvhdv_tot_0, vh_tot_0, &
-  !$omp       visc_rem_max, do_I, FAvi, &
-  !$omp       visc_rem_v_tmp, simple_OBC_pt)
+  !$omp   map(to: G, G%dx_Cv, G%IdyT, G%dyT, G%dyCv, G%mask2dCv, G%areaT, G%IareaT, v, h_in, h_S, &
+  !$omp       h_N, CS, por_face_areaV, vhbt, visc_rem_v, BT_cont) &
+  !$omp   map(alloc: vh, v_cor, BT_cont%FA_v_S0, BT_cont%FA_v_SS, BT_cont%vBT_SS, BT_cont%FA_v_N0, &
+  !$omp       BT_cont%FA_v_NN, BT_cont%vBT_NN, BT_cont%h_v, dv_cor, dvhdv, dv, dv_min_CFL, &
+  !$omp       dv_max_CFL, dvhdv_tot_0, vh_tot_0, visc_rem_max, do_I, FAvi, visc_rem_v_tmp, &
+  !$omp       simple_OBC_pt)
 
   ! a better solution is needed
   if (.not.use_visc_rem) then
@@ -2947,7 +2938,6 @@ pure function ratio_max(a, b, maxrat) result(ratio)
   real, intent(in) :: b       !< Denominator, in arbitrary units [B]
   real, intent(in) :: maxrat  !< Maximum value of ratio [A B-1]
   real :: ratio               !< Return value [A B-1]
-  !$omp declare target
 
   if (abs(a) > abs(maxrat*b)) then
     ratio = maxrat

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2407,6 +2407,10 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, sim
     call MOM_error(FATAL,mesg)
   endif
 
+  !$omp target enter data &
+  !$omp   map(to: G, G%mask2dT(isl-2:iel+2, jsl:jel), h_in(isl-2:iel+2, :, :)) &
+  !$omp   map(alloc: h_W, h_E, slp) ! whole arrays as unclear range of loops in OBC regions
+
   if (simple_2nd) then
     ! untested
     !$omp target teams distribute parallel do collapse(3) &
@@ -2511,6 +2515,10 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, sim
   else
     call PPM_limit_pos(h_in, h_W, h_E, h_min, G, GV, isl, iel, jsl, jel, nz)
   endif
+
+  !$omp target exit data &
+  !$omp   map(from: h_W, h_E) & ! whole arrays as unclear range of loops in OBC regions
+  !$omp   map(release: G, G%mask2dT(isl-2:iel+2, jsl:jel), h_in(isl-2:iel+2, :, :), slp)
 
   return
 end subroutine PPM_reconstruction_x

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2028,19 +2028,10 @@ subroutine merid_flux_layer(v, h, h_S, h_N, vh, dvhdv, visc_rem, dt, G, GV, US, 
   endif ; endif
 
   !$omp target enter data &
-  !$omp   map(to: do_I(ish:ieh, jsh-1:jeh), v(ish:ieh, :, :), G, G%dx_Cv(ish:ieh, jsh-1:jeh), &
-  !$omp       G%IareaT(ish:ieh, jsh-1:jeh+1), G%IdyT(ish:ieh, jsh-1:jeh+1), h_S(ish:ieh, :, :), &
-  !$omp       h_N(ish:ieh, :, :), h(ish:ieh, :, :), por_face_areaV(ish:ieh, :, :), &
-  !$omp       visc_rem(ish:ieh, :, :), vh(ish:ieh, :, :), dvhdv(ish:ieh, :, :))
+  !$omp   map(to: do_I, v, G, G%dx_Cv, G%IareaT, G%IdyT, h_S, h_N, h, por_face_areaV, visc_rem, &
+  !$omp       vh, dvhdv)
 
-  !$omp target teams distribute parallel do collapse(3) &
-  !$omp   private(CFL, curv_3, h_marg) &
-  !$omp   map(to: do_I(ish:ieh, jsh-1:jeh), v(ish:ieh, :, :), G, G%dx_Cv(ish:ieh, jsh-1:jeh), &
-  !$omp       G%IareaT(ish:ieh, jsh-1:jeh+1), G%IdyT(ish:ieh, jsh-1:jeh+1), h_S(ish:ieh, :, :), &
-  !$omp       h_N(ish:ieh, :, :), h(ish:ieh, :, :), por_face_areaV(ish:ieh, :, :), &
-  !$omp       visc_rem(ish:ieh, :, :)) &
-  !$omp   map(tofrom: vh(ish:ieh, :, :), dvhdv(ish:ieh, :, :))
-  do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh ; if (do_I(i,j)) then
+  do concurrent (k=1:nz, j=jsh-1:jeh, i=ish:ieh, do_I(i,j))
     if (v(i,j,k) > 0.0) then
       if (vol_CFL) then ; CFL = (v(i,j,k) * dt) * (G%dx_Cv(i,J) * G%IareaT(i,j))
       else ; CFL = v(i,j,k) * dt * G%IdyT(i,j) ; endif
@@ -2062,15 +2053,10 @@ subroutine merid_flux_layer(v, h, h_S, h_N, vh, dvhdv, visc_rem, dt, G, GV, US, 
       h_marg = 0.5 * (h_S(i,j+1,k) + h_N(i,j,k))
     endif
     dvhdv(i,j,k) = (G%dx_Cv(i,J)*por_face_areaV(i,J,k)) * h_marg * visc_rem(i,j,k)
-  endif ; enddo ; enddo; enddo
+  enddo
 
   if (local_open_BC) then
-    !$omp target teams distribute parallel do collapse(3) &
-    !$omp   map(to: do_I(ish:ieh, jsh-1:jeh), OBC, OBC%segnum_v(ish:ieh, jsh-1:jeh), &
-    !$omp       OBC%segment(:), G, G%dx_Cv(ish:ieh, jsh-1:jeh), por_face_areaV(ish:ieh, :, :), &
-    !$omp       v(ish:ieh, :, :), h(ish:ieh, :, :), visc_rem(ish:ieh, :, :)) &
-    !$omp   map(tofrom: vh(ish:ieh, :, :), dvhdv(ish:ieh, :, :))
-    do k=1,nz ; do j=jsh-1,jeh ; do i=ish,ieh ; if (do_I(i,j)) then
+    do concurrent (k=1:nz, j=jsh-1:jeh, i=ish:ieh, do_I(i,j))
       if (OBC%segnum_v(i,J) /= 0) then
         if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
           if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
@@ -2082,14 +2068,11 @@ subroutine merid_flux_layer(v, h, h_S, h_N, vh, dvhdv, visc_rem, dt, G, GV, US, 
           endif
         endif
       endif
-    endif ; enddo ; enddo ; enddo
+    enddo
   endif
   !$omp target exit data &
-  !$omp   map(from: vh(ish:ieh, :, :), dvhdv(ish:ieh, :, :)) &
-  !$omp   map(release: do_I(ish:ieh, jsh-1:jeh), v(ish:ieh, :, :), G, G%dx_Cv(ish:ieh, jsh-1:jeh), &
-  !$omp       G%IareaT(ish:ieh, jsh-1:jeh+1), G%IdyT(ish:ieh, jsh-1:jeh+1), h_S(ish:ieh, :, :), &
-  !$omp       h_N(ish:ieh, :, :), h(ish:ieh, :, :), por_face_areaV(ish:ieh, :, :), &
-  !$omp       visc_rem(ish:ieh, :, :))
+  !$omp   map(from: vh, dvhdv) &
+  !$omp   map(release: do_I, v, G, G%dx_Cv, G%IareaT, G%IdyT, h_S, h_N, h, por_face_areaV, visc_rem)
 end subroutine merid_flux_layer
 
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -756,9 +756,9 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
         endif
       endif
       if (set_BT_cont) then
-        call set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0,&
-                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem_u, &
-                              visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaU)
+        call set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0,&
+                               du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem_u, &
+                               visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaU)
       endif
     endif
 
@@ -1502,7 +1502,7 @@ end subroutine zonal_flux_adjust
 
 !> Sets a structure that describes the zonal barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
-subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, &
+subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, &
                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaU)
   type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
@@ -1675,173 +1675,6 @@ subroutine set_zonal_BT_cont_fused(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_t
     BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
     BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
   endif ; enddo ; enddo
-
-end subroutine set_zonal_BT_cont_fused
-
-!> Sets a structure that describes the zonal barotropic volume or mass fluxes as a
-!! function of barotropic flow to agree closely with the sum of the layer's transports.
-subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, &
-                             du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             visc_rem_max, j, ish, ieh, do_I, por_face_areaU)
-  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)    :: u    !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to
-                                                                   !! calculate fluxes [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_W  !< West edge thickness in the
-                                                                   !! reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_E  !< East edge thickness in the
-                                                                   !! reconstruction [H ~> m or kg m-2].
-  type(BT_cont_type),                        intent(inout) :: BT_cont !< A structure with elements
-                       !! that describe the effective open face areas as a function of barotropic flow.
-  real, dimension(SZIB_(G)),                 intent(in)    :: uh_tot_0    !< The summed transport
-                       !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: duhdu_tot_0 !< The partial derivative
-                       !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: du_max_CFL  !< Maximum acceptable
-                       !! value of du [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: du_min_CFL  !< Minimum acceptable
-                       !! value of du [L T-1 ~> m s-1].
-  real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  real, dimension(SZIB_(G),SZK_(GV)),        intent(in)    :: visc_rem !< Both the fraction of the
-                       !! momentum originally in a layer that remains after a time-step of viscosity, and
-                       !! the fraction of a time-step's worth of a barotropic acceleration that a layer
-                       !! experiences after viscosity is applied [nondim].
-                       !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZIB_(G)),                 intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim].
-  integer,                                   intent(in)    :: j        !< Spatial index.
-  integer,                                   intent(in)    :: ish      !< Start of index range.
-  integer,                                   intent(in)    :: ieh      !< End of index range.
-  logical, dimension(SZIB_(G)),              intent(in)    :: do_I     !< A logical flag indicating
-                       !! which I values to work on.
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
-                                    intent(in) :: por_face_areaU !< fractional open area of U-faces [nondim]
-  ! Local variables
-  real, dimension(SZIB_(G)) :: &
-    du0, &        ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
-    duL, duR, &   ! The barotropic velocity increments that give the westerly
-                  ! (duL) and easterly (duR) test velocities [L T-1 ~> m s-1].
-    zeros, &      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
-    du_CFL, &     ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
-    u_L, u_R, &   ! The westerly (u_L), easterly (u_R), and zero-barotropic
-    u_0, &        ! transport (u_0) layer test velocities [L T-1 ~> m s-1].
-    duhdu_L, &    ! The effective layer marginal face areas with the westerly
-    duhdu_R, &    ! (_L), easterly (_R), and zero-barotropic (_0) test
-    duhdu_0, &    ! velocities [H L ~> m2 or kg m-1].
-    uh_L, uh_R, & ! The layer transports with the westerly (_L), easterly (_R),
-    uh_0, &       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-    FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
-    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
-    uhtot_L, &    ! The summed transport with the westerly (uhtot_L) and
-    uhtot_R       ! and easterly (uhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real :: FA_0    ! The effective face area with 0 barotropic transport [L H ~> m2 or kg m-1].
-  real :: FA_avg  ! The average effective face area [L H ~> m2 or kg m-1], nominally given by
-                  ! the realized transport divided by the barotropic velocity.
-  real :: visc_rem_lim ! The larger of visc_rem and min_visc_rem [nondim]. This
-                       ! limiting is necessary to keep the inverse of visc_rem
-                       ! from leading to large CFL numbers.
-  real :: min_visc_rem ! The smallest permitted value for visc_rem that is used
-                       ! in finding the barotropic velocity that changes the
-                       ! flow direction [nondim].  This is necessary to keep the inverse
-                       ! of visc_rem from leading to large CFL numbers.
-  real :: CFL_min ! A minimal increment in the CFL to try to ensure that the
-                  ! flow is truly upwind [nondim]
-  real :: Idt     ! The inverse of the time step [T-1 ~> s-1].
-  logical :: domore
-  integer :: i, k, nz
-
-  nz = GV%ke ; Idt = 1.0 / dt
-  min_visc_rem = 0.1 ; CFL_min = 1e-6
-
- ! Diagnose the zero-transport correction, du0.
-  do I=ish-1,ieh ; zeros(I) = 0.0 ; enddo
-  call zonal_flux_adjust(u, h_in, h_W, h_E, zeros, uh_tot_0, duhdu_tot_0, du0, &
-                         du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                         j, ish, ieh, do_I, por_face_areaU)
-
-  ! Determine the westerly- and easterly- fluxes.  Choose a sufficiently
-  ! negative velocity correction for the easterly-flux, and a sufficiently
-  ! positive correction for the westerly-flux.
-  domore = .false.
-  do I=ish-1,ieh
-    if (do_I(I)) domore = .true.
-    du_CFL(I) = (CFL_min * Idt) * G%dxCu(I,j)
-    duR(I) = min(0.0,du0(I) - du_CFL(I))
-    duL(I) = max(0.0,du0(I) + du_CFL(I))
-    FAmt_L(I) = 0.0 ; FAmt_R(I) = 0.0 ; FAmt_0(I) = 0.0
-    uhtot_L(I) = 0.0 ; uhtot_R(I) = 0.0
-  enddo
-
-  if (.not.domore) then
-    do k=1,nz ; do I=ish-1,ieh
-      BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
-      BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
-      BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
-    enddo ; enddo
-    return
-  endif
-
-  do k=1,nz ; do I=ish-1,ieh ; if (do_I(I)) then
-    visc_rem_lim = max(visc_rem(I,k), min_visc_rem*visc_rem_max(I))
-    if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
-      if (u(I,j,k) + duR(I)*visc_rem_lim > -du_CFL(I)*visc_rem(I,k)) &
-        duR(I) = -(u(I,j,k) + du_CFL(I)*visc_rem(I,k)) / visc_rem_lim
-      if (u(I,j,k) + duL(I)*visc_rem_lim < du_CFL(I)*visc_rem(I,k)) &
-        duL(I) = -(u(I,j,k) - du_CFL(I)*visc_rem(I,k)) / visc_rem_lim
-    endif
-  endif ; enddo ; enddo
-
-  do k=1,nz
-    do I=ish-1,ieh ; if (do_I(I)) then
-      u_L(I) = u(I,j,k) + duL(I) * visc_rem(I,k)
-      u_R(I) = u(I,j,k) + duR(I) * visc_rem(I,k)
-      u_0(I) = u(I,j,k) + du0(I) * visc_rem(I,k)
-    endif ; enddo
-    call zonal_flux_layer(u_0, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_0, duhdu_0, &
-                          visc_rem(:,k), dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, por_face_areaU(:,j,k))
-    call zonal_flux_layer(u_L, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_L, duhdu_L, &
-                          visc_rem(:,k), dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, por_face_areaU(:,j,k))
-    call zonal_flux_layer(u_R, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_R, duhdu_R, &
-                          visc_rem(:,k), dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, por_face_areaU(:,j,k))
-    do I=ish-1,ieh ; if (do_I(I)) then
-      FAmt_0(I) = FAmt_0(I) + duhdu_0(I)
-      FAmt_L(I) = FAmt_L(I) + duhdu_L(I)
-      FAmt_R(I) = FAmt_R(I) + duhdu_R(I)
-      uhtot_L(I) = uhtot_L(I) + uh_L(I)
-      uhtot_R(I) = uhtot_R(I) + uh_R(I)
-    endif ; enddo
-  enddo
-  do I=ish-1,ieh ; if (do_I(I)) then
-    FA_0 = FAmt_0(I) ; FA_avg = FAmt_0(I)
-    if ((duL(I) - du0(I)) /= 0.0) &
-      FA_avg = uhtot_L(I) / (duL(I) - du0(I))
-    if (FA_avg > max(FA_0, FAmt_L(I))) then ; FA_avg = max(FA_0, FAmt_L(I))
-    elseif (FA_avg < min(FA_0, FAmt_L(I))) then ; FA_0 = FA_avg ; endif
-
-    BT_cont%FA_u_W0(I,j) = FA_0 ; BT_cont%FA_u_WW(I,j) = FAmt_L(I)
-    if (abs(FA_0-FAmt_L(I)) <= 1e-12*FA_0) then ; BT_cont%uBT_WW(I,j) = 0.0 ; else
-      BT_cont%uBT_WW(I,j) = (1.5 * (duL(I) - du0(I))) * &
-                            ((FAmt_L(I) - FA_avg) / (FAmt_L(I) - FA_0))
-    endif
-
-    FA_0 = FAmt_0(I) ; FA_avg = FAmt_0(I)
-    if ((duR(I) - du0(I)) /= 0.0) &
-      FA_avg = uhtot_R(I) / (duR(I) - du0(I))
-    if (FA_avg > max(FA_0, FAmt_R(I))) then ; FA_avg = max(FA_0, FAmt_R(I))
-    elseif (FA_avg < min(FA_0, FAmt_R(I))) then ; FA_0 = FA_avg ; endif
-
-    BT_cont%FA_u_E0(I,j) = FA_0 ; BT_cont%FA_u_EE(I,j) = FAmt_R(I)
-    if (abs(FAmt_R(I) - FA_0) <= 1e-12*FA_0) then ; BT_cont%uBT_EE(I,j) = 0.0 ; else
-      BT_cont%uBT_EE(I,j) = (1.5 * (duR(I) - du0(I))) * &
-                            ((FAmt_R(I) - FA_avg) / (FAmt_R(I) - FA_0))
-    endif
-  else
-    BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
-    BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
-    BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
-  endif ; enddo
 
 end subroutine set_zonal_BT_cont
 
@@ -2083,7 +1916,7 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     endif
     
     if (set_BT_cont) then
-      call set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
+      call set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
                              dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem_v, &
                              visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaV)
         
@@ -2817,7 +2650,7 @@ end subroutine meridional_flux_adjust
 
 !> Sets of a structure that describes the meridional barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
-subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
+subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
                              dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
                              visc_rem_max, ish, ieh, jsh, jeh, do_I, por_face_areaV)
   type(ocean_grid_type),                      intent(in)    :: G    !< Ocean's grid structure.
@@ -2979,171 +2812,6 @@ subroutine set_merid_BT_cont_fused(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_t
     BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
     BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
   endif ; enddo ; enddo
-
-end subroutine set_merid_BT_cont_fused
-
-!> Sets of a structure that describes the meridional barotropic volume or mass fluxes as a
-!! function of barotropic flow to agree closely with the sum of the layer's transports.
-subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
-                             dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             visc_rem_max, j, ish, ieh, do_I, por_face_areaV)
-  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)   :: v    !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to calculate fluxes,
-                                                                   !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_S  !< South edge thickness in the reconstruction,
-                                                                   !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_N  !< North edge thickness in the reconstruction,
-                                                                   !! [H ~> m or kg m-2].
-  type(BT_cont_type),                        intent(inout) :: BT_cont !< A structure with elements
-                       !! that describe the effective open face areas as a function of barotropic flow.
-  real, dimension(SZI_(G)),                  intent(in)    :: vh_tot_0    !< The summed transport
-                       !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)),                  intent(in)    :: dvhdv_tot_0 !< The partial derivative
-                       !! of du_err with dv at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G)),                  intent(in)    :: dv_max_CFL !< Maximum acceptable value
-                                                                   !!  of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G)),                  intent(in)    :: dv_min_CFL !< Minimum acceptable value
-                                                                   !!  of dv [L T-1 ~> m s-1].
-  real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  real, dimension(SZI_(G),SZK_(GV)),         intent(in)    :: visc_rem !< Both the fraction of the
-                       !! momentum originally in a layer that remains after a time-step
-                       !! of viscosity, and the fraction of a time-step's worth of a barotropic
-                       !! acceleration that a layer experiences after viscosity is applied [nondim].
-                       !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G)),                  intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim]
-  integer,                                   intent(in)    :: j        !< Spatial index.
-  integer,                                   intent(in)    :: ish      !< Start of index range.
-  integer,                                   intent(in)    :: ieh      !< End of index range.
-  logical, dimension(SZI_(G)),               intent(in)    :: do_I     !< A logical flag indicating
-                       !! which I values to work on.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                                intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
-  ! Local variables
-  real, dimension(SZI_(G)) :: &
-    dv0, &        ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
-    dvL, dvR, &   ! The barotropic velocity increments that give the southerly
-                  ! (dvL) and northerly (dvR) test velocities [L T-1 ~> m s-1].
-    zeros, &      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
-    dv_CFL, &     ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
-    v_L, v_R, &   ! The southerly (v_L), northerly (v_R), and zero-barotropic
-    v_0, &        ! transport (v_0) layer test velocities [L T-1 ~> m s-1].
-    dvhdv_L, &    ! The effective layer marginal face areas with the southerly
-    dvhdv_R, &    ! (_L), northerly (_R), and zero-barotropic (_0) test
-    dvhdv_0, &    ! velocities [H L ~> m2 or kg m-1].
-    vh_L, vh_R, & ! The layer transports with the southerly (_L), northerly (_R)
-    vh_0, &       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-    FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
-    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
-    vhtot_L, &    ! The summed transport with the southerly (vhtot_L) and
-    vhtot_R       ! and northerly (vhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real :: FA_0    ! The effective face area with 0 barotropic transport [H L ~> m2 or kg m-1].
-  real :: FA_avg  ! The average effective face area [H L ~> m2 or kg m-1], nominally given by
-                  ! the realized transport divided by the barotropic velocity.
-  real :: visc_rem_lim ! The larger of visc_rem and min_visc_rem [nondim]  This
-                       ! limiting is necessary to keep the inverse of visc_rem
-                       ! from leading to large CFL numbers.
-  real :: min_visc_rem ! The smallest permitted value for visc_rem that is used
-                       ! in finding the barotropic velocity that changes the
-                       ! flow direction [nondim].  This is necessary to keep the inverse
-                       ! of visc_rem from leading to large CFL numbers.
-  real :: CFL_min ! A minimal increment in the CFL to try to ensure that the
-                  ! flow is truly upwind [nondim]
-  real :: Idt     ! The inverse of the time step [T-1 ~> s-1].
-  logical :: domore
-  integer :: i, k, nz
-
-  nz = GV%ke ; Idt = 1.0 / dt
-  min_visc_rem = 0.1 ; CFL_min = 1e-6
-
- ! Diagnose the zero-transport correction, dv0.
-  do i=ish,ieh ; zeros(i) = 0.0 ; enddo
-  call meridional_flux_adjust(v, h_in, h_S, h_N, zeros, vh_tot_0, dvhdv_tot_0, dv0, &
-                         dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                         j, ish, ieh, do_I, por_face_areaV)
-
-  !   Determine the southerly- and northerly- fluxes.  Choose a sufficiently
-  ! negative velocity correction for the northerly-flux, and a sufficiently
-  ! positive correction for the southerly-flux.
-  domore = .false.
-  do i=ish,ieh ; if (do_I(i)) then
-    domore = .true.
-    dv_CFL(i) = (CFL_min * Idt) * G%dyCv(i,J)
-    dvR(i) = min(0.0,dv0(i) - dv_CFL(i))
-    dvL(i) = max(0.0,dv0(i) + dv_CFL(i))
-    FAmt_L(i) = 0.0 ; FAmt_R(i) = 0.0 ; FAmt_0(i) = 0.0
-    vhtot_L(i) = 0.0 ; vhtot_R(i) = 0.0
-  endif ; enddo
-
-  if (.not.domore) then
-    do k=1,nz ; do i=ish,ieh
-      BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
-      BT_cont%vBT_SS(i,J) = 0.0
-      BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
-      BT_cont%vBT_NN(i,J) = 0.0
-    enddo ; enddo
-    return
-  endif
-
-  do k=1,nz ; do i=ish,ieh ; if (do_I(i)) then
-    visc_rem_lim = max(visc_rem(i,k), min_visc_rem*visc_rem_max(i))
-    if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
-      if (v(i,J,k) + dvR(i)*visc_rem_lim > -dv_CFL(i)*visc_rem(i,k)) &
-        dvR(i) = -(v(i,J,k) + dv_CFL(i)*visc_rem(i,k)) / visc_rem_lim
-      if (v(i,J,k) + dvL(i)*visc_rem_lim < dv_CFL(i)*visc_rem(i,k)) &
-        dvL(i) = -(v(i,J,k) - dv_CFL(i)*visc_rem(i,k)) / visc_rem_lim
-    endif
-  endif ; enddo ; enddo
-  do k=1,nz
-    do i=ish,ieh ; if (do_I(i)) then
-      v_L(i) = v(I,j,k) + dvL(i) * visc_rem(i,k)
-      v_R(i) = v(I,j,k) + dvR(i) * visc_rem(i,k)
-      v_0(i) = v(I,j,k) + dv0(i) * visc_rem(i,k)
-    endif ; enddo
-    call merid_flux_layer(v_0, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_0, dvhdv_0, &
-                          visc_rem(:,k), dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k))
-    call merid_flux_layer(v_L, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_L, dvhdv_L, &
-                          visc_rem(:,k), dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k))
-    call merid_flux_layer(v_R, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_R, dvhdv_R, &
-                          visc_rem(:,k), dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k))
-    do i=ish,ieh ; if (do_I(i)) then
-      FAmt_0(i) = FAmt_0(i) + dvhdv_0(i)
-      FAmt_L(i) = FAmt_L(i) + dvhdv_L(i)
-      FAmt_R(i) = FAmt_R(i) + dvhdv_R(i)
-      vhtot_L(i) = vhtot_L(i) + vh_L(i)
-      vhtot_R(i) = vhtot_R(i) + vh_R(i)
-    endif ; enddo
-  enddo
-  do i=ish,ieh ; if (do_I(i)) then
-    FA_0 = FAmt_0(i) ; FA_avg = FAmt_0(i)
-    if ((dvL(i) - dv0(i)) /= 0.0) &
-      FA_avg = vhtot_L(i) / (dvL(i) - dv0(i))
-    if (FA_avg > max(FA_0, FAmt_L(i))) then ; FA_avg = max(FA_0, FAmt_L(i))
-    elseif (FA_avg < min(FA_0, FAmt_L(i))) then ; FA_0 = FA_avg ; endif
-    BT_cont%FA_v_S0(i,J) = FA_0 ; BT_cont%FA_v_SS(i,J) = FAmt_L(i)
-    if (abs(FA_0-FAmt_L(i)) <= 1e-12*FA_0) then ; BT_cont%vBT_SS(i,J) = 0.0 ; else
-      BT_cont%vBT_SS(i,J) = (1.5 * (dvL(i) - dv0(i))) * &
-                   ((FAmt_L(i) - FA_avg) / (FAmt_L(i) - FA_0))
-    endif
-
-    FA_0 = FAmt_0(i) ; FA_avg = FAmt_0(i)
-    if ((dvR(i) - dv0(i)) /= 0.0) &
-      FA_avg = vhtot_R(i) / (dvR(i) - dv0(i))
-    if (FA_avg > max(FA_0, FAmt_R(i))) then ; FA_avg = max(FA_0, FAmt_R(i))
-    elseif (FA_avg < min(FA_0, FAmt_R(i))) then ; FA_0 = FA_avg ; endif
-    BT_cont%FA_v_N0(i,J) = FA_0 ; BT_cont%FA_v_NN(i,J) = FAmt_R(i)
-    if (abs(FAmt_R(i) - FA_0) <= 1e-12*FA_0) then ; BT_cont%vBT_NN(i,J) = 0.0 ; else
-      BT_cont%vBT_NN(i,J) = (1.5 * (dvR(i) - dv0(i))) * &
-                   ((FAmt_R(i) - FA_avg) / (FAmt_R(i) - FA_0))
-    endif
-  else
-    BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
-    BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
-    BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
-  endif ; enddo
 
 end subroutine set_merid_BT_cont
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -165,12 +165,13 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   ! problems with hin
   !$omp target enter data &
   !$omp   map(to: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
-  !$omp       G%mask2dT, G%dx_Cv, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h, CS, US, OBC, pbv, &
-  !$omp       pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, BT_cont) &
+  !$omp     G%mask2dT, G%dx_Cv, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h, CS, US, OBC, pbv, &
+  !$omp     pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, BT_cont, &
+  !$omp     hin) &
   !$omp   map(alloc: h_W, h_E, h_S, h_N, uh, vh, u_cor, v_cor, du_cor, dv_cor, BT_cont%FA_u_E0, &
-  !$omp       BT_cont%FA_u_W0, BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, &
-  !$omp       BT_cont%FA_v_NN, BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, &
-  !$omp       BT_cont%vBT_SS, BT_cont%h_u, BT_cont%h_V, LB)
+  !$omp     BT_cont%FA_u_W0, BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, &
+  !$omp     BT_cont%FA_v_NN, BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, &
+  !$omp     BT_cont%vBT_SS, BT_cont%h_u, BT_cont%h_V, LB)
 
   if (x_first) then
     !  First advect zonally, with loop bounds that accomodate the subsequent meridional advection.
@@ -218,13 +219,13 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
   !$omp target exit data &
   !$omp   map(from: uh, h, vh, u_cor, v_cor, du_cor, dv_cor, BT_cont%FA_u_E0, BT_cont%FA_u_W0, &
-  !$omp       BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, BT_cont%FA_v_NN, &
-  !$omp       BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, BT_cont%vBT_SS, &
-  !$omp       BT_cont%h_u, BT_cont%h_V) &
+  !$omp     BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, BT_cont%FA_v_NN, &
+  !$omp     BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, BT_cont%vBT_SS, &
+  !$omp     BT_cont%h_u, BT_cont%h_V) &
   !$omp   map(release: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
-  !$omp       G%mask2dT, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h_W, h_E, h_S, h_N, CS, US, &
-  !$omp       OBC, pbv, pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, &
-  !$omp       LB)
+  !$omp     G%mask2dT, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h_W, h_E, h_S, h_N, CS, US, &
+  !$omp     OBC, pbv, pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, &
+  !$omp     LB, hin)
 
 end subroutine continuity_PPM
 
@@ -635,7 +636,6 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   if (CS%aggress_adjust) CFL_dt = I_dt
 
   !$omp target enter data &
-  !$omp   map(to: h_in) &
   !$omp   map(alloc: visc_rem_u_tmp, &
   !$omp       duhdu, du, du_min_CFL, du_max_CFL, duhdu_tot_0, uh_tot_0, visc_rem_max)
 
@@ -782,7 +782,7 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
                                    uh, u_cor, du_cor, BT_cont, dt, G, GV, US, CS, OBC, LB)
 
   !$omp target exit data &
-  !$omp   map(release: visc_rem_u_tmp, h_in, duhdu, du, &
+  !$omp   map(release: visc_rem_u_tmp, duhdu, du, &
   !$omp       du_min_CFL, du_max_CFL, duhdu_tot_0, uh_tot_0, visc_rem_max)
 
   call cpu_clock_end(id_clock_correct)
@@ -1727,7 +1727,6 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   if (CS%aggress_adjust) CFL_dt = I_dt
 
   !$omp target enter data &
-  !$omp   map(to: h_in) &
   !$omp   map(alloc: dvhdv, dv, dv_min_CFL, dv_max_CFL, dvhdv_tot_0, vh_tot_0, visc_rem_max, &
   !$omp     visc_rem_v_tmp)
 
@@ -1875,7 +1874,7 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
                                    vh, v_cor, dv_cor, BT_cont, dt, G, GV, US, CS, OBC, LB)
 
   !$omp target exit data &
-  !$omp   map(release: h_in, dvhdv, dv, dv_min_CFL, dv_max_CFL, dvhdv_tot_0, vh_tot_0, &
+  !$omp   map(release: dvhdv, dv, dv_min_CFL, dv_max_CFL, dvhdv_tot_0, vh_tot_0, &
   !$omp     visc_rem_max, visc_rem_v_tmp)
 
   call cpu_clock_end(id_clock_correct)
@@ -2682,9 +2681,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, sim
     call MOM_error(FATAL,mesg)
   endif
 
-  !$omp target enter data &
-  !$omp   map(to: h_in) &
-  !$omp   map(alloc: slp)
+  !$omp target enter data map(alloc: slp)
 
   if (simple_2nd) then
     ! untested
@@ -2769,8 +2766,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, sim
     call PPM_limit_pos(h_in, h_W, h_E, h_min, G, GV, isl, iel, jsl, jel, nz)
   endif
 
-  !$omp target exit data &
-  !$omp   map(release: h_in, slp)
+  !$omp target exit data map(release: slp)
 
 end subroutine PPM_reconstruction_x
 
@@ -2828,9 +2824,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, sim
     call MOM_error(FATAL,mesg)
   endif
 
-  !$omp target enter data &
-  !$omp   map(to: h_in) &
-  !$omp   map(alloc: slp)
+  !$omp target enter data map(alloc: slp)
 
   if (simple_2nd) then
     ! untested
@@ -2913,8 +2907,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, sim
     call PPM_limit_pos(h_in, h_S, h_N, h_min, G, GV, isl, iel, jsl, jel, nz)
   endif
 
-  !$omp target exit data &
-  !$omp   map(release: h_in, slp)
+  !$omp target exit data map(release: slp)
 
 end subroutine PPM_reconstruction_y
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -160,9 +160,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
       "MOM_continuity_PPM: Either both visc_rem_u and visc_rem_v or neither"// &
       " one must be present in call to continuity_PPM.")
 
-  !$omp target enter data &
-  !$omp   map(to: h) &
-  !$omp   map(alloc: h_W, h_E, h_S, h_N)
+  !$omp target enter data map(alloc: h_W, h_E, h_S, h_N)
 
   if (x_first) then
     !  First advect zonally, with loop bounds that accomodate the subsequent meridional advection.
@@ -197,9 +195,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
     call continuity_zonal_convergence(h, uh, dt, G, GV, LB, hmin=h_min)
   endif
 
-  !$omp target exit data &
-  !$omp   map(from: h) &
-  !$omp   map(delete: h_W, h_E, h_S, h_N)
+  !$omp target exit data map(delete: h_W, h_E, h_S, h_N)
 
 end subroutine continuity_PPM
 
@@ -3066,7 +3062,7 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS)
                  "solver for use as the weights in the barotropic solver. "//&
                  "Otherwise use the transport averaged areas.", default=.true.)
   CS%diag => diag
-  !$omp target enter data map(to: CS)
+  !$omp target update to(CS)
 
   id_clock_reconstruct = cpu_clock_id('(Ocean continuity reconstruction)', grain=CLOCK_ROUTINE)
   id_clock_update = cpu_clock_id('(Ocean continuity update)', grain=CLOCK_ROUTINE)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1302,7 +1302,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
                                                  !! faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
   type(ocean_OBC_type),             optional, pointer       :: OBC !< Open boundaries control structure.
   ! Local variables
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
+  real, dimension(SZIB_(G),SZK_(GV)) :: &
     uh_aux         ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
   real :: &
     duhdu, &       ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
@@ -1336,16 +1336,15 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
 
   ! NVIDIA needs private arrays to be alloc'ed to prevent data transfers.
   ! GCC doesn't understand map(alloc: ...) for variables also marked private
-  !$omp target enter data map(alloc: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best)
+  !$omp target enter data map(alloc: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, uh_aux)
 
   ! NVIDIA do concurrent doesn't work with private arrays (private scalars OK)
-  !$omp target loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I) &
-  !$omp   map(alloc: uh_aux)
+  !$omp target loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I, uh_aux)
   do j=jsh,jeh
 
     if (present(uh_3d)) then
       do concurrent (k=1:nz, I=ish-1:ieh)
-        uh_aux(I,j,k) = uh_3d(I,j,k)
+        uh_aux(I,k) = uh_3d(I,j,k)
       enddo
     endif
 
@@ -1414,16 +1413,16 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
         do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I))
           u_new = u(I,j,k) + du(I,j) * visc_rem(I,j,k)
           call flux_elem(u_new, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), &
-                         h_E(I+1,j,k), uh_aux(I,j,k), duhdu, visc_rem(I,j,k), G%dy_Cu(I,j), &
+                         h_E(I+1,j,k), uh_aux(I,k), duhdu, visc_rem(I,j,k), G%dy_Cu(I,j), &
                          G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, US, &
                          CS%vol_CFL, por_face_areaU(I,j,k))
           ! Below if statement looks expensive in profiling results, but I believe it's
           ! masking the expensive update of uh_err beneath
           if (local_OBC) &
-            call flux_elem_OBC(u_new, h_in(I,j,k), h_in(I+1,j,k), uh_aux(I,j,k), duhdu, &
+            call flux_elem_OBC(u_new, h_in(I,j,k), h_in(I+1,j,k), uh_aux(I,k), duhdu, &
                                visc_rem(I,j,k), G, GV, por_face_areaU(I,j,k), G%dy_Cu(I,j), OBC, &
                                OBC%segnum_u(I,j))
-          uh_err(I) = uh_err(I) + uh_aux(I,j,k)
+          uh_err(I) = uh_err(I) + uh_aux(I,k)
           duhdu_tot(I) = duhdu_tot(I) + duhdu
         enddo ; enddo
         do concurrent (I=ish-1:ieh)
@@ -1434,7 +1433,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
     enddo ! itt-loop
     if (present(uh_3d)) then
       do concurrent (k=1:nz, I=ish-1:ieh)
-        uh_3d(I,j,k) = uh_aux(I,j,k)
+        uh_3d(I,j,k) = uh_aux(I,k)
       enddo
     endif
   enddo ! j-loop
@@ -1442,7 +1441,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   ! so-be-it, or else use a final upwind correction?
   ! This never seems to happen with 20 iterations as max_itt.
 
-  !$omp target exit data map(release: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best)
+  !$omp target exit data map(release: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, uh_aux)
 
 end subroutine zonal_flux_adjust
 
@@ -2292,7 +2291,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
                              !! faces = v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
   type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
   ! Local variables
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &
+  real, dimension(SZI_(G),SZK_(GV)) :: &
     vh_aux     ! An auxiliary meridional volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
   real :: &
     dvhdv, &   ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
@@ -2326,15 +2325,15 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
 
   ! NVIDIA needs private arrays to be alloc'ed to prevent data transfers.
   ! GCC doesn't understand map(alloc: ...) for variables also marked private
-  !$omp target enter data map(alloc: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best)
+  !$omp target enter data map(alloc: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best, vh_aux)
 
-  !$omp target loop private(vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I) &
-  !$omp   map(alloc: vh_aux)
+  !$omp target loop &
+  !$omp   private(j, k, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I, vh_aux)
   do J=jsh-1,jeh
 
     if (present(vh_3d)) then
       do concurrent (k=1:nz, i=ish:ieh)
-        vh_aux(i,j,k) = vh_3d(i,J,k)
+        vh_aux(i,k) = vh_3d(i,J,k)
       enddo
     endif
 
@@ -2406,14 +2405,14 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
         do k=1,nz ; do concurrent (i=ish:ieh, do_I(i))
           v_new = v(i,J,k) + dv(i,j) * visc_rem(i,j,k)
           call flux_elem(v_new, h_in(i,J,k), h_in(i,J+1,k), h_S(i,J,k), h_S(i,J+1,k), &
-                         h_N(i,J,k), h_N(i,J+1,k), vh_aux(i,J,k), dvhdv, visc_rem(i,J,k), &
+                         h_N(i,J,k), h_N(i,J+1,k), vh_aux(i,k), dvhdv, visc_rem(i,J,k), &
                          G%dx_Cv(i,J), G%IareaT(i,J), G%IareaT(i,J+1), G%idyT(i,J), G%IdyT(i,J+1), &
                          dt, G, GV, US, CS%vol_CFL, por_face_areaV(i,J,k))
           if (local_OBC) &
-            call flux_elem_OBC(v_new, h_in(i,J,k), h_in(i,J+1,k), vh_aux(i,J,k), &
+            call flux_elem_OBC(v_new, h_in(i,J,k), h_in(i,J+1,k), vh_aux(i,k), &
                                dvhdv, visc_rem(i,J,k), G, GV, por_face_areaV(i,J,k), &
                                G%dx_Cv(i,J), OBC, OBC%segnum_v(i,J))
-          vh_err(i) = vh_err(i) + vh_aux(i,J,k)
+          vh_err(i) = vh_err(i) + vh_aux(i,k)
           dvhdv_tot(i) = dvhdv_tot(i) + dvhdv
         enddo ; enddo
         do concurrent (i=ish:ieh, do_I(i))
@@ -2428,12 +2427,12 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
 
     if (present(vh_3d)) then
       do concurrent (k=1:nz, i=ish:ieh)
-        vh_3d(i,J,k) = vh_aux(i,j,k)
+        vh_3d(i,J,k) = vh_aux(i,k)
       enddo
     endif
   enddo ! j-loop
 
-  !$omp target exit data map(release: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best)
+  !$omp target exit data map(release: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best, vh_aux)
 
 end subroutine meridional_flux_adjust
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1525,12 +1525,8 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
   nz = GV%ke ; Idt = 1.0 / dt
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
-  !$omp target loop private(I, k, duL, duR, du_CFL, FAmt_L, FAmt_R, FAmt_0, uhtot_L, uhtot_R) &
-  !$omp   map(to: u, h_W, h_E, h_in, uh_tot_0, duhdu_tot_0, G, G%IareaT, G%dy_Cu, G%IdxT, G%dxCu, &
-  !$omp     BT_cont, du_max_CFL, du_min_CFL, CS, visc_rem, visc_rem_max, do_I, por_face_areaU, du0) &
-  !$omp   map(alloc: duL, duR, du_CFL, FAmt_L, FAmT_R, FAmt_0, uhtot_L, uhtot_R) &
-  !$omp   map(tofrom: BT_cont%FA_u_W0, BT_cont%FA_u_WW, BT_cont%FA_u_E0, BT_cont%FA_u_EE, &
-  !$omp     BT_cont%uBT_WW, BT_cont%uBT_EE)
+  !$omp target loop private(duL, duR, du_CFL, FAmt_L, FAmt_R, FAmt_0, uhtot_L, uhtot_R) &
+  !$omp   map(alloc: duL, duR, du_CFL, FAmt_L, FAmT_R, FAmt_0, uhtot_L, uhtot_R)
   do j=jsh,jeh
     ! Determine the westerly- and easterly- fluxes.  Choose a sufficiently
     ! negative velocity correction for the easterly-flux, and a sufficiently

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1318,8 +1318,8 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   ! Local variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
     uh_aux, &      ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
-    duhdu, &       ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
-    u_new          ! The velocity with the correction added [L T-1 ~> m s-1].
+    duhdu          ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
+  real :: u_new          ! The velocity with the correction added [L T-1 ~> m s-1].
   real, dimension(SZIB_(G)) :: &
     uh_err, &      ! Difference between uhbt and the summed uh [H L2 T-1 ~> m3 s-1 or kg s-1].
     uh_err_best, & ! The smallest value of uh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
@@ -1424,15 +1424,15 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
           if (use_uhbt) uh_err(I) = -uhbt(I,j)
         enddo
         do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I))
-          u_new(I,j,k) = u(I,j,k) + du(I,j) * visc_rem(I,j,k)
-          call flux_elem(u_new(I,j,k), h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), &
+          u_new = u(I,j,k) + du(I,j) * visc_rem(I,j,k)
+          call flux_elem(u_new, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), &
                          h_E(I+1,j,k), uh_aux(I,j,k), duhdu(I,j,k), visc_rem(I,j,k), G%dy_Cu(I,j), &
                          G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, US, &
                          CS%vol_CFL, por_face_areaU(I,j,k))
           ! Below if statement looks expensive in profiling results, but I believe it's
           ! masking the expensive update of uh_err beneath
           if (local_OBC) &
-            call flux_elem_OBC(u_new(I,j,k), h_in(I,j,k), h_in(I+1,j,k), uh_aux(I,j,k), duhdu(I,j,k), &
+            call flux_elem_OBC(u_new, h_in(I,j,k), h_in(I+1,j,k), uh_aux(I,j,k), duhdu(I,j,k), &
                                visc_rem(I,j,k), G, GV, por_face_areaU(I,j,k), G%dy_Cu(I,j), OBC, &
                                OBC%segnum_u(I,j))
           uh_err(I) = uh_err(I) + uh_aux(I,j,k)
@@ -2305,8 +2305,8 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
   ! Local variables
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &
     vh_aux, &  ! An auxiliary meridional volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
-    dvhdv, &   ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
-    v_new      ! The velocity with the correction added [L T-1 ~> m s-1].
+    dvhdv   ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
+  real :: v_new      ! The velocity with the correction added [L T-1 ~> m s-1].
   real, dimension(SZI_(G)) :: &
     vh_err, &  ! Difference between vhbt and the summed vh [H L2 T-1 ~> m3 s-1 or kg s-1].
     vh_err_best, & ! The smallest value of vh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
@@ -2414,13 +2414,13 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
           if (use_vhbt) vh_err(i) = -vhbt(i,J)
         enddo
         do k=1,nz ; do concurrent (i=ish:ieh, do_I(i))
-          v_new(i,J,k) = v(i,J,k) + dv(i,j) * visc_rem(i,j,k)
-          call flux_elem(v_new(i,J,k), h_in(i,J,k), h_in(i,J+1,k), h_S(i,J,k), h_S(i,J+1,k), &
+          v_new = v(i,J,k) + dv(i,j) * visc_rem(i,j,k)
+          call flux_elem(v_new, h_in(i,J,k), h_in(i,J+1,k), h_S(i,J,k), h_S(i,J+1,k), &
                          h_N(i,J,k), h_N(i,J+1,k), vh_aux(i,J,k), dvhdv(i,J,k), visc_rem(i,J,k), &
                          G%dx_Cv(i,J), G%IareaT(i,J), G%IareaT(i,J+1), G%idyT(i,J), G%IdyT(i,J+1), &
                          dt, G, GV, US, CS%vol_CFL, por_face_areaV(i,J,k))
           if (local_OBC) &
-            call flux_elem_OBC(v_new(i,J,k), h_in(i,J,k), h_in(i,J+1,k), vh_aux(i,J,k), &
+            call flux_elem_OBC(v_new, h_in(i,J,k), h_in(i,J+1,k), vh_aux(i,J,k), &
                                dvhdv(i,J,k), visc_rem(i,J,k), G, GV, por_face_areaV(i,J,k), &
                                G%dx_Cv(i,J), OBC, OBC%segnum_v(i,J))
           vh_err(i) = vh_err(i) + vh_aux(i,J,k)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -161,19 +161,12 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
       " one must be present in call to continuity_PPM.")
 
   !$omp target enter data &
-  !$omp   map(to: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
-  !$omp     G%mask2dT, G%dx_Cv, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h, CS, US, OBC, pbv, &
-  !$omp     pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, BT_cont, &
-  !$omp     hin, dt) &
-  !$omp   map(alloc: h_W, h_E, h_S, h_N, uh, vh, u_cor, v_cor, du_cor, dv_cor, BT_cont%FA_u_E0, &
-  !$omp     BT_cont%FA_u_W0, BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, &
-  !$omp     BT_cont%FA_v_NN, BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, &
-  !$omp     BT_cont%vBT_SS, BT_cont%h_u, BT_cont%h_V, LB)
+  !$omp   map(to: h) &
+  !$omp   map(alloc: h_W, h_E, h_S, h_N)
 
   if (x_first) then
     !  First advect zonally, with loop bounds that accomodate the subsequent meridional advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.true.)
-    !$omp target update to(LB)
     call zonal_edge_thickness(hin, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, hin, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
                          LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
@@ -183,7 +176,6 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
     !  Now advect meridionally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
-    !$omp target update to(LB)
     call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
                               LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
@@ -192,7 +184,6 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   else  ! .not. x_first
     !  First advect meridionally, with loop bounds that accomodate the subsequent zonal advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.true., j_stencil=.false.)
-    !$omp target update to(LB)
     call meridional_edge_thickness(hin, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, hin, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
                               LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
@@ -200,7 +191,6 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
     !  Now advect zonally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
-    !$omp target update to(LB)
     call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
                          LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
@@ -208,14 +198,8 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   endif
 
   !$omp target exit data &
-  !$omp   map(from: uh, h, vh, u_cor, v_cor, du_cor, dv_cor, BT_cont%FA_u_E0, BT_cont%FA_u_W0, &
-  !$omp     BT_cont%FA_v_N0, BT_cont%FA_v_S0, BT_cont%FA_u_EE, BT_cont%FA_u_WW, BT_cont%FA_v_NN, &
-  !$omp     BT_cont%FA_v_SS, BT_cont%uBT_EE, BT_cont%uBT_WW, BT_cont%vBT_NN, BT_cont%vBT_SS, &
-  !$omp     BT_cont%h_u, BT_cont%h_V) &
-  !$omp   map(release: G, G%dy_Cu, G%IareaT, G%IdxT, G%areaT, G%dxT, G%mask2dCu, G%dxCu, G%IareaT, &
-  !$omp     G%mask2dT, G%dyCv, G%dyT, G%IdyT, G%mask2dCv, GV, u, v, h_W, h_E, h_S, h_N, CS, US, &
-  !$omp     OBC, pbv, pbv%por_face_areaU, pbv%por_face_areaV, uhbt, vhbt, visc_rem_u, visc_rem_v, &
-  !$omp     LB, hin, dt)
+  !$omp   map(from: h) &
+  !$omp   map(delete: h_W, h_E, h_S, h_N)
 
 end subroutine continuity_PPM
 
@@ -425,19 +409,21 @@ subroutine continuity_merdional_convergence(h, vh, dt, G, GV, LB, hin, hmin)
   real,              optional, intent(in)    :: hmin !< The minimum layer thickness [H ~> m or kg m-2]
 
   real :: h_min  ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
-  integer :: i, j, k
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz
 
   call cpu_clock_begin(id_clock_update)
+
+  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
 
   h_min = 0.0 ; if (present(hmin)) h_min = hmin
 
   if (present(hin)) then
     ! untested
-    do concurrent (k=1:GV%ke, j=LB%jsh:LB%jeh, i=LB%ish:LB%ieh)
+    do concurrent (k=1:nz, j=jsh:jeh, i=ish:ieh)
       h(i,j,k) = max( hin(i,j,k) - dt * G%IareaT(i,j) * (vh(i,J,k) - vh(i,J-1,k)), h_min )
     enddo
   else
-    do concurrent (k=1:GV%ke, j=LB%jsh:LB%jeh, i=LB%ish:LB%ieh)
+    do concurrent (k=1:nz, j=jsh:jeh, i=ish:ieh)
       h(i,j,k) = max( h(i,j,k) - dt * G%IareaT(i,j) * (vh(i,J,k) - vh(i,J-1,k)), h_min )
     enddo
   endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1334,9 +1334,13 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
 
   tol_vel = CS%tol_vel
 
+  ! NVIDIA needs private arrays to be alloc'ed to prevent data transfers.
+  ! GCC doesn't understand map(alloc: ...) for variables also marked private
+  !$omp target enter data map(alloc: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best)
+
   ! NVIDIA do concurrent doesn't work with private arrays (private scalars OK)
   !$omp target loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I) &
-  !$omp   map(alloc: uh_aux, do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, u_new)
+  !$omp   map(alloc: uh_aux)
   do j=jsh,jeh
 
     if (present(uh_3d)) then
@@ -1438,6 +1442,8 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   ! so-be-it, or else use a final upwind correction?
   ! This never seems to happen with 20 iterations as max_itt.
 
+  !$omp target exit data map(release: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best)
+
 end subroutine zonal_flux_adjust
 
 
@@ -1526,8 +1532,9 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
   nz = GV%ke ; Idt = 1.0 / dt
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
-  !$omp target loop private(duL, duR, du_CFL, FAmt_L, FAmt_R, FAmt_0, uhtot_L, uhtot_R) &
-  !$omp   map(alloc: duL, duR, du_CFL, FAmt_L, FAmT_R, FAmt_0, uhtot_L, uhtot_R)
+  !$omp target enter data map(alloc: duL, duR, du_CFL, FAmt_L, FAmT_R, FAmt_0, uhtot_L, uhtot_R)
+
+  !$omp target loop private(duL, duR, du_CFL, FAmt_L, FAmt_R, FAmt_0, uhtot_L, uhtot_R)
   do j=jsh,jeh
     ! Determine the westerly- and easterly- fluxes.  Choose a sufficiently
     ! negative velocity correction for the easterly-flux, and a sufficiently
@@ -1605,6 +1612,8 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
       endif
     enddo
   enddo
+
+  !$omp target exit data map(release: duL, duR, du_CFL, FAmt_L, FAmT_R, FAmt_0, uhtot_L, uhtot_R)
 
 end subroutine set_zonal_BT_cont
 
@@ -2315,8 +2324,12 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
 
   tol_vel = CS%tol_vel
 
+  ! NVIDIA needs private arrays to be alloc'ed to prevent data transfers.
+  ! GCC doesn't understand map(alloc: ...) for variables also marked private
+  !$omp target enter data map(alloc: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best)
+
   !$omp target loop private(vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I) &
-  !$omp   map(alloc: vh_aux, v_new, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I)
+  !$omp   map(alloc: vh_aux)
   do J=jsh-1,jeh
 
     if (present(vh_3d)) then
@@ -2420,6 +2433,8 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
     endif
   enddo ! j-loop
 
+  !$omp target exit data map(release: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best)
+
 end subroutine meridional_flux_adjust
 
 
@@ -2501,8 +2516,9 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
   nz = GV%ke ; Idt = 1.0 / dt
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
-  !$omp target loop private(dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R) &
-  !$omp   map(alloc: dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
+  !$omp target enter data map(alloc: dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
+
+  !$omp target loop private(dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
   do J=jsh-1,jeh
     ! Determine the southerly- and northerly- fluxes. Choose a sufficiently
     ! negative velocity correction for the northerly-flux, and a sufficiently
@@ -2580,6 +2596,8 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
       endif
     enddo
   enddo
+
+  !$omp target exit data map(release: dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
 
 end subroutine set_merid_BT_cont
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1303,9 +1303,10 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   type(ocean_OBC_type),             optional, pointer       :: OBC !< Open boundaries control structure.
   ! Local variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
-    uh_aux, &      ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
-    duhdu          ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
-  real :: u_new          ! The velocity with the correction added [L T-1 ~> m s-1].
+    uh_aux         ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real :: &
+    duhdu, &       ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
+    u_new          ! The velocity with the correction added [L T-1 ~> m s-1].
   real, dimension(SZIB_(G)) :: &
     uh_err, &      ! Difference between uhbt and the summed uh [H L2 T-1 ~> m3 s-1 or kg s-1].
     uh_err_best, & ! The smallest value of uh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
@@ -1335,7 +1336,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
 
   ! NVIDIA do concurrent doesn't work with private arrays (private scalars OK)
   !$omp target loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I) &
-  !$omp   map(alloc: uh_aux, duhdu, do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, u_new)
+  !$omp   map(alloc: uh_aux, do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, u_new)
   do j=jsh,jeh
 
     if (present(uh_3d)) then
@@ -1409,17 +1410,17 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
         do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I))
           u_new = u(I,j,k) + du(I,j) * visc_rem(I,j,k)
           call flux_elem(u_new, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), &
-                         h_E(I+1,j,k), uh_aux(I,j,k), duhdu(I,j,k), visc_rem(I,j,k), G%dy_Cu(I,j), &
+                         h_E(I+1,j,k), uh_aux(I,j,k), duhdu, visc_rem(I,j,k), G%dy_Cu(I,j), &
                          G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(i+1,j), dt, G, GV, US, &
                          CS%vol_CFL, por_face_areaU(I,j,k))
           ! Below if statement looks expensive in profiling results, but I believe it's
           ! masking the expensive update of uh_err beneath
           if (local_OBC) &
-            call flux_elem_OBC(u_new, h_in(I,j,k), h_in(I+1,j,k), uh_aux(I,j,k), duhdu(I,j,k), &
+            call flux_elem_OBC(u_new, h_in(I,j,k), h_in(I+1,j,k), uh_aux(I,j,k), duhdu, &
                                visc_rem(I,j,k), G, GV, por_face_areaU(I,j,k), G%dy_Cu(I,j), OBC, &
                                OBC%segnum_u(I,j))
           uh_err(I) = uh_err(I) + uh_aux(I,j,k)
-          duhdu_tot(I) = duhdu_tot(I) + duhdu(I,j,k)
+          duhdu_tot(I) = duhdu_tot(I) + duhdu
         enddo ; enddo
         do concurrent (I=ish-1:ieh)
           uh_err_best(I) = min(uh_err_best(I), abs(uh_err(I)))
@@ -2283,9 +2284,10 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
   type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
   ! Local variables
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &
-    vh_aux, &  ! An auxiliary meridional volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
-    dvhdv   ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
-  real :: v_new      ! The velocity with the correction added [L T-1 ~> m s-1].
+    vh_aux     ! An auxiliary meridional volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real :: &
+    dvhdv, &   ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
+    v_new      ! The velocity with the correction added [L T-1 ~> m s-1].
   real, dimension(SZI_(G)) :: &
     vh_err, &  ! Difference between vhbt and the summed vh [H L2 T-1 ~> m3 s-1 or kg s-1].
     vh_err_best, & ! The smallest value of vh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
@@ -2314,7 +2316,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
   tol_vel = CS%tol_vel
 
   !$omp target loop private(vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I) &
-  !$omp   map(alloc: vh_aux, dvhdv, v_new, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I)
+  !$omp   map(alloc: vh_aux, v_new, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I)
   do J=jsh-1,jeh
 
     if (present(vh_3d)) then
@@ -2391,15 +2393,15 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
         do k=1,nz ; do concurrent (i=ish:ieh, do_I(i))
           v_new = v(i,J,k) + dv(i,j) * visc_rem(i,j,k)
           call flux_elem(v_new, h_in(i,J,k), h_in(i,J+1,k), h_S(i,J,k), h_S(i,J+1,k), &
-                         h_N(i,J,k), h_N(i,J+1,k), vh_aux(i,J,k), dvhdv(i,J,k), visc_rem(i,J,k), &
+                         h_N(i,J,k), h_N(i,J+1,k), vh_aux(i,J,k), dvhdv, visc_rem(i,J,k), &
                          G%dx_Cv(i,J), G%IareaT(i,J), G%IareaT(i,J+1), G%idyT(i,J), G%IdyT(i,J+1), &
                          dt, G, GV, US, CS%vol_CFL, por_face_areaV(i,J,k))
           if (local_OBC) &
             call flux_elem_OBC(v_new, h_in(i,J,k), h_in(i,J+1,k), vh_aux(i,J,k), &
-                               dvhdv(i,J,k), visc_rem(i,J,k), G, GV, por_face_areaV(i,J,k), &
+                               dvhdv, visc_rem(i,J,k), G, GV, por_face_areaV(i,J,k), &
                                G%dx_Cv(i,J), OBC, OBC%segnum_v(i,J))
           vh_err(i) = vh_err(i) + vh_aux(i,J,k)
-          dvhdv_tot(i) = dvhdv_tot(i) + dvhdv(i,J,k)
+          dvhdv_tot(i) = dvhdv_tot(i) + dvhdv
         enddo ; enddo
         do concurrent (i=ish:ieh, do_I(i))
           vh_err_best(i) = min(vh_err_best(i), abs(vh_err(i)))

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2313,12 +2313,8 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
 
   tol_vel = CS%tol_vel
 
-  !$omp target loop private(i, k, itt, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I) &
-  !$omp   map(to: G, G%IareaT, G%IdyT, G%dx_Cv, G%IdyT, v, h_in, h_S, h_N, visc_rem, vhbt, &
-  !$omp     dv_max_CFL, dv_min_CFL, vh_tot_0, dvhdv_tot_0, CS, do_I_in, por_face_areaV) &
-  !$omp   map(alloc: vh_aux, dvhdv, v_new, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I) &
-  !$omp   map(tofrom: vh_3d) &
-  !$omp   map(from: dv)
+  !$omp target loop private(vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I) &
+  !$omp   map(alloc: vh_aux, dvhdv, v_new, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I)
   do J=jsh-1,jeh
 
     if (present(vh_3d)) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1339,7 +1339,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   !$omp target enter data map(alloc: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, uh_aux)
 
   ! NVIDIA do concurrent doesn't work with private arrays (private scalars OK)
-  !$omp target loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I, uh_aux)
+  !$omp target teams loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I, uh_aux)
   do j=jsh,jeh
 
     if (present(uh_3d)) then
@@ -1533,7 +1533,7 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
 
   !$omp target enter data map(alloc: duL, duR, du_CFL, FAmt_L, FAmT_R, FAmt_0, uhtot_L, uhtot_R)
 
-  !$omp target loop private(duL, duR, du_CFL, FAmt_L, FAmt_R, FAmt_0, uhtot_L, uhtot_R)
+  !$omp target teams loop private(duL, duR, du_CFL, FAmt_L, FAmt_R, FAmt_0, uhtot_L, uhtot_R)
   do j=jsh,jeh
     ! Determine the westerly- and easterly- fluxes.  Choose a sufficiently
     ! negative velocity correction for the easterly-flux, and a sufficiently
@@ -2327,7 +2327,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
   ! GCC doesn't understand map(alloc: ...) for variables also marked private
   !$omp target enter data map(alloc: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best, vh_aux)
 
-  !$omp target loop &
+  !$omp target teams loop &
   !$omp   private(j, k, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I, vh_aux)
   do J=jsh-1,jeh
 
@@ -2517,7 +2517,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
 
   !$omp target enter data map(alloc: dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
 
-  !$omp target loop private(dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
+  !$omp target teams loop private(dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
   do J=jsh-1,jeh
     ! Determine the southerly- and northerly- fluxes. Choose a sufficiently
     ! negative velocity correction for the northerly-flux, and a sufficiently

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2499,12 +2499,8 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
   nz = GV%ke ; Idt = 1.0 / dt
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
-  !$omp target loop private(i, k, dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R) &
-  !$omp   map(to: G, G%dx_Cv, G%dyCv, G%IdyT, v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
-  !$omp     dv_max_CFL, dv_min_CFL, CS, visc_rem, visc_rem_max, do_I, por_face_areaV, dv0) &
-  !$omp   map(alloc: dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R) &
-  !$omp   map(from: BT_cont%FA_v_S0, BT_cont%FA_v_SS, BT_cont%vBT_SS, BT_cont%FA_v_N0, &
-  !$omp     BT_cont%FA_v_NN, BT_cont%vBT_NN)
+  !$omp target loop private(dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R) &
+  !$omp   map(alloc: dvL, dvR, dv_CFL, FAmt_L, FAmt_R, FAmt_0, vhtot_L, vhtot_R)
   do J=jsh-1,jeh
     ! Determine the southerly- and northerly- fluxes. Choose a sufficiently
     ! negative velocity correction for the northerly-flux, and a sufficiently

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1764,9 +1764,9 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     if (present(vhbt) .or. set_BT_cont) then
       if (use_visc_rem .and. CS%use_visc_rem_max) then
         do concurrent (i=ish:ieh)
-          visc_rem_max(i,J) = visc_rem_v(i,J,1)
+          visc_rem_max(i,J) = 0.0
         enddo
-        do k=2,nz ; do concurrent (i=ish:ieh)
+        do k=1,nz ; do concurrent (i=ish:ieh)
           visc_rem_max(i,J) = max(visc_rem_max(i,J), visc_rem_v_tmp(i,J,k))
         enddo ; enddo
       else
@@ -1948,14 +1948,14 @@ subroutine present_vhbt_or_set_BT_cont(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0,
         l_seg = abs(OBC%segnum_v(i,J))
 
         ! Avoid reconciling barotropic/baroclinic transports if transport is specified
-        simple_OBC_pt(i,j) = .false.
-        if (l_seg /= 0) simple_OBC_pt(i,j) = OBC%segment(l_seg)%specified
-        do_I(i,j) = .not.simple_OBC_pt(i,j)
-        any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(i,j)
+        simple_OBC_pt(i,J) = .false.
+        if (l_seg /= 0) simple_OBC_pt(i,J) = OBC%segment(l_seg)%specified
+        do_I(i,J) = .not.simple_OBC_pt(i,J)
+        any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(i,J)
       enddo
     else
-      do concurrent (j=jsh-1:jeh, i=ish:ieh)
-        do_I(i,j) = .true.
+      do concurrent (J=jsh-1:jeh, i=ish:ieh)
+        do_I(i,J) = .true.
       enddo
     endif ! local_specified_BC .or. local_Flather_OBC
 
@@ -2226,21 +2226,21 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
         if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
           if (present(visc_rem_v)) then
             do concurrent (k=1:nz, i = OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied)
-              h_v(i,J,k) = h(i,j,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
+              h_v(i,J,k) = h(i,J,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
             enddo
           else
             do concurrent (k=1:nz, i = OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied)
-              h_v(i,J,k) = h(i,j,k) * por_face_areaV(i,J,k)
+              h_v(i,J,k) = h(i,J,k) * por_face_areaV(i,J,k)
             enddo
           endif
         else
           if (present(visc_rem_v)) then
             do concurrent (k=1:nz, i = OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied)
-              h_v(i,J,k) = h(i,j+1,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
+              h_v(i,J,k) = h(i,J+1,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
             enddo
           else
             do concurrent (k=1:nz, i = OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied)
-              h_v(i,J,k) = h(i,j+1,k) * por_face_areaV(i,J,k)
+              h_v(i,J,k) = h(i,J+1,k) * por_face_areaV(i,J,k)
             enddo
           endif
         endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -612,8 +612,8 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   if (CS%aggress_adjust) CFL_dt = I_dt
 
   !$omp target enter data &
-  !$omp   map(alloc: visc_rem_u_tmp, &
-  !$omp       duhdu, du, du_min_CFL, du_max_CFL, duhdu_tot_0, uh_tot_0, visc_rem_max)
+  !$omp   map(alloc: visc_rem_u_tmp, duhdu, du, du_min_CFL, du_max_CFL, duhdu_tot_0, uh_tot_0, &
+  !$omp     visc_rem_max)
 
   do concurrent (j=jsh:jeh)
 
@@ -758,8 +758,8 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
                                    uh, u_cor, du_cor, BT_cont, dt, G, GV, US, CS, OBC, LB)
 
   !$omp target exit data &
-  !$omp   map(release: visc_rem_u_tmp, duhdu, du, &
-  !$omp       du_min_CFL, du_max_CFL, duhdu_tot_0, uh_tot_0, visc_rem_max)
+  !$omp   map(release: visc_rem_u_tmp, duhdu, du, du_min_CFL, du_max_CFL, duhdu_tot_0, uh_tot_0, &
+  !$omp     visc_rem_max)
 
   call cpu_clock_end(id_clock_correct)
 
@@ -1334,11 +1334,8 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   tol_vel = CS%tol_vel
 
   ! NVIDIA do concurrent doesn't work with private arrays (private scalars OK)
-  !$omp target loop private(i, k, itt, uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I) &
-  !$omp   map(to: do_I_in, du_max_CFL, du_min_CFL, uh_tot_0, uhbt, duhdu_tot_0, G, G%IareaT, &
-  !$omp     CS, u, visc_rem, h_W, h_E, h_in, G%dy_Cu, G%IdxT, por_face_areaU) &
-  !$omp   map(alloc: uh_aux, duhdu, do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, u_new) &
-  !$omp   map(tofrom: uh_3d, du)
+  !$omp target loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I) &
+  !$omp   map(alloc: uh_aux, duhdu, do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, u_new)
   do j=jsh,jeh
 
     if (present(uh_3d)) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1,3 +1,5 @@
+#include "do_concurrent_compat.h"
+
 !> Solve the layer continuity equation using the PPM method for layer fluxes.
 module MOM_continuity_PPM
 
@@ -1314,7 +1316,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   real :: tol_eta  ! The tolerance for the current iteration [H ~> m or kg m-2].
   real :: tol_vel  ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
   integer :: i, j, k, nz, itt
-  logical :: domore, do_I(SZIB_(G)), local_OBC, use_uhbt
+  logical :: do_I(SZIB_(G)), local_OBC, use_uhbt
   integer, parameter:: max_itts = 20
 
   local_OBC = .false.
@@ -1335,7 +1337,8 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
   !$omp target enter data map(alloc: do_I, du_max, du_min, duhdu_tot, uh_err, uh_err_best, uh_aux)
 
   ! NVIDIA do concurrent doesn't work with private arrays (private scalars OK)
-  !$omp target teams loop private(uh_err, uh_err_best, duhdu_tot, du_min, du_max, do_I, uh_aux)
+  !$omp target teams loop &
+  !$omp   private(uh_aux, do_I, du_max, du_min, uh_err, duhdu_tot, uh_err_best, itt, tol_eta)
   do j=jsh,jeh
 
     if (present(uh_3d)) then
@@ -1361,9 +1364,8 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
         case default ; tol_eta = CS%tol_eta
       end select
 
-      domore = .false.
-      ! *should* need a reduce clause, but nvfortran seems smart enough
-      do concurrent (I=ish-1:ieh, do_I(I))
+      do concurrent (I=ish-1:ieh, do_I(I)) &
+          & DO_LOCALITY(local(ddu, du_prev))
         if (uh_err(I) > 0.0) then ; du_max(I) = du(I,j)
         elseif (uh_err(I) < 0.0) then ; du_min(I) = du(I,j)
         else ; do_I(I) = .false. ; endif
@@ -1388,17 +1390,16 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
               if (du_prev - du_min(I) < 1.0e-15*abs(du(I,j))) do_I(I) = .false.
             endif
           endif
-          if (do_I(I)) domore = .true.
         else
           do_I(I) = .false.
         endif
       enddo
 
-      ! Below conditional compilation is to control whether early exit happens when compiled with
-      ! OpenMP - compiling with OpenMP prevents early exit. Without OpenMP, enables early exit.
-      ! Early exit saves time on CPU, but causes other loops to be serialized on GPU.
+      !! Below conditional compilation is to control whether early exit happens when compiled with
+      !! OpenMP - compiling with OpenMP prevents early exit. Without OpenMP, enables early exit.
+      !! Early exit saves time on CPU, but causes other loops to be serialized on GPU.
       !$ if (.false.) then
-      if (.not.domore) exit
+      if (.not. any(do_I(ish-1:ieh))) exit
       !$ endif
 
       if ((itt < max_itts) .or. present(uh_3d)) then
@@ -1406,7 +1407,7 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uh_tot_0, duhdu_tot_0, &
           uh_err(I) = 0.0 ; duhdu_tot(I) = 0.0
           if (use_uhbt) uh_err(I) = -uhbt(I,j)
         enddo
-        do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I))
+        do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I)) DO_LOCALITY(local(u_new, duhdu))
           u_new = u(I,j,k) + du(I,j) * visc_rem(I,j,k)
           call flux_elem(u_new, h_in(I,j,k), h_in(I+1,j,k), h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), &
                          h_E(I+1,j,k), uh_aux(I,k), duhdu, visc_rem(I,j,k), G%dy_Cu(I,j), &
@@ -1521,7 +1522,6 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
   real :: CFL_min ! A minimal increment in the CFL to try to ensure that the
                   ! flow is truly upwind [nondim]
   real :: Idt     ! The inverse of the time step [T-1 ~> s-1].
-  logical :: domore
   integer :: i, j, k, nz
 
   nz = GV%ke ; Idt = 1.0 / dt
@@ -1542,8 +1542,8 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
       uhtot_L(I) = 0.0 ; uhtot_R(I) = 0.0
     enddo
 
-  ! nvfortran do concurrent bad performance if k is inside
-    do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I,j))
+    ! nvfortran do concurrent bad performance if k is inside
+    do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I,j)) DO_LOCALITY(local(visc_rem_lim))
       visc_rem_lim = max(visc_rem(I,j,k), min_visc_rem*visc_rem_max(I,j))
       if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
         if (u(I,j,k) + duR(I)*visc_rem_lim > -du_CFL(I)*visc_rem(I,j,k)) &
@@ -1553,7 +1553,8 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
       endif
     enddo ; enddo
 
-    do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I,j))
+    do k=1,nz ; do concurrent (I=ish-1:ieh, do_I(I,j)) &
+        & DO_LOCALITY(local(u_0, u_L, u_R, uh_0, uh_L, uh_R, duhdu_0, duhdu_L, duhdu_R))
       u_L = u(I,j,k) + duL(I) * visc_rem(I,j,k)
       u_R = u(I,j,k) + duR(I) * visc_rem(I,j,k)
       u_0 = u(I,j,k) + du0(I,j) * visc_rem(I,j,k)
@@ -1575,7 +1576,8 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, du0, uh_tot_0, duhdu_to
       uhtot_L(I) = uhtot_L(I) + uh_L
       uhtot_R(I) = uhtot_R(I) + uh_R
     enddo ; enddo
-    do concurrent (I=ish-1:ieh)
+
+    do concurrent (I=ish-1:ieh) DO_LOCALITY(local(FA_0, FA_avg))
       if (do_I(I,j)) then
         FA_0 = FAmt_0(I) ; FA_avg = FAmt_0(I)
         if ((duL(I) - du0(I,j)) /= 0.0) &
@@ -2303,7 +2305,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
   real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
   real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
   integer :: i, j, k, nz, itt
-  logical :: domore, do_I(SZI_(G)), local_OBC, use_vhbt
+  logical :: do_I(SZI_(G)), local_OBC, use_vhbt
   integer, parameter :: max_itts = 20
 
   local_OBC = .false.
@@ -2324,7 +2326,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
   !$omp target enter data map(alloc: do_I, dv_max, dv_min, dvhdv_tot, vh_err, vh_err_best, vh_aux)
 
   !$omp target teams loop &
-  !$omp   private(j, k, vh_err, vh_err_best, dvhdv_tot, dv_min, dv_max, do_I, vh_aux)
+  !$omp   private(vh_aux, do_I, dv_max, dv_min, vh_err, dvhdv_tot, vh_err_best, itt, tol_eta)
   do J=jsh-1,jeh
 
     if (present(vh_3d)) then
@@ -2356,9 +2358,8 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
         else ; do_I(i) = .false. ; endif
       enddo
 
-      domore = .false.
-      ! *should* need a reduce clause, but nvfortran seems smart enough
-      do concurrent (i=ish:ieh, do_I(i))
+      do concurrent (i=ish:ieh, do_I(i)) &
+          & DO_LOCALITY(local(ddv, dv_prev))
         if ((dt * min(G%IareaT(i,j),G%IareaT(i,j+1))*abs(vh_err(i)) > tol_eta) .or. &
             (CS%better_iter .and. ((abs(vh_err(i)) > tol_vel * dvhdv_tot(i)) .or. &
                                   (abs(vh_err(i)) > vh_err_best(i))) )) then
@@ -2380,7 +2381,6 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
               if (dv_prev - dv_min(i) < 1.0e-15*abs(dv(i,j))) do_I(i) = .false.
             endif
           endif
-          if (do_I(i)) domore = .true.
         else
           do_I(i) = .false.
         endif
@@ -2390,7 +2390,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
       ! OpenMP - compiling with OpenMP prevents early exit. Without OpenMP, enables early exit.
       ! Early exit saves time on CPU, but causes other loops to be serialized on GPU.
       !$ if (.false.) then
-      if (.not.domore) exit
+      if (.not. any(do_I(ish:ieh))) exit
       !$ endif
 
       if ((itt < max_itts) .or. present(vh_3d)) then
@@ -2398,7 +2398,7 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vh_tot_0, dvhdv_tot_0, &
           vh_err(i) = 0.0 ; dvhdv_tot(i) = 0.0
           if (use_vhbt) vh_err(i) = -vhbt(i,J)
         enddo
-        do k=1,nz ; do concurrent (i=ish:ieh, do_I(i))
+        do k=1,nz ; do concurrent (i=ish:ieh, do_I(i)) DO_LOCALITY(local(v_new, dvhdv))
           v_new = v(i,J,k) + dv(i,j) * visc_rem(i,j,k)
           call flux_elem(v_new, h_in(i,J,k), h_in(i,J+1,k), h_S(i,J,k), h_S(i,J+1,k), &
                          h_N(i,J,k), h_N(i,J+1,k), vh_aux(i,k), dvhdv, visc_rem(i,J,k), &
@@ -2528,7 +2528,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
 
     ! not parallelized on k because of dvR/L are calculated per column
     ! nvfortran do concurrent poor performance when k is inside
-    do k=1,nz ; do concurrent (i=ish:ieh, do_I(i,J))
+    do k=1,nz ; do concurrent (i=ish:ieh, do_I(i,J)) DO_LOCALITY(local(visc_rem_lim))
       visc_rem_lim = max(visc_rem(i,J,k), min_visc_rem*visc_rem_max(i,J))
       if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
         if (v(i,J,k) + dvR(i)*visc_rem_lim > -dv_CFL(i)*visc_rem(i,J,k)) &
@@ -2538,7 +2538,8 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
       endif
     enddo ; enddo
 
-    do k=1,nz ; do concurrent (i=ish:ieh, do_I(i,j))
+    do k=1,nz ; do concurrent (i=ish:ieh, do_I(i,j)) &
+        & DO_LOCALITY(local(v_0, v_L, v_R, dvhdv_0, dvhdv_L, dvhdv_R, vh_0, vh_L, vh_R))
       v_L = v(I,J,k) + dvL(i) * visc_rem(i,J,k)
       v_R = v(I,J,k) + dvR(i) * visc_rem(i,J,k)
       v_0 = v(I,J,k) + dv0(i,J) * visc_rem(i,J,k)
@@ -2561,7 +2562,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, dv0, vh_tot_0, dvhdv_to
       vhtot_R(i) = vhtot_R(i) + vh_R
     enddo ; enddo
 
-    do concurrent (i=ish:ieh)
+    do concurrent (i=ish:ieh) DO_LOCALITY(local(FA_0, FA_Avg))
       if (do_I(i,j)) then
         FA_0 = FAmt_0(i) ; FA_avg = FAmt_0(i)
         if ((dvL(i) - dv0(i,J)) /= 0.0) &

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -426,7 +426,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! allocate internal variables on GPU
   !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
   !$omp target enter data map(alloc: hp)
-  !$omp target update to(eta, pbv, pbv%por_face_areaU, pbv%por_face_areaV)
+  !$omp target update to(eta)
 
   !$OMP parallel do default(shared)
   do k=1,nz

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -426,7 +426,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! allocate internal variables on GPU
   !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
   !$omp target enter data map(alloc: hp)
-  !$omp target update to(eta)
+  !$omp target update to(eta, pbv, pbv%por_face_areaU, pbv%por_face_areaV)
 
   !$OMP parallel do default(shared)
   do k=1,nz

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -410,6 +410,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
                             ! in the  corrector step (not the predict)
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil, vel_stencil
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_tmp ! temporary copy of Layer thickness [H ~> m or kg m-2]
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -1110,7 +1111,8 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! h  = h + dt * div . uh
   ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
   call cpu_clock_begin(id_clock_continuity)
-  call continuity(u_inst, v_inst, h, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
+  h_tmp(:, :, :) = h(:, :, :)
+  call continuity(u_inst, v_inst, h_tmp, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av)
   call cpu_clock_end(id_clock_continuity)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -434,6 +434,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     do j=G%jsdB,G%jedB ; do i=G%isd,G%ied   ;  vp(i,j,k) = 0.0 ; enddo ; enddo
     do j=G%jsd,G%jed   ; do i=G%isd,G%ied   ;  hp(i,j,k) = h(i,j,k) ; enddo ; enddo
   enddo
+  ! TODO: hp needs accurate +/-2 halos.
+  ! For now we need to update the GPU halo here, but this can be phased out.
+  !$omp target update to(hp)
 
   ! Update CFL truncation value as function of time
   call updateCFLtruncationValue(Time_local, CS%vertvisc_CSp, US)
@@ -666,6 +669,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(u_inst, v_inst)
   if (associated(CS%BT_cont) .or. CS%BT_use_layer_fluxes) then
     call cpu_clock_begin(id_clock_continuity)
+
     !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
     call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                     visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, BT_cont=CS%BT_cont)
@@ -1607,6 +1611,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
 
   id_clock_pass_init = cpu_clock_id('(Ocean init message passing)', grain=CLOCK_ROUTINE)
 
+  !$omp target enter data map(alloc: CS%continuity_CSp)
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -434,6 +434,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     do j=G%jsdB,G%jedB ; do i=G%isd,G%ied   ;  vp(i,j,k) = 0.0 ; enddo ; enddo
     do j=G%jsd,G%jed   ; do i=G%isd,G%ied   ;  hp(i,j,k) = h(i,j,k) ; enddo ; enddo
   enddo
+  ! TODO: hp needs accurate +/-2 halos.
+  ! For now we need to update the GPU halo here, but this can be phased out.
+  !$omp target update to(hp)
 
   ! Update CFL truncation value as function of time
   call updateCFLtruncationValue(Time_local, CS%vertvisc_CSp, US)
@@ -665,6 +668,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(u_inst, v_inst)
   if (associated(CS%BT_cont) .or. CS%BT_use_layer_fluxes) then
     call cpu_clock_begin(id_clock_continuity)
+
     !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
     call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                     visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, BT_cont=CS%BT_cont)
@@ -1605,6 +1609,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
 
   id_clock_pass_init = cpu_clock_id('(Ocean init message passing)', grain=CLOCK_ROUTINE)
 
+  !$omp target enter data map(alloc: CS%continuity_CSp)
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -425,7 +425,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   ! allocate internal variables on GPU
   !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
-  !$omp target enter data map(alloc: hp, dz)
+  !$omp target enter data map(alloc: up, vp, hp, dz, h_tmp)
   !$omp target update to(eta, pbv, pbv%por_face_areaU, pbv%por_face_areaV)
 
   !$OMP parallel do default(shared)
@@ -805,7 +805,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! uh = u_av * h
   ! hp = h + dt * div . uh
   call cpu_clock_begin(id_clock_continuity)
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, up, vp)
   call continuity(up, vp, h, hp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av, BT_cont=CS%BT_cont)
@@ -1087,7 +1087,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! h  = h + dt * div . uh
   ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
   call cpu_clock_begin(id_clock_continuity)
-  h_tmp(:, :, :) = h(:, :, :)
+  do concurrent (k=1:nz, j=G%jsd:G%jed, i=G%isd:G%ied)
+    h_tmp(i,j,k) = h(i,j,k)
+  enddo
   !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, u_inst, v_inst)
   call continuity(u_inst, v_inst, h_tmp, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
@@ -1133,7 +1135,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   ! release internal variables
   !$omp target exit data map(release: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
-  !$omp target exit data map(delete: hp, dz)
+  !$omp target exit data map(delete: hp, up, vp, dz, h_tmp)
 
   if (CS%store_CAu) then
     ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -425,7 +425,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   ! allocate internal variables on GPU
   !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
-  !$omp target enter data map(alloc: hp)
+  !$omp target enter data map(alloc: hp, up, vp, h_tmp)
   !$omp target update to(eta)
 
   !$OMP parallel do default(shared)
@@ -803,7 +803,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! uh = u_av * h
   ! hp = h + dt * div . uh
   call cpu_clock_begin(id_clock_continuity)
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, up, vp)
   call continuity(up, vp, h, hp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av, BT_cont=CS%BT_cont)
@@ -1085,7 +1085,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! h  = h + dt * div . uh
   ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
   call cpu_clock_begin(id_clock_continuity)
-  h_tmp(:, :, :) = h(:, :, :)
+  do concurrent (k=1:nz, j=G%jsd:G%jed, i=G%isd:G%ied)
+    h_tmp(i,j,k) = h(i,j,k)
+  enddo
   !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, u_inst, v_inst)
   call continuity(u_inst, v_inst, h_tmp, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
@@ -1131,7 +1133,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   ! release internal variables
   !$omp target exit data map(release: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
-  !$omp target exit data map(delete: hp)
+  !$omp target exit data map(delete: hp, up, vp, h_tmp)
 
   if (CS%store_CAu) then
     ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -410,6 +410,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
                             ! in the  corrector step (not the predict)
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil, vel_stencil
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_tmp ! temporary copy of Layer thickness [H ~> m or kg m-2]
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -1112,7 +1113,8 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! h  = h + dt * div . uh
   ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
   call cpu_clock_begin(id_clock_continuity)
-  call continuity(u_inst, v_inst, h, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
+  h_tmp(:, :, :) = h(:, :, :)
+  call continuity(u_inst, v_inst, h_tmp, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av)
   call cpu_clock_end(id_clock_continuity)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -426,7 +426,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! allocate internal variables on GPU
   !$omp target enter data map(alloc: u_bc_accel, v_bc_accel, eta_pred, uh_in, vh_in)
   !$omp target enter data map(alloc: hp, dz)
-  !$omp target update to(eta)
+  !$omp target update to(eta, pbv, pbv%por_face_areaU, pbv%por_face_areaV)
 
   !$OMP parallel do default(shared)
   do k=1,nz

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -662,13 +662,14 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call complete_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
 
 ! u_accel_bt = layer accelerations due to barotropic solver
+  !$omp target update to(u_inst, v_inst)
   if (associated(CS%BT_cont) .or. CS%BT_use_layer_fluxes) then
     call cpu_clock_begin(id_clock_continuity)
+    !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
     call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                     visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, BT_cont=CS%BT_cont)
     call cpu_clock_end(id_clock_continuity)
     if (BT_cont_BT_thick) then
-      !$omp target update to(h, CS%BT_cont%h_u, CS%BT_cont%h_v)
       call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
                   OBC=CS%OBC)
     endif
@@ -677,7 +678,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (CS%BT_use_layer_fluxes) then
     uh_ptr => uh_in ; vh_ptr => vh_in; u_ptr => u_inst ; v_ptr => v_inst
-    !$omp target update to(uh_in, vh_in)
   endif
 
   call cpu_clock_begin(id_clock_btstep)
@@ -693,25 +693,12 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
-  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
-  !$omp target update to(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update to(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update to(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update to(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update to(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update to(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
+  !$omp target update to(u_bc_accel, v_bc_accel)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt)
-  !$omp target update from(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update from(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update from(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update from(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update from(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update from(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
   if (showCallTree) call callTree_leave("btstep()")
   call cpu_clock_end(id_clock_btstep)
 
@@ -816,9 +803,11 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! uh = u_av * h
   ! hp = h + dt * div . uh
   call cpu_clock_begin(id_clock_continuity)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
   call continuity(up, vp, h, hp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av, BT_cont=CS%BT_cont)
+  !$omp target update from(u_av, v_av, hp, uh, vh)
   call cpu_clock_end(id_clock_continuity)
   if (showCallTree) call callTree_wayPoint("done with continuity (step_MOM_dyn_split_RK2)")
 
@@ -856,7 +845,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! hp can be changed if CS%begw /= 0.
   ! eta_cor = ...                 (hidden inside CS%barotropic_CSp)
   call cpu_clock_begin(id_clock_btcalc)
-  !$omp target update to(hp)
   call bt_mass_source(hp, eta_pred, .false., G, GV, CS%barotropic_CSp)
   call cpu_clock_end(id_clock_btcalc)
 
@@ -909,7 +897,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
 
   if (BT_cont_BT_thick) then
-    !$omp target update to(h, CS%BT_cont%h_u, CS%BT_cont%h_v)
     call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
                 OBC=CS%OBC)
     if (showCallTree) call callTree_wayPoint("done with btcalc[BT_cont_BT_thick] (step_MOM_dyn_split_RK2)")
@@ -992,25 +979,12 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the corrector step call to btstep.
   !$omp target update to(u_bc_accel, v_bc_accel)
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
-  !$omp target update to(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update to(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update to(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update to(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update to(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update to(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
   !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
-  !$omp target update from(CS%uhbt, CS%vhbt, eta_pred)
-  !$omp target update from(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update from(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update from(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update from(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update from(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update from(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
+  !$omp target update from(eta_pred)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif
@@ -1112,9 +1086,11 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
   call cpu_clock_begin(id_clock_continuity)
   h_tmp(:, :, :) = h(:, :, :)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, u_inst, v_inst)
   call continuity(u_inst, v_inst, h_tmp, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av)
+  !$omp target update from(h, u_av, v_av, uh, vh)
   call cpu_clock_end(id_clock_continuity)
   call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
   ! Whenever thickness changes let the diag manager know, target grids

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -663,13 +663,14 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call complete_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
 
 ! u_accel_bt = layer accelerations due to barotropic solver
+  !$omp target update to(u_inst, v_inst)
   if (associated(CS%BT_cont) .or. CS%BT_use_layer_fluxes) then
     call cpu_clock_begin(id_clock_continuity)
+    !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
     call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                     visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, BT_cont=CS%BT_cont)
     call cpu_clock_end(id_clock_continuity)
     if (BT_cont_BT_thick) then
-      !$omp target update to(h, CS%BT_cont%h_u, CS%BT_cont%h_v)
       call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
                   OBC=CS%OBC)
     endif
@@ -678,7 +679,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (CS%BT_use_layer_fluxes) then
     uh_ptr => uh_in ; vh_ptr => vh_in; u_ptr => u_inst ; v_ptr => v_inst
-    !$omp target update to(uh_in, vh_in)
   endif
 
   call cpu_clock_begin(id_clock_btstep)
@@ -694,25 +694,12 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the predictor step call to btstep.
   ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
-  !$omp target update to(uh_ptr, vh_ptr, u_ptr, v_ptr, u_bc_accel, v_bc_accel)
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
-  !$omp target update to(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update to(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update to(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update to(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update to(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update to(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
+  !$omp target update to(u_bc_accel, v_bc_accel)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr)
-  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt, CS%uhbt, CS%vhbt)
-  !$omp target update from(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update from(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update from(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update from(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update from(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update from(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
+  !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
   if (showCallTree) call callTree_leave("btstep()")
   call cpu_clock_end(id_clock_btstep)
 
@@ -818,9 +805,11 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! uh = u_av * h
   ! hp = h + dt * div . uh
   call cpu_clock_begin(id_clock_continuity)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
   call continuity(up, vp, h, hp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av, BT_cont=CS%BT_cont)
+  !$omp target update from(u_av, v_av, hp, uh, vh)
   call cpu_clock_end(id_clock_continuity)
   if (showCallTree) call callTree_wayPoint("done with continuity (step_MOM_dyn_split_RK2)")
 
@@ -858,7 +847,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! hp can be changed if CS%begw /= 0.
   ! eta_cor = ...                 (hidden inside CS%barotropic_CSp)
   call cpu_clock_begin(id_clock_btcalc)
-  !$omp target update to(hp)
   call bt_mass_source(hp, eta_pred, .false., G, GV, CS%barotropic_CSp)
   call cpu_clock_end(id_clock_btcalc)
 
@@ -911,7 +899,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
 
   if (BT_cont_BT_thick) then
-    !$omp target update to(h, CS%BT_cont%h_u, CS%BT_cont%h_v)
     call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
                 OBC=CS%OBC)
     if (showCallTree) call callTree_wayPoint("done with btcalc[BT_cont_BT_thick] (step_MOM_dyn_split_RK2)")
@@ -994,25 +981,12 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
   ! This is the corrector step call to btstep.
   !$omp target update to(u_bc_accel, v_bc_accel)
-  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
-  !$omp target update to(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update to(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update to(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update to(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update to(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update to(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
   call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
               CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
               CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
               eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
   !$omp target update from(CS%u_accel_bt, CS%v_accel_bt)
-  !$omp target update from(CS%uhbt, CS%vhbt, eta_pred)
-  !$omp target update from(CS%BT_cont%FA_u_EE, CS%BT_cont%FA_u_E0)
-  !$omp target update from(CS%BT_cont%FA_u_W0, CS%BT_cont%FA_u_WW)
-  !$omp target update from(CS%BT_cont%uBT_WW, CS%BT_cont%uBT_EE)
-  !$omp target update from(CS%BT_cont%FA_v_NN, CS%BT_cont%FA_v_N0)
-  !$omp target update from(CS%BT_cont%FA_v_S0, CS%BT_cont%FA_v_SS)
-  !$omp target update from(CS%BT_cont%vBT_SS, CS%BT_cont%vBT_NN)
+  !$omp target update from(eta_pred)
   if (CS%id_deta_dt>0) then
     do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
   endif
@@ -1114,9 +1088,11 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
   call cpu_clock_begin(id_clock_continuity)
   h_tmp(:, :, :) = h(:, :, :)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v, u_inst, v_inst)
   call continuity(u_inst, v_inst, h_tmp, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
                   uhbt=CS%uhbt, vhbt=CS%vhbt, visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, &
                   u_cor=u_av, v_cor=v_av)
+  !$omp target update from(h, u_av, v_av, uh, vh)
   call cpu_clock_end(id_clock_continuity)
   call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
   ! Whenever thickness changes let the diag manager know, target grids

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -514,9 +514,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(h)
   call PressureForce(h, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                      CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
-  !$omp target update from(CS%PFu, CS%PFv, CS%pbce, CS%eta_PF)
+  !$omp target update from(CS%PFu, CS%PFv, CS%pbce)
 
   if (dyn_p_surf) then
+    !$omp target update from(CS%eta_PF)
     pres_to_eta = 1.0 / (GV%g_Earth * GV%H_to_RZ)
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -644,7 +645,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   call cpu_clock_begin(id_clock_btcalc)
   ! Calculate the relative layer weights for determining barotropic quantities.
-  !$omp target update to(h)
   if (.not.BT_cont_BT_thick) then
     call btcalc(h, G, GV, CS%barotropic_CSp, OBC=CS%OBC)
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -514,9 +514,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(h)
   call PressureForce(h, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
                      CS%ALE_CSp, CS%ADp, p_surf, CS%pbce, CS%eta_PF)
-  !$omp target update from(CS%PFu, CS%PFv, CS%pbce, CS%eta_PF)
+  !$omp target update from(CS%PFu, CS%PFv, CS%pbce)
 
   if (dyn_p_surf) then
+    !$omp target update from(CS%eta_PF)
     pres_to_eta = 1.0 / (GV%g_Earth * GV%H_to_RZ)
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -643,7 +644,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   call cpu_clock_begin(id_clock_btcalc)
   ! Calculate the relative layer weights for determining barotropic quantities.
-  !$omp target update to(h)
   if (.not.BT_cont_BT_thick) then
     call btcalc(h, G, GV, CS%barotropic_CSp, OBC=CS%OBC)
   endif


### PR DESCRIPTION
Hi Marshall,

Here's the ported continuity_ppm. I wanted to run over it with a finer comb to minimize data transfers in the step_rk2 routine, so opening as draft. Also need to check that the OBC changes that were made in dev/gfdl haven't accidentally been erased during the rebase. At this point most needed data transfers happen in step_rk2, but there's some data transfer happening with OBC which I still want to investigate.

Would it also be helpful for you if i clean up the git history?

Will still be helpful for you to test either way.

PS i accidentally opened a pull request to mom-ocean so please ignore that.