### PR TITLE
offload pass_uta_uhbta

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1969,7 +1969,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     call start_group_pass(CS%pass_ubta_uhbta, G%DoMain)
     !$omp target update to(e_anom)
   else
-    call do_group_pass(CS%pass_ubta_uhbta, G%Domain)
+    call do_group_pass(CS%pass_ubta_uhbta, G%Domain, omp_offload=.true.)
   endif
   if (id_clock_pass_post > 0) call cpu_clock_end(id_clock_pass_post)
   if (id_clock_calc_post > 0) call cpu_clock_begin(id_clock_calc_post)


### PR DESCRIPTION
This covers the remaining a `do_group_pass` that didn't have `ompoffload=.true.`. Multi-gpu seems to work now.