### PR TITLE
dev/gpu do concurrent loop reoder

### DIFF
--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -244,7 +244,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
   !$omp target enter data map(alloc: Area_h, Area_q)
 
-  do concurrent (I=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
+  do concurrent (j=Jsq-1:Jeq+2, I=Isq-1:Ieq+2)
     Area_h(i,j) = G%mask2dT(i,j) * G%areaT(i,j)
   enddo
 
@@ -276,7 +276,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     !$omp target update to(Area_h)
   endif
 
-  do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+  do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
     Area_q(i,j) = (Area_h(i,j) + Area_h(i+1,j+1)) + &
                   (Area_h(i+1,j) + Area_h(i,j+1))
   enddo
@@ -322,7 +322,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! First calculate the contributions to the circulation around the q-point.
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+        do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
           dvSdx(I,J) = (-Waves%us_y(i+1,J,k)*G%dyCv(i+1,J)) - &
                        (-Waves%us_y(i,J,k)*G%dyCv(i,J))
           duSdy(I,J) = (-Waves%us_x(I,j+1,k)*G%dxCu(I,j+1)) - &
@@ -330,39 +330,39 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo
       endif
       if (.not. Waves%Passive_Stokes_VF) then
-        do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+        do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
           dvdx(I,J) = ((v(i+1,J,k)-Waves%us_y(i+1,J,k))*G%dyCv(i+1,J)) - &
                       ((v(i,J,k)-Waves%us_y(i,J,k))*G%dyCv(i,J))
           dudy(I,J) = ((u(I,j+1,k)-Waves%us_x(I,j+1,k))*G%dxCu(I,j+1)) - &
                       ((u(I,j,k)-Waves%us_x(I,j,k))*G%dxCu(I,j))
         enddo
       else
-        do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+        do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
           dvdx(I,J) = (v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J))
           dudy(I,J) = (u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j))
         enddo
       endif
     else
-      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
         dvdx(I,J) = (v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J))
         dudy(I,J) = (u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j))
       enddo
     endif
 
-    do concurrent (i=Isq-1:Ieq+2, J=Jsq-1:Jeq+1)
+    do concurrent (J=Jsq-1:Jeq+1, i=Isq-1:Ieq+2)
       hArea_v(i,J) = 0.5*((Area_h(i,j) * h(i,j,k)) + (Area_h(i,j+1) * h(i,j+1,k)))
     enddo
 
-    do concurrent (I=Isq-1:Ieq+1, j=Jsq-1:Jeq+2)
+    do concurrent (j=Jsq-1:Jeq+2, I=Isq-1:Ieq+1)
       hArea_u(I,j) = 0.5*((Area_h(i,j) * h(i,j,k)) + (Area_h(i+1,j) * h(i+1,j,k)))
     enddo
 
     if (CS%Coriolis_En_Dis) then
-      do concurrent (I=is-1:ie, J=Jsq:Jeq+1)
+      do concurrent (J=Jsq:Jeq+1, I=is-1:ie)
         uh_center(I,j) = 0.5 * ((G%dy_Cu(I,j)*pbv%por_face_areaU(I,j,k)) * u(I,j,k)) * (h(i,j,k) + h(i+1,j,k))
       enddo
 
-      do concurrent (i=Isq:Ieq+1, J=js-1:je)
+      do concurrent (J=js-1:je, i=Isq:Ieq+1)
         vh_center(i,J) = 0.5 * ((G%dx_Cv(i,J)*pbv%por_face_areaV(i,J,k)) * v(i,J,k)) * (h(i,j,k) + h(i,j+1,k))
       enddo
     endif
@@ -504,34 +504,34 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     if (CS%no_slip) then
-      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
         rel_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
       enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+          do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
           enddo
         endif
       endif
     else
-      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
         rel_vort(I,J) = G%mask2dBu(I,J) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
       enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+          do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
           enddo
         endif
       endif
     endif
 
-    do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+    do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
       abs_vort(I,J) = G%CoriolisBu(I,J) + rel_vort(I,J)
     enddo
 
-    do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+    do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
       hArea_q = (hArea_u(I,j) + hArea_u(I,j+1)) + (hArea_v(i,J) + hArea_v(i+1,J))
       Ih_q(I,J) = Area_q(I,J) / (hArea_q + vol_neglect)
       q(I,J) = abs_vort(I,J) * Ih_q(I,J)
@@ -539,26 +539,26 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+        do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
           qS(I,J) = stk_vort(I,J) * Ih_q(I,J)
         enddo
       endif
     endif
 
     if (CS%id_rv > 0) then
-      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
         RV(I,J,k) = rel_vort(I,J)
       enddo
     endif
 
     if (CS%id_PV > 0) then
-      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
         PV(I,J,k) = q(I,J)
       enddo
     endif
 
     if (associated(AD%rv_x_v) .or. associated(AD%rv_x_u)) then
