### PR TITLE
New CS alloc pattern, first dycore loop to GPU

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2888,7 +2888,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(to: G%areaT, G%areaCu, G%areaCv)
   !$omp target enter data map(to: G%IareaT, G%IareaCu, G%IareaCv, G%IareaBu)
   !$omp target enter data map(to: G%bathyT)
-  !$omp target enter data map(to: G%CoriolisBu)
+  !$omp target enter data map(to: G%CoriolisBu, G%Coriolis2Bu)
   !$omp target enter data map(to: G%mask2dCu, G%mask2dCv)
 
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3094,6 +3094,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     call register_restarts_dyn_split_RK2b(HI, GV, US, param_file, &
              CS%dyn_split_RK2b_CSp, restart_CSp, CS%uh, CS%vh)
   elseif (CS%split) then
+    allocate(CS%dyn_split_RK2_CSp)
+    !$omp target enter data map(alloc: CS%dyn_split_RK2_CSp)
     call register_restarts_dyn_split_RK2(HI, GV, US, param_file, &
              CS%dyn_split_RK2_CSp, restart_CSp, CS%uh, CS%vh)
   elseif (CS%use_RK2) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3009,7 +3009,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                            diag_form=2, underflow_conc=salin_underflow, Tr_out=CS%tv%tr_S)
     endif
   endif
-  !$omp target enter data map(alloc: CS%h)
 
   if (use_p_surf_in_EOS) allocate(CS%tv%p_surf(isd:ied,jsd:jed), source=0.0)
   if (use_frazil) then

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -106,12 +106,14 @@ subroutine PressureForce_init(Time, G, GV, US, param_file, diag, CS, ADp, SAL_CS
                  "described in Adcroft et al., O. Mod. (2008).", default=.true.)
 
   if (CS%Analytic_FV_PGF) then
+    !$omp target enter data map(alloc: CS%PressureForce_FV)
     call PressureForce_FV_init(Time, G, GV, US, param_file, diag, &
              CS%PressureForce_FV, ADp, SAL_CSp, tides_CSp)
   else
     call PressureForce_Mont_init(Time, G, GV, US, param_file, diag, &
              CS%PressureForce_Mont, SAL_CSp, tides_CSp)
   endif
+  !$omp target update to(CS)
 end subroutine PressureForce_init
 
 !> \namespace mom_pressureforce

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -2319,6 +2319,8 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, ADp, SAL
   CS%GFS_scale = 1.0
   if (GV%g_prime(1) /= GV%g_Earth) CS%GFS_scale = GV%g_prime(1) / GV%g_Earth
 
+  !$omp target update to (CS)
+
   call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale, units="nondim")
 
 end subroutine PressureForce_FV_init

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3649,7 +3649,6 @@ subroutine set_dtbt(G, GV, US, CS, pbce, gtot_est, BT_cont, eta, SSH_add)
     call chksum0(CS%dtbt, "End set_dtbt dtbt", unscale=US%T_to_s)
     call chksum0(CS%dtbt_max, "End set_dtbt dtbt_max", unscale=US%T_to_s)
   endif
-
 end subroutine set_dtbt
 
 ! The following 5 subroutines apply the open boundary conditions.
@@ -6044,20 +6043,6 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
     do k=1,GV%ke ; gtot_estimate = gtot_estimate + H_to_Z*GV%g_prime(K) ; enddo
   endif
 
-  ! CS%dtbt calculated here by set_dtbt is only used when dtbt is not reset during the run, i.e. DTBT_RESET_PERIOD<0.
-  call set_dtbt(G, GV, US, CS, gtot_est=gtot_estimate, SSH_add=SSH_extra)
-
-  if (dtbt_input > 0.0) then
-    CS%dtbt = US%s_to_T * dtbt_input
-  elseif (dtbt_restart > 0.0) then
-    CS%dtbt = dtbt_restart
-  endif
-
-  calc_dtbt = .true. ; if ((dtbt_restart > 0.0) .and. (dtbt_input > 0.0)) calc_dtbt = .false.
-
-  call log_param(param_file, mdl, "DTBT as used", CS%dtbt, units="s", unscale=US%T_to_s)
-  call log_param(param_file, mdl, "estimated maximum DTBT", CS%dtbt_max, units="s", unscale=US%T_to_s)
-
   ! ubtav and vbtav, and perhaps ubt_IC and vbt_IC, are allocated and
   ! initialized in register_barotropic_restarts.
 
