### PR TITLE
Barotropic: frhat[uv] HYBRID repro fix

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4542,14 +4542,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
             CS%frhatu(I,j,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
-      enddo
-    enddo
-    !$omp end target data
-    do concurrent (j=js:je, I=is-1:ie)
-      do k=1,nz
         hatutot(I,j) = hatutot(I,j) + CS%frhatu(I,j,k)
       enddo
     enddo
+    !$omp end target data
   elseif (CS%hvel_scheme == HARMONIC) then
     !   Interpolates thicknesses onto u grid points with the
     ! second order accurate estimate h = 2*(h+ * h-)/(h+ + h-).
@@ -4647,14 +4643,10 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
             CS%frhatv(i,J,k) = wt_arith*h_arith + (1.0-wt_arith)*h_harm
           endif
         endif
-      enddo
-    enddo
-    !$omp end target data
-    do concurrent (J=js-1:je, i=is:ie)
-      do k=1,nz
         hatvtot(i,J) = hatvtot(i,J) + CS%frhatv(i,J,k)
       enddo
     enddo
+    !$omp end target data
   elseif (CS%hvel_scheme == HARMONIC) then
     do concurrent (k=1:nz, J=js-1:je, i=is:ie)
       CS%frhatv(i,J,k) = 2.0*(h(i,j+1,k) * h(i,j,k)) / &


### PR DESCRIPTION
This patch fixes a minor bit reproducibility regression in the calculation of `hat[uv]tot` and, consequently, `frhat[uv]` in the ifort compiler.

Currently, the `hat[uv]tot` loops were moved to separate loops.  This patch moves `hat[uv]tot` back into the principal `frhat[uv]` (or in this case, `hat[uv]`) loop.

There may be performance consequences to this, I have not yet investigated.

This was notably subtle, since many tests only call `btcalc()` once without the BTCONT `h_[uv]` inputs, was only observed in `frhatu`, and did not actually change solution answers.  Nonetheless, this is a genuine answer change in an actively used solver, so we want to preserve bit repro until discussed and approved by the consortium.

Although I can't see exactly the reason for the diff, it seems possible that Intel has added a reduction-like optimization, even at `-O0`.  It also may not have occurred in production compilations with `-fp-model` flags.