-      do concurrent (I=Isq-1:Ieq+1, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, I=Isq-1:Ieq+1)
         q2(I,J) = rel_vort(I,J) * Ih_q(I,J)
       enddo
     endif
@@ -568,17 +568,17 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! scheme.  All are defined at u grid points.
 
     if (CS%Coriolis_Scheme == ARAKAWA_HSU90) then
-      do concurrent (I=is-1:Ieq, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, I=is-1:Ieq)
         a(I,j) = (q(I,J) + (q(I+1,J) + q(I,J-1))) * C1_12
         d(I,j) = ((q(I,J) + q(I+1,J-1)) + q(I,J-1)) * C1_12
       enddo
 
-      do concurrent (I=Isq:Ieq, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, I=Isq:Ieq)
         b(I,j) = (q(I,J) + (q(I-1,J) + q(I,J-1))) * C1_12
         c(I,j) = ((q(I,J) + q(I-1,J-1)) + q(I,J-1)) * C1_12
       enddo
     elseif (CS%Coriolis_Scheme == ARAKAWA_LAMB81) then
-      do concurrent (I=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, I=Isq:Ieq+1)
         a(I-1,j) = (2.0*(q(I,J) + q(I-1,J-1)) + (q(I-1,J) + q(I,J-1))) * C1_24
         d(I-1,j) = ((q(I,j) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
         b(I,j) =   ((q(I,J) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
@@ -593,7 +593,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! This allows the code to always give Sadourny Energy
       if (CS%F_eff_max_blend <= 2.0) then ; Fe_m2 = -1. ; rat_lin = -1.0 ; endif
 
-      do concurrent (I=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, I=Isq:Ieq+1)
         min_Ihq = MIN(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
         max_Ihq = MAX(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
         rat_m1 = 1.0e15
@@ -638,7 +638,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     !  c1 = 1.0-1.5*RANGE ; c2 = 1.0-RANGE ; c3 = 2.0 ; slope = 0.5
       c1 = 1.0-1.5*0.5 ; c2 = 1.0-0.5 ; c3 = 2.0 ; slope = 0.5
 
-      do concurrent (I=is-1:ie, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, I=is-1:ie)
         uhc = uh_center(I,j)
         uhm = uh(I,j,k)
         ! This sometimes matters with some types of open boundary conditions.
@@ -660,7 +660,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         endif
       enddo
 
-      do concurrent (i=Isq:Ieq+1, J=js-1:je)
+      do concurrent (J=js-1:je, i=Isq:Ieq+1)
         vhc = vh_center(i,J)
         vhm = vh(i,J,k)
         ! This sometimes matters with some types of open boundary conditions.
@@ -693,7 +693,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        do concurrent (I=Isq:Ieq, j=js:je)
+        do concurrent (j=js:je, I=Isq:Ieq)
           if (q(I,J)*u(I,j,k) == 0.0) then
             temp1 = q(I,J) * ( (vh_max(i,j)+vh_max(i+1,j)) &
                              + (vh_min(i,j)+vh_min(i+1,j)) )*0.5
@@ -714,14 +714,14 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        do concurrent (I=Isq:Ieq, j=js:je)
+        do concurrent (j=js:je, I=Isq:Ieq)
           CAu(I,j,k) = 0.25 * &
             ((q(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
              (q(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
         enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         CAu(I,j,k) = 0.125 * (G%IdxCu(I,j) * (q(I,J) + q(I,J-1))) * &
                      ((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
       enddo
@@ -729,7 +729,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         CAu(I,j,k) = (((a(I,j) * vh(i+1,J,k)) +  (c(I,j) * vh(i,J-1,k)))  + &
                       ((b(I,j) * vh(i,J,k)) +  (d(I,j) * vh(i+1,J-1,k)))) * G%IdxCu(I,j)
       enddo
@@ -737,7 +737,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_v that should be returned by the
       !       continuity solver. AJA
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         Heff1 = abs(vh(i,J,k) * G%IdxCv(i,J)) / (eps_vel+abs(v(i,J,k)))
         Heff1 = max(Heff1, min(h(i,j,k),h(i,j+1,k)))
         Heff1 = min(Heff1, max(h(i,j,k),h(i,j+1,k)))
@@ -766,7 +766,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         CAu(I,j,k) = CAu(I,j,k) + &
               ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
       enddo
@@ -775,7 +775,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAu
-        do concurrent (I=Isq:Ieq, j=js:je)
+        do concurrent (j=js:je, I=Isq:Ieq)
           CAuS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
                  (qS(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
@@ -784,7 +784,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     if (CS%bound_Coriolis) then
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         fv1 = abs_vort(I,J) * v(i+1,J,k)
         fv2 = abs_vort(I,J) * v(i,J,k)
         fv3 = abs_vort(I,J-1) * v(i+1,J-1,k)
@@ -799,12 +799,12 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     ! Term - d(KE)/dx.
-    do concurrent (I=Isq:Ieq, j=js:je)
+    do concurrent (j=js:je, I=Isq:Ieq)
       CAu(I,j,k) = CAu(I,j,k) - KEx(I,j)
     enddo
 
     if (associated(AD%gradKEu)) then
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         AD%gradKEu(I,j,k) = -KEx(I,j)
       enddo
     endif
@@ -815,7 +815,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        do concurrent (i=is:ie, J=Jsq:Jeq)
+        do concurrent (J=Jsq:Jeq, i=is:ie)
           if (q(I-1,J)*v(i,J,k) == 0.0) then
             temp1 = q(I-1,J) * ( (uh_max(i-1,j)+uh_max(i-1,j+1)) &
                                + (uh_min(i-1,j)+uh_min(i-1,j+1)) )*0.5
@@ -836,14 +836,14 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        do concurrent (i=is:ie, J=Jsq:Jeq)
+        do concurrent (J=Jsq:Jeq, i=is:ie)
           CAv(i,J,k) = - 0.25* &
               ((q(I-1,J)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q(I,J)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
         enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J) + q(I,J))) * &
                      ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
       enddo
@@ -851,7 +851,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         CAv(i,J,k) = - (((a(I-1,j)   * uh(I-1,j,k)) + &
                          (c(I,j+1)   * uh(I,j+1,k)))  &
                       + ((b(I,j)     * uh(I,j,k)) +   &
@@ -861,7 +861,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_u that should be returned by the
       !       continuity solver. AJA
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         Heff1 = abs(uh(I,j,k) * G%IdyCu(I,j)) / (eps_vel+abs(u(I,j,k)))
         Heff1 = max(Heff1, min(h(i,j,k),h(i+1,j,k)))
         Heff1 = min(Heff1, max(h(i,j,k),h(i+1,j,k)))
@@ -892,7 +892,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! Add in the additonal terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
         (CS%Coriolis_Scheme == AL_BLEND)) then
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         CAv(i,J,k) = CAv(i,J,k) + &
               ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
       enddo
@@ -901,7 +901,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAv
-        do concurrent (i=is:ie, J=Jsq:Jeq)
+        do concurrent (J=Jsq:Jeq, i=is:ie)
           CAvS(I,j,k) = 0.25 * &
                 ((qS(I,J) * (uh(I,j+1,k) + uh(I,j,k))) + &
                  (qS(I,J-1) * (uh(I-1,j,k) + uh(I-1,j+1,k)))) * G%IdyCv(i,J)
@@ -910,7 +910,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     if (CS%bound_Coriolis) then
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         fu1 = -abs_vort(I,J) * u(I,j+1,k)
         fu2 = -abs_vort(I,J) * u(I,j,k)
         fu3 = -abs_vort(I-1,J) * u(I-1,j+1,k)
@@ -925,11 +925,11 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     endif
 
     ! Term - d(KE)/dy.
-    do concurrent (i=is:ie, J=Jsq:Jeq)
+    do concurrent (J=Jsq:Jeq, i=is:ie)
       CAv(i,J,k) = CAv(i,J,k) - KEy(i,J)
     enddo
     if (associated(AD%gradKEv)) then
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         AD%gradKEv(i,J,k) = -KEy(i,J)
       enddo
     endif
@@ -938,7 +938,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! Calculate the Coriolis-like acceleration due to relative vorticity.
       if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
         if (associated(AD%rv_x_u)) then
-          do concurrent (i=is:ie, J=Jsq:Jeq)
+          do concurrent (J=Jsq:Jeq, i=is:ie)
             AD%rv_x_u(i,J,k) = - 0.25* &
               ((q2(I-1,j)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
                (q2(I,j)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
@@ -946,7 +946,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         endif
 
         if (associated(AD%rv_x_v)) then
-          do concurrent (I=Isq:Ieq, j=js:je)
+          do concurrent (j=js:je, I=Isq:Ieq)
             AD%rv_x_v(I,j,k) = 0.25 * &
               ((q2(I,j) * (vh(i+1,J,k) + vh(i,J,k))) + &
                (q2(I,j-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
@@ -954,7 +954,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         endif
       else
         if (associated(AD%rv_x_u)) then
-          do concurrent (i=is:ie, J=Jsq:Jeq)
+          do concurrent (J=Jsq:Jeq, i=is:ie)
             AD%rv_x_u(i,J,k) = -G%IdyCv(i,J) * C1_12 * &
               (((((q2(I,J) + q2(I-1,J-1)) + q2(I-1,J)) * uh(I-1,j,k)) + &
                 (((q2(I-1,J) + q2(I,J+1)) + q2(I,J)) * uh(I,j+1,k))) + &
@@ -964,7 +964,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         endif
 
         if (associated(AD%rv_x_v)) then
-          do concurrent (I=Isq:Ieq, j=js:je)
+          do concurrent (j=js:je, I=Isq:Ieq)
             AD%rv_x_v(I,j,k) = G%IdxCu(I,j) * C1_12 * &
               (((((q2(I+1,J) + q2(I,J-1)) + q2(I,J)) * vh(i+1,J,k)) + &
                 (((q2(I-1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i,J-1,k))) + &
@@ -1073,7 +1073,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
     ! The following calculation of Kinetic energy includes the metric terms
     ! identified in Arakawa & Lamb 1982 as important for KE conservation.  It
     ! also includes the possibility of partially-blocked tracer cell faces.
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       KE(i,j) = ( ( (G%areaCu( I ,j)*(u( I ,j,k)*u( I ,j,k))) + &
                     (G%areaCu(I-1,j)*(u(I-1,j,k)*u(I-1,j,k))) ) + &
                   ( (G%areaCv(i, J )*(v(i, J ,k)*v(i, J ,k))) + &
@@ -1082,7 +1082,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
   elseif (CS%KE_Scheme == KE_SIMPLE_GUDONOV) then
     ! The following discretization of KE is based on the one-dimensional Gudonov
     ! scheme which does not take into account any geometric factors
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       up = 0.5*( u(I-1,j,k) + ABS( u(I-1,j,k) ) ) ; up2 = up*up
       um = 0.5*( u( I ,j,k) - ABS( u( I ,j,k) ) ) ; um2 = um*um
       vp = 0.5*( v(i,J-1,k) + ABS( v(i,J-1,k) ) ) ; vp2 = vp*vp
@@ -1092,7 +1092,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
   elseif (CS%KE_Scheme == KE_GUDONOV) then
     ! The following discretization of KE is based on the one-dimensional Gudonov
     ! scheme but has been adapted to take horizontal grid factors into account
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       up = 0.5*( u(I-1,j,k) + ABS( u(I-1,j,k) ) ) ; up2a = up*up*G%areaCu(I-1,j)
       um = 0.5*( u( I ,j,k) - ABS( u( I ,j,k) ) ) ; um2a = um*um*G%areaCu( I ,j)
       vp = 0.5*( v(i,J-1,k) + ABS( v(i,J-1,k) ) ) ; vp2a = vp*vp*G%areaCv(i,J-1)
@@ -1108,12 +1108,12 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
   !
 
   ! Term - d(KE)/dx.
-  do concurrent (I=Isq:Ieq, j=js:je)
+  do concurrent (j=js:je, I=Isq:Ieq)
     KEx(I,j) = (KE(i+1,j) - KE(i,j)) * G%IdxCu(I,j)
   enddo
 
   ! Term - d(KE)/dy.
-  do concurrent (i=is:ie, J=Jsq:Jeq)
+  do concurrent (J=Jsq:Jeq, i=is:ie)
     KEy(i,J) = (KE(i,j+1) - KE(i,j)) * G%IdyCv(i,J)
   enddo
 

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1154,7 +1154,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
 
   !$omp target enter data map(alloc: e)
 
-  do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+  do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
     e(i,j,nz+1) = -G%bathyT(i,j)
   enddo
 
@@ -1212,7 +1212,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   endif
 
   do k=nz,1,-1
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       e(i,j,K) = e(i,j,K+1) + h(i,j,k)*GV%H_to_Z
     enddo
   enddo
@@ -1268,11 +1268,11 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   ! integrals, assuming that the surface pressure anomaly varies linearly
   ! in x and y.
   if (use_p_atm) then
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       pa(i,j,1) = GxRho_ref * (e(i,j,1) - G%Z_ref) + p_atm(i,j)
     enddo
   else
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       pa(i,j,1) = GxRho_ref * (e(i,j,1) - G%Z_ref)
     enddo
   endif
@@ -1280,15 +1280,15 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   if (use_EOS) then
     !$omp target enter data map(alloc: Z_0p) if (use_EOS)
     if (CS%use_SSH_in_Z0p .and. use_p_atm) then
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         Z_0p(i,j) = e(i,j,1) + p_atm(i,j) * I_g_rho
       enddo
     elseif (CS%use_SSH_in_Z0p) then
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         Z_0p(i,j) = e(i,j,1)
       enddo
     else
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         Z_0p(i,j) = G%Z_ref
       enddo
     endif
@@ -1347,15 +1347,15 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   else
     !$omp target data map(alloc: dz_geo)
     do k=1,nz
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         dz_geo(i,j) = GV%g_Earth * GV%H_to_Z*h(i,j,k)
         dpa(i,j,k) = (GV%Rlay(k) - rho_ref) * dz_geo(i,j)
         intz_dpa(i,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * dz_geo(i,j)*h(i,j,k)
       enddo
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         intx_dpa(I,j,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j) + dz_geo(i+1,j))
       enddo
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         inty_dpa(i,J,k) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_geo(i,j) + dz_geo(i,j+1))
       enddo
     enddo
@@ -1364,7 +1364,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
 
   ! Set the pressure anomalies at the interfaces.
   do k=1,nz
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       pa(i,j,K+1) = pa(i,j,K) + dpa(i,j,k)
     enddo
   enddo
@@ -1869,10 +1869,10 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     ! Calculate SAL geopotential anomaly and add its gradient to pressure
     ! gradient force
     if (CS%calculate_SAL) then
-      do concurrent(I=Isq:Ieq, j=js:je, k=1:nz)
+      do concurrent (k=1:nz, j=js:je, I=Isq:Ieq)
           PFu(I,j,k) = PFu(I,j,k) + (e_sal(i+1,j) - e_sal(i,j)) * GV%g_Earth * G%IdxCu(I,j)
       enddo
-      do concurrent (i=is:ie, J=Jsq:Jeq, k=1:nz)
+      do concurrent (k=1:nz, J=Jsq:Jeq, i=is:ie)
           PFv(i,J,k) = PFv(i,J,k) + (e_sal(i,j+1) - e_sal(i,j)) * GV%g_Earth * G%IdyCv(i,J)
       enddo
     endif
@@ -1880,11 +1880,11 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
     ! Calculate tidal geopotential anomaly and add its gradient to pressure
     ! gradient force
     if (CS%tides) then
-      do concurrent(I=Isq:Ieq, j=js:je, k=1:nz)
+      do concurrent (k=1:nz, j=js:je, I=Isq:Ieq)
           PFu(I,j,k) = PFu(I,j,k) + ((e_tidal_eq(i+1,j) + e_tidal_sal(i+1,j)) &
               - (e_tidal_eq(i,j) + e_tidal_sal(i,j))) * GV%g_Earth * G%IdxCu(I,j)
       enddo
-      do concurrent(i=is:ie, J=Jsq:Jeq, k=1:nz)
+      do concurrent (k=1:nz, J=Jsq:Jeq, i=is:ie)
           PFv(i,J,k) = PFv(i,J,k) + ((e_tidal_eq(i,j+1) + e_tidal_sal(i,j+1)) &
               - (e_tidal_eq(i,j) + e_tidal_sal(i,j))) * GV%g_Earth * G%IdyCv(i,J)
       enddo
@@ -1925,16 +1925,16 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
 
       !$omp end target data
     else
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         dM(i,j) = (CS%GFS_scale - 1.0) * (G_Rho0 * GV%Rlay(1)) * (e(i,j,1) - G%Z_ref)
       enddo
     endif
 
     do k=1,nz
-      do concurrent (I=Isq:Ieq, j=js:je)
+      do concurrent (j=js:je, I=Isq:Ieq)
         PFu(I,j,k) = PFu(I,j,k) - (dM(i+1,j) - dM(i,j)) * G%IdxCu(I,j)
       enddo
-      do concurrent (i=is:ie, J=Jsq:Jeq)
+      do concurrent (J=Jsq:Jeq, i=is:ie)
         PFv(i,J,k) = PFv(i,J,k) - (dM(i,j+1) - dM(i,j)) * G%IdyCv(i,J)
       enddo
     enddo
@@ -1958,24 +1958,24 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   if (present(eta)) then
     ! eta is the sea surface height relative to a time-invariant geoid, for comparison with
     ! what is used for eta in btstep.  See how e was calculated about 200 lines above.
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       eta(i,j) = e(i,j,1)*GV%Z_to_H
     enddo
 
     if (CS%tides .and. (.not.CS%bq_sal_tides)) then
       if (CS%tides_answer_date>20230630) then
-        do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+        do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
           eta(i,j) = eta(i,j) + (e_tidal_eq(i,j)+e_tidal_sal(i,j))*GV%Z_to_H
         enddo
       else
-        do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+        do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
           eta(i,j) = eta(i,j) + e_sal_and_tide(i,j)*GV%Z_to_H
         enddo
       endif
     endif
 
     if (CS%calculate_SAL .and. (CS%tides_answer_date>20230630) .and. (.not.CS%bq_sal_tides)) then
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         eta(i,j) = eta(i,j) + e_sal(i,j)*GV%Z_to_H
       enddo
     endif

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -760,12 +760,12 @@ subroutine Set_pbce_Bouss(e, tv, G, GV, US, Rho0, GFS_scale, pbce, rho_star)
       !$omp end target data
     endif
   else
-    do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+    do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
       Ihtot(i,j) = 1.0 / ((e(i,j,1) - e(i,j,nz+1)) + dz_neglect)
       pbce(i,j,1) = GV%g_prime(1) * GV%H_to_Z
     enddo
     do k=2,nz
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         pbce(i,j,k) = pbce(i,j,k-1) + (GV%g_prime(K) * GV%H_to_Z) &
             * ((e(i,j,K) - e(i,j,nz+1)) * Ihtot(i,j))
       enddo

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -962,12 +962,12 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
   !   Possibly because Nvidia cannot associate `this` with `EOS%type`.
 
   if (present(rho_ref)) then
-    do concurrent (i=is:ie, j=js:je)
+    do concurrent (j=js:je, i=is:ie)
       rho(i,j) = density_anomaly_elem_buggy_Wright(this, T(i,j), S(i,j), &
           pressure(i,j), rho_ref)
     enddo
   else
-    do concurrent (i=is:ie, j=js:je)
+    do concurrent (j=js:je, i=is:ie)
       rho(i,j) = density_elem_buggy_Wright(this, T(i,j), S(i,j), pressure(i,j))
     enddo
   endif
@@ -1026,7 +1026,7 @@ subroutine calculate_density_derivs_2d_buggy_Wright(this, T, S, pressure, &
 
   ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
 
-  do concurrent (i=is:ie, j=js:je)
+  do concurrent (j=js:je, i=is:ie)
     call calculate_density_derivs_elem_buggy_Wright(this, T(i,j), S(i,j), &
         pressure(i,j), drho_dT(i,j), drho_dS(i,j))
   enddo

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -702,22 +702,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Griffies and Hallberg (2000).
 
     ! Calculate horizontal tension
-    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
+    do concurrent (j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
       dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                   (G%IdyCu(I-1,j) * u(I-1,j,k)))
     enddo
 
-    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
+    do concurrent (j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
       dvdy(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
                                   (G%IdxCv(i,J-1) * v(i,J-1,k)))
     enddo
 
-    do concurrent (i=Isq-1:Ieq+2, j=Jsq-1:Jeq+2)
+    do concurrent (j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
       sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
     enddo
 
     ! Components for the shearing strain
-    do concurrent (I=is_vort:ie_vort, J=js_vort:je_vort)
+    do concurrent (J=js_vort:je_vort, I=is_vort:ie_vort)
       dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
     enddo
@@ -754,24 +754,24 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
     if (use_cont_huv) then
-      do concurrent (I=Isq-1:Ieq+1, j=js-2:je+2)
+      do concurrent (j=js-2:je+2, I=Isq-1:Ieq+1)
         h_u(I,j) = hu_cont(I,j,k)
       enddo
-      do concurrent (i=is-2:ie+2, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, i=is-2:ie+2)
         h_v(i,J) = hv_cont(i,J,k)
       enddo
     elseif (CS%use_land_mask) then
-      do concurrent (I=is-2:Ieq+1, j=js-2:je+2)
+      do concurrent (j=js-2:je+2, I=is-2:Ieq+1)
         h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
       enddo
-      do concurrent (i=is-2:ie+2, J=js-2:Jeq+1)
+      do concurrent (J=js-2:Jeq+1, i=is-2:ie+2)
         h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
       enddo
     else
-      do concurrent (I=is-2:Ieq+1, j=js-2:je+2)
+      do concurrent (j=js-2:je+2, I=is-2:Ieq+1)
         h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
       enddo
-      do concurrent (i=is-2:ie+2, J=js-2:Jeq+1)
+      do concurrent (J=js-2:Jeq+1, i=is-2:ie+2)
         h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
       enddo
     endif
@@ -906,17 +906,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
-      do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
+      do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
         sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
       enddo
     else
-      do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
+      do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
         sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
       enddo
     endif
 
     if (CS%id_shearstress > 0) then
-      do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
+      do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
         ShSt(I,J,k) = sh_xy(I,J)
       enddo
     endif
@@ -937,12 +937,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
-      do concurrent (I=Isq-1:Ieq+1, j=js-1:Jeq+1)
+      do concurrent (j=js-1:Jeq+1, I=Isq-1:Ieq+1)
         Del2u(I,j) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
                      CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j)) - (CS%dy2h(i,j)*sh_xx(i,j)))
       enddo
 
-      do concurrent (i=is-1:Ieq+1, J=Jsq-1:Jeq+1)
+      do concurrent (J=Jsq-1:Jeq+1, i=is-1:Ieq+1)
         Del2v(i,J) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
                      CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1)) - (CS%dx2h(i,j)*sh_xx(i,j)))
       enddo
@@ -1127,7 +1127,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         sh_xx_sq = sh_xx(i,j)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1)**2) + (sh_xy(I,J)**2)) &
                           + ((sh_xy(I-1,J)**2) + (sh_xy(I,J-1)**2)) )
@@ -1136,7 +1136,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
-      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         h_min = min(h_u(I,j), h_u(I-1,j), h_v(i,J), h_v(i,J-1))
         hrat_min(i,j) = min(1.0, h_min / (h(i,j,k) + h_neglect))
       enddo
@@ -1162,32 +1162,32 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Static (pre-computed) background viscosity
-      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         Kh(i,j) = CS%Kh_bg_xx(i,j)
       enddo
 
       if (CS%add_LES_viscosity) then
         if (CS%Smagorinsky_Kh) then
-          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Kh(i,j) = Kh(i,j) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j)
           enddo
         endif
 
         if (CS%Leith_Kh) then
-          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Kh(i,j) = Kh(i,j) &
                 + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3
           enddo
         endif
       else
         if (CS%Smagorinsky_Kh) then
-          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Kh(i,j) = max(Kh(i,j), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j))
           enddo
         endif
 
         if (CS%Leith_Kh) then
-          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Kh(i,j) = max(Kh(i,j), &
                 CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
           enddo
@@ -1214,7 +1214,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Place a floor on the viscosity, if desired.
-      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
       enddo
 
@@ -1259,7 +1259,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! Newer method of bounding for stability
       if ((CS%better_bound_Kh) .and. (CS%better_bound_Ah)) then
-        do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+        do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           visc_bound_rem(i,j) = 1.0
           Kh_max_here = hrat_min(i,j) * CS%Kh_Max_xx(i,j)
           if (Kh(i,j) >= Kh_max_here) then
@@ -1270,7 +1270,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         enddo
       elseif (CS%better_bound_Kh) then
-        do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+        do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           Kh(i,j) = min(Kh(i,j), hrat_min(i,j) * CS%Kh_Max_xx(i,j))
         enddo
       endif
@@ -1315,11 +1315,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         str_xx(i,j) = -Kh(i,j) * sh_xx(i,j)
       enddo
     else
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         str_xx(i,j) = 0.0
       enddo
     endif ! Get Kh at h points and get Laplacian component of str_xx
@@ -1339,20 +1339,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Determine the biharmonic viscosity at h points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
-      do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         Ah(i,j) = CS%Ah_bg_xx(i,j)
       enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+            do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               AhSm = Shear_mag(i,j) * (CS%Biharm_const_xx(i,j) &
                   + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j))
               Ah(i,j) = max(Ah(i,j), AhSm)
             enddo
           else
-            do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+            do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j)
               Ah(i,j) = max(Ah(i,j), AhSm)
             enddo
@@ -1427,7 +1427,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
 
         if (CS%bound_Ah .and. .not. CS%better_bound_Ah) then
-          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Ah(i,j) = min(Ah(i,j), CS%Ah_Max_xx(i,j))
           enddo
         endif
@@ -1453,11 +1453,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (CS%better_bound_Ah) then
         if (CS%better_bound_Kh) then
-          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Ah(i,j) = min(Ah(i,j), visc_bound_rem(i,j) * hrat_min(i,j) * CS%Ah_Max_xx(i,j))
           enddo
         else
-          do concurrent (i=is_Kh:ie_Kh, j=js_Kh:je_Kh)
+          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Ah(i,j) = min(Ah(i,j), hrat_min(i,j) * CS%Ah_Max_xx(i,j))
           enddo
         endif
@@ -1502,7 +1502,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j)) - (G%IdyCu(I-1,j) * Del2u(I-1,j))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J)) - (G%IdxCv(i,J-1) * Del2v(i,J-1))
         d_str = Ah(i,j) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
@@ -1556,7 +1556,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J)*G%IdyCv(i+1,J)) - (Del2v(i,J)*G%IdyCv(i,J)))
         dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1)*G%IdxCu(I,j+1)) - (Del2u(I,j)*G%IdxCu(I,j)))
       enddo
@@ -1589,7 +1589,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         sh_xy_sq = sh_xy(I,J)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j)**2) + (sh_xx(i+1,j+1)**2)) &
                           + ((sh_xx(i,j+1)**2) + (sh_xx(i+1,j)**2)) )
@@ -1597,7 +1597,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
     endif
 
-    do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+    do concurrent (J=js-1:Jeq, I=is-1:Ieq)
       h2uq = 4.0 * (h_u(I,j) * h_u(I,j+1))
       h2vq = 4.0 * (h_v(i,J) * h_v(i+1,J))
       hq(I,J) = (2.0 * (h2uq * h2vq)) &
@@ -1605,7 +1605,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     enddo
 
     if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         h_min = min(h_u(I,j), h_u(I,j+1), h_v(i,J), h_v(i+1,J))
         hrat_min(I,J) = min(1.0, h_min / (hq(I,J) + h_neglect))
       enddo
@@ -1672,17 +1672,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Static (pre-computed) background viscosity
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         Kh(I,J) = CS%Kh_bg_xy(I,J)
       enddo
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
-          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
             Kh(I,J) = Kh(I,J) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J)
           enddo
         else
-          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
             Kh(I,J) = max(Kh(I,J), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J) )
           enddo
         endif