@@ -6205,9 +6190,24 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
     endif
   endif
 
-  !$omp target enter data map(to: CS)
-  !$omp target enter data map(to: CS%frhatu, CS%frhatv)
-  !$omp target enter data map(to: CS%eta_cor)
+  !$omp target update to (CS)
+
+  ! CS%dtbt calculated here by set_dtbt is only used when dtbt is not reset during the run, i.e. DTBT_RESET_PERIOD<0.
+  !$omp target enter data map (to: CS%frhatu, CS%frhatv)
+  !$omp target enter data map (to: CS%eta_cor)
+  call set_dtbt(G, GV, US, CS, gtot_est=gtot_estimate, SSH_add=SSH_extra)
+
+  if (dtbt_input > 0.0) then
+    CS%dtbt = US%s_to_T * dtbt_input
+  elseif (dtbt_restart > 0.0) then
+    CS%dtbt = dtbt_restart
+  endif
+  !$omp target update to (CS%dtbt)
+
+  calc_dtbt = .true. ; if ((dtbt_restart > 0.0) .and. (dtbt_input > 0.0)) calc_dtbt = .false.
+
+  call log_param(param_file, mdl, "DTBT as used", CS%dtbt, units="s", unscale=US%T_to_s)
+  call log_param(param_file, mdl, "estimated maximum DTBT", CS%dtbt_max, units="s", unscale=US%T_to_s)
 
   if (CS%id_frhatu1 > 0) allocate(CS%frhatu1(IsdB:IedB,jsd:jed,nz), source=0.)
   if (CS%id_frhatv1 > 0) allocate(CS%frhatv1(isd:ied,JsdB:JedB,nz), source=0.)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1640,12 +1640,14 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   else
     HA_CSp => NULL()
   endif
+
+  !$omp target enter data map(alloc: CS%PressureForce_CSp)
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
-  !$omp target enter data map(to: CS%PressureForce_CSp)
 
-  !$omp target enter data map(to: CS%hor_visc)
+  !$omp target enter data map(alloc: CS%hor_visc)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)
+
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp, CS%fpmix)
   CS%set_visc_CSp => set_visc
@@ -1676,6 +1678,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   ! Copy eta into an output array.
   do j=js,je ; do i=is,ie ; eta(i,j) = CS%eta(i,j) ; enddo ; enddo
 
+  !$omp target enter data map (alloc: CS%barotropic_CSp)
   call barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, &
                        CS%barotropic_CSp, restart_CS, calc_dtbt, CS%BT_cont, &
                        CS%OBC, CS%SAL_CSp, HA_CSp)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -576,15 +576,18 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
 ! u_bc_accel = CAu + PFu + diffu(u[n-1])
   call cpu_clock_begin(id_clock_btforce)
-  !$OMP parallel do default(shared)
+
   do k=1,nz
-    do j=js,je ; do I=Isq,Ieq
+    do concurrent (j=js:je, I=Isq:Ieq)
       u_bc_accel(I,j,k) = (CS%CAu_pred(I,j,k) + CS%PFu(I,j,k)) + CS%diffu(I,j,k)
-    enddo ; enddo
-    do J=Jsq,Jeq ; do i=is,ie
+    enddo
+    do concurrent (J=Jsq:Jeq, i=is:ie)
       v_bc_accel(i,J,k) = (CS%CAv_pred(i,J,k) + CS%PFv(i,J,k)) + CS%diffv(i,J,k)
-    enddo ; enddo
+    enddo
   enddo
+  ! TODO: Keep on GPU, don't copy back
+  !$omp target update from (u_bc_accel, v_bc_accel)
+
   if (associated(CS%OBC)) then
     call open_boundary_zero_normal_flow(CS%OBC, G, GV, u_bc_accel, v_bc_accel)
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1284,7 +1284,7 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_C
   type(verticalGrid_type),       intent(in)    :: GV         !< ocean vertical grid structure
   type(unit_scale_type),         intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),         intent(in)    :: param_file !< parameter file
