### PR TITLE
port thickness_to_dz_3d to gpu (defensively)

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -620,7 +620,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (CS%debug) then
     call uvchksum("before vertvisc: up", up, vp, G%HI, haloshift=0, symmetric=sym, unscale=US%L_T_to_m_s)
   endif
-  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1, no_update=.true.)
+  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1, do_offload=.true.)
   !$omp target update from(dz)
   call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
   call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
@@ -769,7 +769,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     enddo
   endif
 
-  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1, no_update=.true.)
+  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1, do_offload=.true.)
   !$omp target update from(dz)
   call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt_pred, G, GV, US, CS%vertvisc_CSp, &
                      CS%OBC, VarMix)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -620,7 +620,8 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (CS%debug) then
     call uvchksum("before vertvisc: up", up, vp, G%HI, haloshift=0, symmetric=sym, unscale=US%L_T_to_m_s)
   endif
-  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1, no_update=.true.)
+  !$omp target update from(dz)
   call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
   call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
   call cpu_clock_end(id_clock_vertvisc)
@@ -768,7 +769,8 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     enddo
   endif
 
-  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1, no_update=.true.)
+  !$omp target update from(dz)
   call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt_pred, G, GV, US, CS%vertvisc_CSp, &
                      CS%OBC, VarMix)
 

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -852,7 +852,7 @@ end subroutine dz_to_thickness_simple
 !> Converts layer thicknesses in thickness units to the vertical distance between edges in height
 !! units, perhaps by multiplication by the precomputed layer-mean specific volume stored in an
 !! array in the thermo_var_ptrs type when in non-Boussinesq mode.
-subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size, no_update)
+subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size, do_offload)
   type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV !< The ocean's vertical grid structure
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
@@ -866,21 +866,16 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size, no_update)
                                                !! inout to preserve any initialized values in halo points.
   integer,       optional, intent(in)    :: halo_size !< Width of halo within which to
                                                !! calculate thicknesses
-  logical,       optional, intent(in)    :: no_update !< Flag that, if .true., only uses data
-                                               !! already on GPU and doesn't update CPU result.
+  logical,       optional, intent(in)    :: do_offload !< If .true., only uses data calculates dz
+                                               !! on GPU (default .false.)
   ! Local variables
   character(len=128) :: mesg    ! A string for error messages
   integer :: i, j, k, is, ie, js, je, halo, nz
-  logical :: do_update
+  logical :: use_doconcurrent
 
-  ! temporary guard to allow turning off update to minimize transfers
-  do_update = .true.
-  if (present(no_update)) do_update = .not.no_update
-
-  !$omp target update to(h) if(do_update)
-
-  ! if h, dz already on GPU, does nothing; otherwise initializes them on GPU
-  !$omp target enter data map(to: h) map(alloc: dz)
+  ! guard to allow turning off/on do concurrent
+  use_doconcurrent = .false.
+  if (present(do_offload)) use_doconcurrent = do_offload
 
   halo = 0 ; if (present(halo_size)) halo = max(0,halo_size)
   is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo ; nz = GV%ke
@@ -895,21 +890,26 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size, no_update)
       endif
       call MOM_error(FATAL, "thickness_to_dz called in fully non-Boussinesq mode with "//trim(mesg))
     endif
-    !$omp target update to(tv%SpV_avg) if(do_update)
-    !$omp target enter data map(to: tv, tv%SpV_avg)
-    do concurrent (k=1:nz, j=js:je, i=is:ie)
-      dz(i,j,k) = GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
-    enddo
-    !$omp target exit data map(release: tv, tv%SpV_avg)
+    if (use_doconcurrent) then
+      do concurrent (k=1:nz, j=js:je, i=is:ie)
+        dz(i,j,k) = GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
+      enddo
+    else
+      do k=1,nz ; do j=js,je ; do i=is,ie
+        dz(i,j,k) = GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
+      enddo ; enddo ; enddo
+    endif        
   else
-    do concurrent (k=1:nz, j=js:je, i=is:ie)
-      dz(i,j,k) = GV%H_to_Z * h(i,j,k)
-    enddo
+    if (use_doconcurrent) then
+      do concurrent (k=1:nz, j=js:je, i=is:ie)
+        dz(i,j,k) = GV%H_to_Z * h(i,j,k)
+      enddo
+    else
+      do k=1,nz ; do j=js,je ; do i=is,ie
+        dz(i,j,k) = GV%H_to_Z * h(i,j,k)
+      enddo ; enddo ; enddo
+    endif
   endif
-
-  !$omp target exit data map(release: h) map(from: dz)
-
-  !$omp target update from(dz) if(do_update)
 
 end subroutine thickness_to_dz_3d
 

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -866,7 +866,8 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size, no_update)
                                                !! inout to preserve any initialized values in halo points.
   integer,       optional, intent(in)    :: halo_size !< Width of halo within which to
                                                !! calculate thicknesses