@@ -1721,7 +1721,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(Kh)
       endif
 
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         ! Place a floor on the viscosity, if desired.
         Kh(I,J) = max(Kh(I,J), CS%Kh_bg_min)
       enddo
@@ -1763,7 +1763,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%better_bound_Kh) .and. (CS%better_bound_Ah)) then
         ! Newer method of bounding for stability
-        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
           visc_bound_rem(I,J) = 1.0
           Kh_max_here = hrat_min(I,J) * CS%Kh_Max_xy(I,J)
           if (Kh(I,J) >= Kh_max_here) then
@@ -1774,7 +1774,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         enddo
       elseif (CS%better_bound_Kh) then
-        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
           Kh(I,J) = min(Kh(I,J), hrat_min(I,J) * CS%Kh_Max_xy(I,J))
         enddo
       endif
@@ -1801,13 +1801,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_sh_xy_q > 0) then
-        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
           sh_xy_q(I,J,k) = sh_xy(I,J)
         enddo
       endif
 
       if (.not. CS%use_Leithy) then
-        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
         enddo
       else
@@ -1818,7 +1818,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         !$omp target update to(str_xy)
       endif
     else
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         str_xy(I,J) = 0.
       enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
@@ -1838,20 +1838,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         Ah(I,J) = CS%Ah_bg_xy(I,J)
       enddo
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+            do concurrent (J=js-1:Jeq, I=is-1:Ieq)
               AhSm = Shear_mag(I,J) * (CS%Biharm_const_xy(I,J) &
                   + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J))
               Ah(I,J) = max(Ah(I,J), AhSm)
             enddo
           else