-  type(MOM_dyn_split_RK2_CS),    pointer       :: CS         !< module control structure
+  type(MOM_dyn_split_RK2_CS),    intent(inout) :: CS         !< module control structure
   type(MOM_restart_CS),          intent(inout) :: restart_CS !< MOM restart control structure
   real, dimension(SZIB_(HI),SZJ_(HI),SZK_(GV)), &
                          target, intent(inout) :: uh !< zonal volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
@@ -1299,14 +1299,6 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_C
 
   isd  = HI%isd  ; ied  = HI%ied  ; jsd  = HI%jsd  ; jed  = HI%jed ; nz = GV%ke
   IsdB = HI%IsdB ; IedB = HI%IedB ; JsdB = HI%JsdB ; JedB = HI%JedB
-
-  ! This is where a control structure specific to this module would be allocated.
-  if (associated(CS)) then
-    call MOM_error(WARNING, "register_restarts_dyn_split_RK2 called with an associated "// &
-                             "control structure.")
-    return
-  endif
-  allocate(CS)
 
   ! TODO: Are these initializations necessary?  If not, then we can do
   !   map(alloc:) rather than map(to:)

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -596,16 +596,11 @@ subroutine allocate_metrics(G)
   allocate(G%gridLonB(G%IsgB:G%IegB), source=0.0)
   allocate(G%gridLatT(jsg:jeg), source=0.0)
   allocate(G%gridLatB(G%JsgB:G%JegB), source=0.0)
-
-  !$omp target enter data map(to: G, G%Coriolis2Bu)
-
 end subroutine allocate_metrics
 
 !> Release memory used by the ocean_grid_type and related structures.
 subroutine MOM_grid_end(G)
   type(ocean_grid_type), intent(inout) :: G !< The horizontal grid type
-
-  !$omp target exit data map(release: G, G%Coriolis2Bu)
 
   deallocate(G%Block)
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2876,6 +2876,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       "LAPLACIAN or BIHARMONIC viscosity.")
     return ! We are not using either Laplacian or Bi-harmonic lateral viscosity
   endif
+
+  !$omp target update to(CS)
+
   deg2rad = atan(1.0) / 45.
   ALLOC_(CS%dx2h(isd:ied,jsd:jed))        ; CS%dx2h(:,:)    = 0.0
   ALLOC_(CS%dy2h(isd:ied,jsd:jed))        ; CS%dy2h(:,:)    = 0.0


### PR DESCRIPTION
This PR contains a few changes to possibly streamline the handling of CS allocations on GPUs.  It follows with a porting of one of the early (if not first) do-loops to GPU in the RK2 dycore.

The general pattern is like this:
```
allocate(CS%component)
call component_init(CS%component, ...)

inside component_init(CS, ...)
! set params
!$omp target update to(CS)
! allocate arrays
!$omp target enter data map(to: CS%arr1, CS%arr2)
```
That is,

1. Allocate CS outside of init function
2. Co-allocate CS on GPU.
3. Set any internal non-allocated data (e.g. scalars, parameters, ...)
4. Update CS to GPU
5. Allocate and set array data
6. Allocate CS array data on GPU and transfer.

This seemed to bring slightly greater stability to the whole CS memory management process, or at least enoug to ensure that the first do-loop in the dycore could be converted to do-concurrent and run on GPU.

Prior to this, any attempt would either cause "partial presence" errors, or overwrite the array values (say from a misplaced `map(to: CS)` or `update to(CS)`.

Also:

* Removed a redundant `map(alloc: h)`

* Gathered the grid GPU allocs with the rest (although perhaps they can all be moved into MOM_grid?)

* This also includes a fix to the debug chksum output in `set_dtbt`.  I don't think it changed solution output, so it must not have been a serious issue.

  But the fix involved moving the set_dtbt output *after* some parameter operations.  It more closely conforms to the proposed pattern of "allocate -> set param -> update CS -> set arrays".