-  logical,       optional, intent(in)    :: no_update
+  logical,       optional, intent(in)    :: no_update !< Flag that, if .true., only uses data
+                                               !! already on GPU and doesn't update CPU result.
   ! Local variables
   character(len=128) :: mesg    ! A string for error messages
   integer :: i, j, k, is, ie, js, je, halo, nz

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -898,7 +898,7 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size, do_offload)
       do k=1,nz ; do j=js,je ; do i=is,ie
         dz(i,j,k) = GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
       enddo ; enddo ; enddo
-    endif        
+    endif
   else
     if (use_doconcurrent) then
       do concurrent (k=1:nz, j=js:je, i=is:ie)

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -852,7 +852,7 @@ end subroutine dz_to_thickness_simple
 !> Converts layer thicknesses in thickness units to the vertical distance between edges in height
 !! units, perhaps by multiplication by the precomputed layer-mean specific volume stored in an
 !! array in the thermo_var_ptrs type when in non-Boussinesq mode.
-subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size)
+subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size, no_update)
   type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV !< The ocean's vertical grid structure
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
@@ -866,11 +866,20 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size)
                                                !! inout to preserve any initialized values in halo points.
   integer,       optional, intent(in)    :: halo_size !< Width of halo within which to
                                                !! calculate thicknesses
+  logical,       optional, intent(in)    :: no_update
   ! Local variables
   character(len=128) :: mesg    ! A string for error messages
   integer :: i, j, k, is, ie, js, je, halo, nz
+  logical :: do_update
 
-  !$omp target update to(h)
+  ! temporary guard to allow turning off update to minimize transfers
+  do_update = .true.
+  if (present(no_update)) do_update = .not.no_update
+
+  !$omp target update to(h) if(do_update)
+
+  ! if h, dz already on GPU, does nothing; otherwise initializes them on GPU
+  !$omp target enter data map(to: h) map(alloc: dz)
 
   halo = 0 ; if (present(halo_size)) halo = max(0,halo_size)
   is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo ; nz = GV%ke
@@ -885,17 +894,21 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size)
       endif
       call MOM_error(FATAL, "thickness_to_dz called in fully non-Boussinesq mode with "//trim(mesg))
     endif
-    !$omp target update to(tv%SpV_avg)
+    !$omp target update to(tv%SpV_avg) if(do_update)
+    !$omp target enter data map(to: tv, tv%SpV_avg)
     do concurrent (k=1:nz, j=js:je, i=is:ie)
       dz(i,j,k) = GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
     enddo
+    !$omp target exit data map(release: tv, tv%SpV_avg)
   else
     do concurrent (k=1:nz, j=js:je, i=is:ie)
       dz(i,j,k) = GV%H_to_Z * h(i,j,k)
     enddo
   endif
 
-  !$omp target update from(dz)
+  !$omp target exit data map(release: h) map(from: dz)
+
+  !$omp target update from(dz) if(do_update)
 
 end subroutine thickness_to_dz_3d
 

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -870,6 +870,8 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size)
   character(len=128) :: mesg    ! A string for error messages
   integer :: i, j, k, is, ie, js, je, halo, nz
 
+  !$omp target update to(h)
+
   halo = 0 ; if (present(halo_size)) halo = max(0,halo_size)
   is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo ; nz = GV%ke
 
@@ -883,15 +885,17 @@ subroutine thickness_to_dz_3d(h, tv, dz, G, GV, US, halo_size)
       endif
       call MOM_error(FATAL, "thickness_to_dz called in fully non-Boussinesq mode with "//trim(mesg))
     endif
-
-    do k=1,nz ; do j=js,je ; do i=is,ie
+    !$omp target update to(tv%SpV_avg)
+    do concurrent (k=1:nz, j=js:je, i=is:ie)
       dz(i,j,k) = GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
-    enddo ; enddo ; enddo
+    enddo
   else
-    do k=1,nz ; do j=js,je ; do i=is,ie
+    do concurrent (k=1:nz, j=js:je, i=is:ie)
       dz(i,j,k) = GV%H_to_Z * h(i,j,k)
-    enddo ; enddo ; enddo
+    enddo
   endif
+
+  !$omp target update from(dz)
 
 end subroutine thickness_to_dz_3d
 


### PR DESCRIPTION
This converts the loops in `thickness_to_dz_3d` to using `do concurrent`.

This subroutine is used in many places throughout MOM6 (including in parts not in the dyncore), so I've added some maps and updates to make sure it works, while minimize data transfer. 

I've also added an arg to turn off the updates so we can minimize transfers in the dyn core.