-            do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+            do concurrent (J=js-1:Jeq, I=is-1:Ieq)
               AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J)
               Ah(I,J) = max(Ah(I,J), AhSm)
             enddo
@@ -1868,7 +1868,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
 
         if (CS%bound_Ah .and. .not.CS%better_bound_Ah) then
-          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
             Ah(I,J) = min(Ah(I,J), CS%Ah_Max_xy(I,J))
           enddo
         endif
@@ -1895,11 +1895,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (CS%better_bound_Ah) then
         if (CS%better_bound_Kh) then
-          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
             Ah(I,J) = min(Ah(I,J), visc_bound_rem(I,J) * hrat_min(I,J) * CS%Ah_Max_xy(I,J))
           enddo
         else
-          do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
             Ah(I,J) = min(Ah(I,J), hrat_min(I,J) * CS%Ah_Max_xy(I,J))
           enddo
         endif
@@ -1934,7 +1934,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Again, need to initialize str_xy as if its biharmonic
-      do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
         d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
 
         str_xy(I,J) = str_xy(I,J) + d_str
@@ -2026,24 +2026,24 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update to(str_xx, str_xy)
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do concurrent (i=Isq:Ieq+1, j=Jsq:Jeq+1)
+      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
         enddo
       else
-        do concurrent (I=is-1:Ieq, J=js-1:Jeq)
+        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo
       endif
     endif ! use_GME
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
-    do concurrent (I=Isq:Ieq, j=js:je)
+    do concurrent (j=js:je, I=Isq:Ieq)
       diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1)) - (CS%dx2q(I,J)*str_xy(I,J))) + &
                        G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j)) - (CS%dy2h(i+1,j)*str_xx(i+1,j)))) * &
                      G%IareaCu(I,j)) / (h_u(I,j) + h_neglect)
