### PR TITLE
Vert frict: nk_in_ml reduce locality in v

### DIFF
--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -2904,7 +2904,7 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
           enddo
         enddo
       else
-        do concurrent (j=js:je, i=is:ie, do_i(i,j))
+        do concurrent (j=js:je, i=is:ie, do_i(i,j)) DO_LOCALITY(reduce(max:max_nk))
           nk_in_ml(i,j) = ceiling(visc%nkml_visc_v(i,J))
           max_nk = max(max_nk, nk_in_ml(i,j))
         enddo


### PR DESCRIPTION
This patch adds a missing reduce(max: max_nk) locality modifier to nk_in_ml in the v-direction.

This fixes an openmp regression that was detected in ifx 2025.2.