@@ -2065,7 +2065,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
-    do concurrent (i=is:ie, J=Jsq:Jeq)
+    do concurrent (J=Jsq:Jeq, i=is:ie)
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j)) - (CS%dx2h(i,j+1)*str_xx(i,j+1)))) * &
                      G%IareaCv(i,J)) / (h_v(i,J) + h_neglect)
@@ -2980,7 +2980,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
     endif
   endif
 
-  do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
+  do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
     CS%dx2q(I,J) = G%dxBu(I,J)*G%dxBu(I,J) ; CS%dy2q(I,J) = G%dyBu(I,J)*G%dyBu(I,J)
   enddo
 
@@ -2988,20 +2988,20 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       ((G%isc-G%isd < 3) .or. (G%isc-G%isd < 3))) call MOM_error(FATAL, &
           "The minimum halo size is 3 when a Leith viscosity is being used.")
   if (CS%use_Leithy) then
-    do concurrent (I=is-3:Ieq+2, J=js-3:Jeq+2)
+    do concurrent (J=js-3:Jeq+2, I=is-3:Ieq+2)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
     enddo
   elseif ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
-    do concurrent (I=Isq-2:Ieq+2, J=Jsq-2:Jeq+2)
+    do concurrent (J=Jsq-2:Jeq+2, I=Isq-2:Ieq+2)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
     enddo
   else
-    do concurrent (I=is-2:Ieq+1, J=js-2:Jeq+1)
+    do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
     enddo
   endif
 
-  do concurrent (i=is-2:Ieq+2, j=js-2:Jeq+2)
+  do concurrent (j=js-2:Jeq+2, i=is-2:Ieq+2)
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)
     CS%DX_dyT(i,j) = G%dxT(i,j)*G%IdyT(i,j) ; CS%DY_dxT(i,j) = G%dyT(i,j)*G%IdxT(i,j)
   enddo


### PR DESCRIPTION
This PR reverses the do concurrent ordering to j-i form, which is more favorable for Intel compilations.  (GNU and Nvidia will optimally reorder; Intel seems to do something halfway.)