### PR TITLE
Bbl cleanup almost step

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -843,9 +843,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
   rel_time = 0.0
 
+  !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
   do n=1,n_max
-    !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
-
     if (CS%use_diabatic_time_bug) then
       ! This wrong form of update was used until Feb 2018, recovered with CS%use_diabatic_time_bug=T.
       CS%Time = Time_start + real_to_time(US%T_to_s*int(floor(rel_time+0.5*dt+0.5)))
@@ -1089,10 +1088,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     if (do_dyn .and. .not.CS%count_calls) CS%nstep_tot = CS%nstep_tot + 1
     if (showCallTree) call callTree_leave("DT cycles (step_MOM)")
-
-    !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
-
-  enddo ! complete the n loop
+  enddo
+  !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
 
   if (CS%count_calls .and. cycle_start) CS%nstep_tot = CS%nstep_tot + 1
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -633,6 +633,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   call cpu_clock_begin(id_clock_other)
 
   if (CS%debug) then
+    !$omp target update from(u, v, h)
     call query_debugging_checks(do_redundant=debug_redundant)
     call MOM_state_chksum("Beginning of step_MOM ", u, v, h, CS%uh, CS%vh, G, GV, US)
   endif
@@ -738,6 +739,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       do j=jsd,jed ; do i=isd,ied ; CS%tv%p_surf(i,j) = forces%p_surf(i,j) ; enddo ; enddo
 
       if (allocated(CS%tv%SpV_avg) .and. associated(CS%tv%T)) then
+        !$omp target update from(h)
         ! The internal ocean state depends on the surface pressues, so update SpV_avg.
         dynamics_stencil = min(3, G%Domain%nihalo, G%Domain%njhalo)
         call calc_derived_thermo(CS%tv, h, G, GV, US, halo=dynamics_stencil, debug=CS%debug)
@@ -762,6 +764,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     if (associated(CS%tv%p_surf) .and. associated(fluxes%p_surf)) then
       do j=js,je ; do i=is,ie ; CS%tv%p_surf(i,j) = fluxes%p_surf(i,j) ; enddo ; enddo
       if (allocated(CS%tv%SpV_avg)) then
+        !$omp target update from(h)
         call pass_var(CS%tv%p_surf, G%Domain, clock=id_clock_pass)
         ! The internal ocean state depends on the surface pressues, so update SpV_avg.
         call extract_diabatic_member(CS%diabatic_CSp, diabatic_halo=halo_sz)
@@ -787,6 +790,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     do j=js,je ; do i=is,ie ; CS%ssh_rint(i,j) = 0.0 ; enddo ; enddo
 
     if (CS%VarMix%use_variable_mixing) then
+      !$omp target update from(h)
       call enable_averages(cycle_time, Time_start + real_to_time(US%T_to_s*cycle_time), CS%diag)
       call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, CS%OBC, dt)
       call calc_depth_function(G, CS%VarMix)
@@ -823,6 +827,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif
   else ! not do_dyn.
     if (CS%UseWaves) then ! Diagnostics are not enabled in this call.
+      !$omp target update from(h)
       call find_ustar(fluxes, CS%tv, U_star, G, GV, US, halo=1)
       call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=1)
       call Update_Stokes_Drift(G, GV, US, Waves, dz, U_star, time_interval, do_dyn)
@@ -830,6 +835,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   endif
 
   if (CS%debug) then
+    !$omp target update from(u, v, h)
     if (cycle_start) &
       call MOM_state_chksum("Before steps ", u, v, h, CS%uh, CS%vh, G, GV, US)
     if (cycle_start .and. debug_redundant) &
@@ -843,7 +849,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
   rel_time = 0.0
 
-  !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
+  ! TODO: This appears safe to remove but needs verification.
+  !**!$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
+
   do n=1,n_max
     if (CS%use_diabatic_time_bug) then
       ! This wrong form of update was used until Feb 2018, recovered with CS%use_diabatic_time_bug=T.
@@ -867,8 +875,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     !===========================================================================
     ! This is the first place where the diabatic processes and remapping could occur.
     if (CS%diabatic_first .and. (CS%t_dyn_rel_adv==0.0) .and. do_thermo) then ! do thermodynamics.
-      !$omp target update from(u, v, h)
-
       if (.not.do_dyn) then
         dtdia = dt
       elseif (thermo_does_span_coupling) then
@@ -901,9 +907,17 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ! Apply diabatic forcing, do mixing, and regrid.
       call step_MOM_thermo(CS, G, GV, US, u, v, h, CS%tv, fluxes, dtdia, &
                            end_time_thermo, .true., Waves=Waves)
-      if ( CS%use_ALE_algorithm ) &
+
+      if ( CS%use_ALE_algorithm ) then
+        !$omp target update from(u, v, h)
         call ALE_regridding_and_remapping(CS, G, GV, US, u, v, h, CS%tv, dtdia, Time_local)
+        !$omp target update to(u, v, h)
+      endif
+
+      !$omp target update from(u, v, h)
       call post_diabatic_halo_updates(CS, G, GV, US, u, v, h, CS%tv)
+      !$omp target update to(u, v, h)
+
       CS%time_in_thermo_cycle = CS%time_in_thermo_cycle + dtdia
 
       ! The diabatic processes are now ahead of the dynamics by dtdia.
@@ -914,7 +928,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
         ! This step was missing prior to Feb 2018, recovered with CS%use_diabatic_time_bug=T.
         CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
 
-      !$omp target update to(u, v, h)
     endif ! end of block "(CS%diabatic_first .and. (CS%t_dyn_rel_adv==0.0))"
 
     if (do_dyn) then
@@ -1006,7 +1019,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif
 
     if ((CS%t_dyn_rel_adv==0.0) .and. (.not.CS%diabatic_first) .and. do_diabatic) then
-      !$omp target update from(u, v, h)
       dtdia = CS%t_dyn_rel_thermo
       ! If the MOM6 dynamic and thermodynamic time stepping is being orchestrated
       ! by the coupler, the value of diabatic_first does not matter.
@@ -1027,9 +1039,17 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ! Apply diabatic forcing, do mixing, and regrid.
       call step_MOM_thermo(CS, G, GV, US, u, v, h, CS%tv, fluxes, dtdia, &
                            Time_local, .false., Waves=Waves)
-      if ( CS%use_ALE_algorithm ) &
+
+      if ( CS%use_ALE_algorithm ) then
+        !$omp target update from(u, v, h)
         call ALE_regridding_and_remapping(CS, G, GV, US, u, v, h, CS%tv, dtdia, Time_local)
+        !$omp target update to(u, v, h)
+      endif
+
+      !$omp target update from(u, v, h)
       call post_diabatic_halo_updates(CS, G, GV, US, u, v, h, CS%tv)
+      !$omp target update to(u, v, h)
+
       CS%time_in_thermo_cycle = CS%time_in_thermo_cycle + dtdia
 
       if ((CS%t_dyn_rel_thermo==0.0) .and. .not.do_dyn) then
@@ -1043,8 +1063,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ! This step was missing prior to Feb 2018, and is skipped with CS%use_diabatic_time_bug=T.
       if (dtdia > dt .and. .not. CS%use_diabatic_time_bug) &
         CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
-
-      !$omp target update to(u, v, h)
     endif
 
     if (do_dyn) then
@@ -1089,7 +1107,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     if (do_dyn .and. .not.CS%count_calls) CS%nstep_tot = CS%nstep_tot + 1
     if (showCallTree) call callTree_leave("DT cycles (step_MOM)")
   enddo
-  !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
+
+  ! TODO: This appears safe to remove but needs verification.
+  !**!$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
 
   if (CS%count_calls .and. cycle_start) CS%nstep_tot = CS%nstep_tot + 1
 
@@ -1161,11 +1181,12 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     call accumulate_net_input(fluxes, sfc_state, CS%tv, fluxes%dt_buoy_accum, &
                               G, US, CS%sum_output_CSp)
 
-  if (MOM_state_is_synchronized(CS)) &
+  if (MOM_state_is_synchronized(CS)) then
+    !$omp target update from(u, v, h)
     call write_energy(CS%u, CS%v, CS%h, CS%tv, Time_local, CS%nstep_tot, &
                       G, GV, US, CS%sum_output_CSp, CS%tracer_flow_CSp, &
                       dt_forcing=real_to_time(US%T_to_s*time_interval) )
-
+  endif
   call cpu_clock_end(id_clock_other)
 
   ! De-rotate fluxes and copy back to the input, since they can be changed.
@@ -1740,7 +1761,6 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
       !$omp target update to(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV)
       !$omp target update to(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV)
     endif
-    !$omp target update to(u, v, h)
     call set_viscous_BBL(u, v, h, tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
     call cpu_clock_end(id_clock_BBL_visc)
     if (showCallTree) call callTree_wayPoint("done with set_viscous_BBL (step_MOM_thermo)")
@@ -1768,8 +1788,10 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
 
     call cpu_clock_begin(id_clock_diabatic)
 
+    !$omp target update from(u, v, h)
     call diabatic(u, v, h, tv, CS%Hml, fluxes, CS%visc, CS%ADp, CS%CDp, dtdia, &
                   Time_end_thermo, G, GV, US, CS%diabatic_CSp, CS%stoch_CS, CS%OBC, Waves)
+    !$omp target update to (u,v,h)
     fluxes%fluxes_used = .true.
 
     if (CS%stoch_CS%do_skeb) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -969,6 +969,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_tradv_here, bbl_time_int, CS, &
                              Time_local, Waves=Waves)
+      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
       !$omp target exit data map(release: dt)
 
       !===========================================================================
@@ -1292,8 +1293,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     call cpu_clock_begin(id_clock_BBL_visc)
     call set_viscous_BBL(CS%u, CS%v, CS%h, CS%tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
     call cpu_clock_end(id_clock_BBL_visc)
-    !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
-    !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
     if (showCallTree) call callTree_wayPoint("done with set_viscous_BBL (step_MOM)")
     call disable_averaging(CS%diag)
   endif
@@ -1326,6 +1325,8 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
 
     if (CS%use_alt_split) then
       !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
+      !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+      !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
       call step_MOM_dyn_split_RK2b(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                   CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2b_CSp, calc_dtbt, CS%VarMix, &
@@ -1351,6 +1352,8 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
 
     if (CS%use_RK2) then
       !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
+      !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+      !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
       call step_MOM_dyn_unsplit_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_RK2_CSp, CS%VarMix, CS%MEKE, CS%pbv, &
@@ -1358,6 +1361,8 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
       !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
     else
       !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
+      !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+      !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
       call step_MOM_dyn_unsplit(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_CSp, CS%VarMix, CS%MEKE, CS%pbv, &
@@ -1471,17 +1476,19 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     endif
   endif
 
-  !$omp target update from(u, v, h)
-  !$omp target update from(CS%uhtr, CS%vhtr)
-
   ! Whenever thickness changes let the diag manager know, target grids
   ! for vertical remapping may need to be regenerated.
   call diag_update_remap_grids(CS%diag)
 
   if (CS%useMEKE .and. CS%MEKE_in_dynamics) then
+    !$omp target update from(u, v, h)
+    !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+    !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
+    ! TODO: visc? [uv]h?
     call step_forward_MEKE(CS%MEKE, h, CS%VarMix%SN_u, CS%VarMix%SN_v, &
                            CS%visc, dt, G, GV, US, CS%MEKE_CSp, CS%uhtr, CS%vhtr, &
                            CS%u, CS%v, CS%tv, Time_local)
+    !$omp target update to(u, v)
   endif
   call disable_averaging(CS%diag)
 
@@ -1489,7 +1496,8 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
   CS%t_dyn_rel_adv = CS%t_dyn_rel_adv + dt
 
   if (CS%use_particles .and. CS%do_dynamics .and. CS%use_uh_particles) then
-    !Run particles using thickness-weighted velocity
+    !$omp target update to(h, CS%uhtr, CS%vhtr)
+    ! Run particles using thickness-weighted velocity
     call particles_run(CS%particles, Time_local, CS%uhtr, CS%vhtr, CS%h, &
         CS%tv, CS%t_dyn_rel_adv, CS%use_uh_particles)
   endif
@@ -1507,16 +1515,33 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
 
   call cpu_clock_end(id_clock_dynamics)
 
-  call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)
-  call enable_averages(dt, Time_local, CS%diag)
-  ! These diagnostics are available after every time dynamics step.
-  if (IDs%id_u > 0) call post_data(IDs%id_u, u, CS%diag)
-  if (IDs%id_v > 0) call post_data(IDs%id_v, v, CS%diag)
-  if (IDs%id_h > 0) call post_data(IDs%id_h, h, CS%diag)
-  if (CS%use_stochastic_EOS) call post_stoch_EOS_diags(CS%stoch_eos_CS, CS%tv, CS%diag)
-  call disable_averaging(CS%diag)
-  call cpu_clock_end(id_clock_diagnostics) ; call cpu_clock_end(id_clock_other)
+  ! Diagnostic finalization
 
+  call cpu_clock_begin(id_clock_other)
+  call cpu_clock_begin(id_clock_diagnostics)
+
+  call enable_averages(dt, Time_local, CS%diag)
+
+  ! These diagnostics are available after every time dynamics step.
+  if (IDs%id_u > 0) then
+    !$omp target update from(u)
+    call post_data(IDs%id_u, u, CS%diag)
+  endif
+  if (IDs%id_v > 0) then
+    !$omp target update from(v)
+    call post_data(IDs%id_v, v, CS%diag)
+  endif
+  if (IDs%id_h > 0) then
+    !$omp target update from(h)
+    call post_data(IDs%id_h, h, CS%diag)
+  endif
+
+  if (CS%use_stochastic_EOS) call post_stoch_EOS_diags(CS%stoch_eos_CS, CS%tv, CS%diag)
+
+  call disable_averaging(CS%diag)
+
+  call cpu_clock_end(id_clock_diagnostics)
+  call cpu_clock_end(id_clock_other)
 end subroutine step_MOM_dynamics
 
 !> step_MOM_tracer_dyn does tracer advection and lateral diffusion, bringing the
@@ -1721,6 +1746,8 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
 
     call cpu_clock_begin(id_clock_diabatic)
 
+    !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+    !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
     call diabatic(u, v, h, tv, CS%Hml, fluxes, CS%visc, CS%ADp, CS%CDp, dtdia, &
                   Time_end_thermo, G, GV, US, CS%diabatic_CSp, CS%stoch_CS, CS%OBC, Waves)
     fluxes%fluxes_used = .true.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -790,7 +790,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     do j=js,je ; do i=is,ie ; CS%ssh_rint(i,j) = 0.0 ; enddo ; enddo
 
     if (CS%VarMix%use_variable_mixing) then
-      !$omp target update from(h)
       call enable_averages(cycle_time, Time_start + real_to_time(US%T_to_s*cycle_time), CS%diag)
       call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, CS%OBC, dt)
       call calc_depth_function(G, CS%VarMix)
@@ -914,9 +913,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
         !$omp target update to(u, v, h)
       endif
 
-      !$omp target update from(u, v, h)
+      !!$omp target update from(u, v, h)
       call post_diabatic_halo_updates(CS, G, GV, US, u, v, h, CS%tv)
-      !$omp target update to(u, v, h)
+      !!$omp target update to(u, v, h)
 
       CS%time_in_thermo_cycle = CS%time_in_thermo_cycle + dtdia
 
@@ -1046,9 +1045,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
         !$omp target update to(u, v, h)
       endif
 
-      !$omp target update from(u, v, h)
+      !!$omp target update from(u, v, h)
       call post_diabatic_halo_updates(CS, G, GV, US, u, v, h, CS%tv)
-      !$omp target update to(u, v, h)
+      !!$omp target update to(u, v, h)
 
       CS%time_in_thermo_cycle = CS%time_in_thermo_cycle + dtdia
 
@@ -2077,7 +2076,8 @@ subroutine post_diabatic_halo_updates(CS, G, GV, US, u, v, h, tv)
   if (associated(tv%S)) &
     call create_group_pass(pass_uv_T_S_h, tv%S, G%Domain, halo=dynamics_stencil)
   call create_group_pass(pass_uv_T_S_h, h, G%Domain, halo=dynamics_stencil)
-  call do_group_pass(pass_uv_T_S_h, G%Domain, clock=id_clock_pass)
+  ! TODO: Safe? what about T and S?
+  call do_group_pass(pass_uv_T_S_h, G%Domain, clock=id_clock_pass, omp_offload=.true.)
 
   if ((.not.tv%frazil_was_reset) .and. CS%vertex_shear) call pass_var(tv%frazil, G%Domain, halo=1)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1024,6 +1024,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
         CS%Time = CS%Time - real_to_time(0.5*US%T_to_s*(dtdia-dt))
 
       ! Apply diabatic forcing, do mixing, and regrid.
+      !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+      !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
       call step_MOM_thermo(CS, G, GV, US, u, v, h, CS%tv, fluxes, dtdia, &
                            Time_local, .false., Waves=Waves)
       if ( CS%use_ALE_algorithm ) &
@@ -1738,8 +1740,14 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
       call porous_widths_interface(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
       call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
                       G%Domain, direction=To_ALL+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
+      !$omp target update to(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV)
+      !$omp target update to(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV)
     endif
+    !$omp target update to(u, v, h)
     call set_viscous_BBL(u, v, h, tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
+    !$omp target update from(CS%visc%Ray_u, Cs%visc%Ray_v)
+    !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+    !$omp target update from(CS%visc%Kv_bbl_u, CS%visc%Kv_bbl_v)
     call cpu_clock_end(id_clock_BBL_visc)
     if (showCallTree) call callTree_wayPoint("done with set_viscous_BBL (step_MOM_thermo)")
   endif
@@ -1760,8 +1768,6 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
 
     call cpu_clock_begin(id_clock_diabatic)
 
-    !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
-    !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
     call diabatic(u, v, h, tv, CS%Hml, fluxes, CS%visc, CS%ADp, CS%CDp, dtdia, &
                   Time_end_thermo, G, GV, US, CS%diabatic_CSp, CS%stoch_CS, CS%OBC, Waves)
     fluxes%fluxes_used = .true.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -842,7 +842,10 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   call cpu_clock_end(id_clock_other)
 
   rel_time = 0.0
+
   do n=1,n_max
+    !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
+
     if (CS%use_diabatic_time_bug) then
       ! This wrong form of update was used until Feb 2018, recovered with CS%use_diabatic_time_bug=T.
       CS%Time = Time_start + real_to_time(US%T_to_s*int(floor(rel_time+0.5*dt+0.5)))
@@ -852,6 +855,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ! Set the universally visible time to the middle of the time step.
       CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
     endif
+
     ! Set the local time to the end of the time step.
     Time_local = Time_start + real_to_time(US%T_to_s*rel_time)
 
@@ -864,6 +868,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     !===========================================================================
     ! This is the first place where the diabatic processes and remapping could occur.
     if (CS%diabatic_first .and. (CS%t_dyn_rel_adv==0.0) .and. do_thermo) then ! do thermodynamics.
+      !$omp target update from(u, v, h)
 
       if (.not.do_dyn) then
         dtdia = dt
@@ -909,15 +914,16 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       if (dtdia > dt .and. .not. CS%use_diabatic_time_bug) & ! Reset CS%Time to its previous value.
         ! This step was missing prior to Feb 2018, recovered with CS%use_diabatic_time_bug=T.
         CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
+
+      !$omp target update to(u, v, h)
     endif ! end of block "(CS%diabatic_first .and. (CS%t_dyn_rel_adv==0.0))"
 
     if (do_dyn) then
-      !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
-
       ! Store pre-dynamics thicknesses for proper diagnostic remapping for transports or
       ! advective tendencies.  If there are more than one dynamics steps per advective
       ! step (i.e DT_THERM > DT), this needs to be stored at the first dynamics call.
       if (.not.CS%preadv_h_stored .and. (CS%t_dyn_rel_adv == 0.)) then
+        !$omp target update from(h)
         call diag_copy_diag_to_storage(CS%diag_pre_dyn, h, CS%diag)
         CS%preadv_h_stored = .true.
       endif
@@ -1058,12 +1064,11 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       call cpu_clock_end(id_clock_dynamics)
     endif
 
-    !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
-
     !===========================================================================
     ! Calculate diagnostics at the end of the time step if the state is self-consistent.
     if (MOM_state_is_synchronized(CS)) then
     !### Perhaps this should be if (CS%t_dyn_rel_thermo == 0.0)
+      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
       call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)
       ! Diagnostics that require the complete state to be up-to-date can be calculated.
 
@@ -1082,6 +1087,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     if (do_dyn .and. .not.CS%count_calls) CS%nstep_tot = CS%nstep_tot + 1
     if (showCallTree) call callTree_leave("DT cycles (step_MOM)")
+
+    !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
 
   enddo ! complete the n loop
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1249,6 +1249,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
       call cpu_clock_end(id_clock_thick_diff)
 
       call pass_var(h, G%Domain, clock=id_clock_pass, halo=max(2,CS%cont_stencil))
+
       !$omp target update to(h, CS%uhtr, CS%vhtr)
       if (showCallTree) call callTree_waypoint("finished thickness_diffuse_first (step_MOM)")
     endif
@@ -1404,28 +1405,34 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     enddo; enddo
   endif
 
-  !$omp target update from(u, v, h)
-  !$omp target update from(CS%uhtr, CS%vhtr)
-
   if ((CS%thickness_diffuse .or. CS%interface_filter) .and. &
       .not.CS%thickness_diffuse_first) then
 
     if (CS%debug) call hchksum(h,"Pre-thickness_diffuse h", G%HI, haloshift=0, unscale=GV%H_to_MKS)
 
     if (CS%thickness_diffuse) then
+      !$omp target update from(h, CS%uhtr, CS%vhtr)
       call cpu_clock_begin(id_clock_thick_diff)
+
       if (CS%VarMix%use_variable_mixing) &
         call calc_slope_functions(h, CS%tv, dt, G, GV, US, CS%VarMix, OBC=CS%OBC)
+
       call thickness_diffuse(h, CS%uhtr, CS%vhtr, CS%tv, dt, G, GV, US, &
                              CS%MEKE, CS%VarMix, CS%CDp, CS%thickness_diffuse_CSp, CS%stoch_CS)
 
-      if (CS%debug) call hchksum(h,"Post-thickness_diffuse h", G%HI, haloshift=1, unscale=GV%H_to_MKS)
+      if (CS%debug) &
+        call hchksum(h,"Post-thickness_diffuse h", G%HI, haloshift=1, unscale=GV%H_to_MKS)
+
       call cpu_clock_end(id_clock_thick_diff)
+
       call pass_var(h, G%Domain, clock=id_clock_pass, halo=max(2,CS%cont_stencil))
+      !$omp target update to(h, CS%uhtr, CS%vhtr)
+
       if (showCallTree) call callTree_waypoint("finished thickness_diffuse (step_MOM)")
     endif
 
     if (CS%interface_filter) then
+      !$omp target update from(h, CS%uhtr, CS%vhtr)
       if (allocated(CS%tv%SpV_avg)) call pass_var(CS%tv%SpV_avg, G%Domain, clock=id_clock_pass)
       CS%tv%valid_SpV_halo = min(G%Domain%nihalo, G%Domain%njhalo)
       call cpu_clock_begin(id_clock_int_filter)
@@ -1438,6 +1445,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
       endif
       call cpu_clock_end(id_clock_int_filter)
       call pass_var(h, G%Domain, clock=id_clock_pass, halo=max(2,CS%cont_stencil))
+      !$omp target update to(h, CS%uhtr, CS%vhtr)
       if (showCallTree) call callTree_waypoint("finished interface_filter (step_MOM)")
     endif
   endif
@@ -1449,17 +1457,22 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
       call uvchksum("Pre-mixedlayer_restrat uhtr", &
                     CS%uhtr, CS%vhtr, G%HI, haloshift=0, unscale=GV%H_to_MKS*US%L_to_m**2)
     endif
+    !$omp target update from(h, CS%uhtr, CS%vhtr)
     call cpu_clock_begin(id_clock_ml_restrat)
     call mixedlayer_restrat(h, CS%uhtr, CS%vhtr, CS%tv, forces, dt, CS%visc%MLD, CS%visc%h_ML, &
                             CS%visc%sfc_buoy_flx, CS%VarMix, G, GV, US, CS%mixedlayer_restrat_CSp)
     call cpu_clock_end(id_clock_ml_restrat)
     call pass_var(h, G%Domain, clock=id_clock_pass, halo=max(2,CS%cont_stencil))
+    !$omp target update to(h, CS%uhtr, CS%vhtr)
     if (CS%debug) then
       call hchksum(h,"Post-mixedlayer_restrat h", G%HI, haloshift=1, unscale=GV%H_to_MKS)
       call uvchksum("Post-mixedlayer_restrat [uv]htr", &
                     CS%uhtr, CS%vhtr, G%HI, haloshift=0, unscale=GV%H_to_MKS*US%L_to_m**2)
     endif
   endif
+
+  !$omp target update from(u, v, h)
+  !$omp target update from(CS%uhtr, CS%vhtr)
 
   ! Whenever thickness changes let the diag manager know, target grids
   ! for vertical remapping may need to be regenerated.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -818,6 +818,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif
     if (CS%UseWaves) then
       ! Update wave information, which is presently kept static over each call to step_mom
+      !$omp target update from(h)
       call enable_averages(time_interval, Time_start + real_to_time(US%T_to_s*time_interval), CS%diag)
       call find_ustar(forces, CS%tv, U_star, G, GV, US, halo=1)
       call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=1)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -965,7 +965,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       if (associated(CS%HA_CSp)) call HA_accum_FtF(Time_Local, CS%HA_CSp)
 
       !$omp target enter data map(to: dt)
-      !$omp target update to(u, v, h)
+      !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_tradv_here, bbl_time_int, CS, &
                              Time_local, Waves=Waves)
@@ -1236,8 +1236,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
 
     call enable_averages(dt_tr_adv, Time_local+real_to_time(US%T_to_s*(dt_tr_adv-dt)), CS%diag)
     if (CS%thickness_diffuse) then
-      !$omp target update from(h)
-      ! TODO: CS%[uv]htr is already on host
+      !$omp target update from(h, CS%uhtr, CS%vhtr)
       call cpu_clock_begin(id_clock_thick_diff)
 
       if (CS%VarMix%use_variable_mixing) &
@@ -1330,7 +1329,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
                   CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2b_CSp, calc_dtbt, CS%VarMix, &
                   CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
     else
-      !$omp target update to(CS%uhtr, CS%vhtr)
       call step_MOM_dyn_split_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                   CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2_CSp, calc_dtbt, CS%VarMix, &
@@ -4584,6 +4582,7 @@ subroutine MOM_end(CS)
   ! TODO: debug_truncations deallocation
 
   DEALLOC_(CS%uhtr) ; DEALLOC_(CS%vhtr)
+  !$omp target exit data map(delete: CS%uhtr, CS%vhtr)
 
   if (associated(CS%Hml)) deallocate(CS%Hml)
   if (associated(CS%tv%salt_deficit)) deallocate(CS%tv%salt_deficit)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -912,6 +912,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif ! end of block "(CS%diabatic_first .and. (CS%t_dyn_rel_adv==0.0))"
 
     if (do_dyn) then
+      !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
+
       ! Store pre-dynamics thicknesses for proper diagnostic remapping for transports or
       ! advective tendencies.  If there are more than one dynamics steps per advective
       ! step (i.e DT_THERM > DT), this needs to be stored at the first dynamics call.
@@ -922,6 +924,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       ! The pre-dynamics velocities might be stored for debugging truncations.
       if (associated(CS%u_prev) .and. associated(CS%v_prev)) then
+        !$omp target update from(u, v)
         do k=1,nz ; do j=jsd,jed ; do I=IsdB,IedB
           CS%u_prev(I,j,k) = u(I,j,k)
         enddo ; enddo ; enddo
@@ -964,13 +967,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       if (associated(CS%HA_CSp)) call HA_accum_FtF(Time_Local, CS%HA_CSp)
 
-      !$omp target enter data map(to: dt)
-      !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_tradv_here, bbl_time_int, CS, &
                              Time_local, Waves=Waves)
-      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
-      !$omp target exit data map(release: dt)
 
       !===========================================================================
       ! This is the start of the tracer advection part of the algorithm.
@@ -982,11 +981,15 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       endif
 
       if (do_advection) then ! Do advective transport and lateral tracer mixing.
+        !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
         call step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
         if (CS%diabatic_first .and. abs(CS%t_dyn_rel_thermo) > 1e-6*dt) call MOM_error(FATAL, &
                 "step_MOM: Mismatch between the dynamics and diabatic times "//&
                 "with DIABATIC_FIRST.")
+        !$omp target update to(CS%uhtr, CS%vhtr)
       endif
+
+      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
     endif ! end of (do_dyn)
 
     !===========================================================================

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -988,8 +988,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
                 "with DIABATIC_FIRST.")
         !$omp target update to(CS%uhtr, CS%vhtr)
       endif
-
-      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
     endif ! end of (do_dyn)
 
     !===========================================================================
@@ -999,8 +997,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     else
       do_diabatic = (do_thermo .and. ((MOD(n,ntstep) == 0) .or. (n==n_max)))
     endif
-    if ((CS%t_dyn_rel_adv==0.0) .and. (.not.CS%diabatic_first) .and. do_diabatic) then
 
+    if ((CS%t_dyn_rel_adv==0.0) .and. (.not.CS%diabatic_first) .and. do_diabatic) then
+      !$omp target update from(u, v, h)
       dtdia = CS%t_dyn_rel_thermo
       ! If the MOM6 dynamic and thermodynamic time stepping is being orchestrated
       ! by the coupler, the value of diabatic_first does not matter.
@@ -1037,9 +1036,12 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ! This step was missing prior to Feb 2018, and is skipped with CS%use_diabatic_time_bug=T.
       if (dtdia > dt .and. .not. CS%use_diabatic_time_bug) &
         CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
+
+      !$omp target update to(u, v, h)
     endif
 
     if (do_dyn) then
+      !$omp target update from(h)
       call cpu_clock_begin(id_clock_dynamics)
       ! Determining the time-average sea surface height is part of the algorithm.
       ! This may be eta_av if Boussinesq, or need to be diagnosed if not.
@@ -1055,6 +1057,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       endif
       call cpu_clock_end(id_clock_dynamics)
     endif
+
+    !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
 
     !===========================================================================
     ! Calculate diagnostics at the end of the time step if the state is self-consistent.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -984,11 +984,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       if (associated(CS%HA_CSp)) call HA_accum_FtF(Time_Local, CS%HA_CSp)
 
-      !$omp target enter data map(to: dt)
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_tradv_here, bbl_time_int, CS, &
                              Time_local, Waves=Waves)
-      !$omp target exit data map(release: dt)
 
       !===========================================================================
       ! This is the start of the tracer advection part of the algorithm.
@@ -1000,7 +998,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       endif
 
       if (do_advection) then ! Do advective transport and lateral tracer mixing.
-        !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
+        !$omp target update from(h, CS%uhtr, CS%vhtr)
         call step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
         if (CS%diabatic_first .and. abs(CS%t_dyn_rel_thermo) > 1e-6*dt) call MOM_error(FATAL, &
                 "step_MOM: Mismatch between the dynamics and diabatic times "//&
@@ -1655,9 +1653,13 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
   if (CS%useMEKE .and. (.not. CS%MEKE_in_dynamics)) then
+    !$omp target update from(CS%u, CS%v)
+    !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
+    !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
     call step_forward_MEKE(CS%MEKE, h, CS%VarMix%SN_u, CS%VarMix%SN_v, &
                            CS%visc, CS%t_dyn_rel_adv, G, GV, US, CS%MEKE_CSp, CS%uhtr, CS%vhtr, &
                            CS%u, CS%v, CS%tv, Time_local)
+    !$omp target update to(CS%u, CS%v)
   endif
 
   if (associated(CS%tv%T)) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1324,19 +1324,20 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     endif
 
     if (CS%use_alt_split) then
+      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
       call step_MOM_dyn_split_RK2b(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                   CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2b_CSp, calc_dtbt, CS%VarMix, &
                   CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
+      !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
     else
       call step_MOM_dyn_split_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                   CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2_CSp, calc_dtbt, CS%VarMix, &
                   CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, CS%stoch_CS, waves=waves)
-      !$omp target update from(u, v, h)
-      !$omp target update from(CS%uhtr, CS%vhtr)
       ! TODO: uh, vh, CS%eta_av_bc ?
     endif
+
     if (showCallTree) call callTree_waypoint("finished step_MOM_dyn_split (step_MOM)")
 
   elseif (CS%do_dynamics) then ! ------------------------------------ not SPLIT
@@ -1348,34 +1349,38 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     ! useful for debugging purposes.
 
     if (CS%use_RK2) then
+      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
       call step_MOM_dyn_unsplit_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_RK2_CSp, CS%VarMix, CS%MEKE, CS%pbv, &
                CS%stoch_CS)
+      !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
     else
+      !$omp target update from(u, v, h, CS%uhtr, CS%vhtr)
       call step_MOM_dyn_unsplit(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
                CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_CSp, CS%VarMix, CS%MEKE, CS%pbv, &
                CS%stoch_CS, Waves=Waves)
+      !$omp target update to(u, v, h, CS%uhtr, CS%vhtr)
     endif
-    if (showCallTree) call callTree_waypoint("finished step_MOM_dyn_unsplit (step_MOM)")
 
-  endif ! -------------------------------------------------- end SPLIT
+    if (showCallTree) call callTree_waypoint("finished step_MOM_dyn_unsplit (step_MOM)")
+  endif
 
   if (CS%use_particles .and. CS%do_dynamics .and. (.not. CS%use_uh_particles)) then
     if (CS%thickness_diffuse_first) call MOM_error(WARNING,"particles_run: "//&
       "Thickness_diffuse_first is true and use_uh_particles is false. "//&
       "This is usually a bad combination.")
-    !Run particles using unweighted velocity
+    ! Run particles using unweighted velocity
+    !$omp target update from(u, v, h)
     call particles_run(CS%particles, Time_local, CS%u, CS%v, CS%h, &
                        CS%tv, dt, CS%use_uh_particles)
     call particles_to_z_space(CS%particles, h)
   endif
 
-
-
   ! Update the model's current to reflect wind-wave growth
   if (Waves%Stokes_DDT .and. (.not.Waves%Passive_Stokes_DDT)) then
+    !$omp target update from(u, v)
     do J=jsq,jeq ; do i=is,ie
       v(i,J,:) = v(i,J,:) + Waves%ddt_us_y(i,J,:)*dt
     enddo; enddo
@@ -1383,6 +1388,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
       u(I,j,:) = u(I,j,:) + Waves%ddt_us_x(I,j,:)*dt
     enddo; enddo
     call pass_vector(u,v,G%Domain)
+    !$omp target update to(u, v)
   endif
   ! Added an additional output to track Stokes drift time tendency.
   ! It is mostly for debugging, and perhaps doesn't need to hang
@@ -1398,6 +1404,8 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     enddo; enddo
   endif
 
+  !$omp target update from(u, v, h)
+  !$omp target update from(CS%uhtr, CS%vhtr)
 
   if ((CS%thickness_diffuse .or. CS%interface_filter) .and. &
       .not.CS%thickness_diffuse_first) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -972,9 +972,11 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       if (associated(CS%HA_CSp)) call HA_accum_FtF(Time_Local, CS%HA_CSp)
 
+      !$omp target enter data map(to: dt)
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_tradv_here, bbl_time_int, CS, &
                              Time_local, Waves=Waves)
+      !$omp target exit data map(release: dt)
 
       !===========================================================================
       ! This is the start of the tracer advection part of the algorithm.
@@ -1023,8 +1025,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
         CS%Time = CS%Time - real_to_time(0.5*US%T_to_s*(dtdia-dt))
 
       ! Apply diabatic forcing, do mixing, and regrid.
-      !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
-      !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
       call step_MOM_thermo(CS, G, GV, US, u, v, h, CS%tv, fluxes, dtdia, &
                            Time_local, .false., Waves=Waves)
       if ( CS%use_ALE_algorithm ) &
@@ -1497,7 +1497,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     !$omp target update from(u, v, h)
     !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
     !$omp target update from(CS%visc%kv_bbl_u, CS%visc%kv_bbl_v)
-    ! TODO: visc? [uv]h?
     call step_forward_MEKE(CS%MEKE, h, CS%VarMix%SN_u, CS%VarMix%SN_v, &
                            CS%visc, dt, G, GV, US, CS%MEKE_CSp, CS%uhtr, CS%vhtr, &
                            CS%u, CS%v, CS%tv, Time_local)
@@ -1734,6 +1733,7 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     call cpu_clock_begin(id_clock_BBL_visc)
     !update porous barrier fractional cell metrics
     if (CS%use_porbar) then
+      !$omp target update from(h)
       call porous_widths_interface(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
       call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
                       G%Domain, direction=To_ALL+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
@@ -1742,15 +1742,18 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     endif
     !$omp target update to(u, v, h)
     call set_viscous_BBL(u, v, h, tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
-    !$omp target update from(CS%visc%Ray_u, Cs%visc%Ray_v)
-    !$omp target update from(CS%visc%bbl_thick_u, CS%visc%bbl_thick_v)
-    !$omp target update from(CS%visc%Kv_bbl_u, CS%visc%Kv_bbl_v)
     call cpu_clock_end(id_clock_BBL_visc)
     if (showCallTree) call callTree_wayPoint("done with set_viscous_BBL (step_MOM_thermo)")
   endif
 
   call cpu_clock_begin(id_clock_thermo)
   if (.not.CS%adiabatic) then
+    !$omp target update from(CS%visc%Ray_u) if (allocated(CS%visc%Ray_u))
+    !$omp target update from(CS%visc%Ray_v) if (allocated(CS%visc%Ray_v))
+    !$omp target update from(CS%visc%bbl_thick_u) if (allocated(CS%visc%bbl_thick_u))
+    !$omp target update from(CS%visc%bbl_thick_v) if (allocated(CS%visc%bbl_thick_v))
+    !$omp target update from(CS%visc%Kv_bbl_u) if (allocated(CS%visc%Kv_bbl_u))
+    !$omp target update from(CS%visc%Kv_bbl_v) if (allocated(CS%visc%Kv_bbl_v))
     if (CS%debug) then
       call uvchksum("Pre-diabatic [uv]", u, v, G%HI, haloshift=2, unscale=US%L_T_to_m_s)
       call hchksum(h,"Pre-diabatic h", G%HI, haloshift=1, unscale=GV%H_to_MKS)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -965,6 +965,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       if (associated(CS%HA_CSp)) call HA_accum_FtF(Time_Local, CS%HA_CSp)
 
       !$omp target enter data map(to: dt)
+      !$omp target update to(u, v, h)
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_tradv_here, bbl_time_int, CS, &
                              Time_local, Waves=Waves)
@@ -1218,9 +1219,11 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
   showCallTree = callTree_showQuery()
 
   call cpu_clock_begin(id_clock_dynamics)
+
   call cpu_clock_begin(id_clock_stoch)
   if (CS%use_stochastic_EOS) call MOM_stoch_eos_run(G, u, v, dt, Time_local, CS%stoch_eos_CS)
   call cpu_clock_end(id_clock_stoch)
+
   call cpu_clock_begin(id_clock_varT)
   if (CS%use_stochastic_EOS) then
     call MOM_calc_varT(G, GV, US, h, CS%tv, CS%stoch_eos_CS, dt)
@@ -1233,18 +1236,26 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
 
     call enable_averages(dt_tr_adv, Time_local+real_to_time(US%T_to_s*(dt_tr_adv-dt)), CS%diag)
     if (CS%thickness_diffuse) then
+      !$omp target update from(h)
+      ! TODO: CS%[uv]htr is already on host
       call cpu_clock_begin(id_clock_thick_diff)
+
       if (CS%VarMix%use_variable_mixing) &
         call calc_slope_functions(h, CS%tv, dt, G, GV, US, CS%VarMix, OBC=CS%OBC)
+
       call thickness_diffuse(h, CS%uhtr, CS%vhtr, CS%tv, dt_tr_adv, G, GV, US, &
                              CS%MEKE, CS%VarMix, CS%CDp, CS%thickness_diffuse_CSp, &
                              CS%stoch_CS)
+
       call cpu_clock_end(id_clock_thick_diff)
+
       call pass_var(h, G%Domain, clock=id_clock_pass, halo=max(2,CS%cont_stencil))
+      !$omp target update to(h, CS%uhtr, CS%vhtr)
       if (showCallTree) call callTree_waypoint("finished thickness_diffuse_first (step_MOM)")
     endif
 
     if (CS%interface_filter) then
+      !$omp target update from(h, CS%uhtr, CS%vhtr)
       if (allocated(CS%tv%SpV_avg)) call pass_var(CS%tv%SpV_avg, G%Domain, clock=id_clock_pass)
       CS%tv%valid_SpV_halo = min(G%Domain%nihalo, G%Domain%njhalo)
       call cpu_clock_begin(id_clock_int_filter)
@@ -1252,6 +1263,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
                             CS%CDp, CS%interface_filter_CSp)
       call cpu_clock_end(id_clock_int_filter)
       call pass_var(h, G%Domain, clock=id_clock_pass, halo=max(2,CS%cont_stencil))
+      !$omp target update to(h, CS%uhtr, CS%vhtr)
       if (showCallTree) call callTree_waypoint("finished interface_filter_first (step_MOM)")
     endif
 
@@ -1263,6 +1275,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
 
   ! Update porous barrier fractional cell metrics
   if (CS%use_porbar) then
+    !$omp target update from(h)
     call enable_averages(dt, Time_local, CS%diag)
     call porous_widths_layer(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
     call disable_averaging(CS%diag)
@@ -1276,7 +1289,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     call enable_averages(bbl_time_int, &
               Time_local + real_to_time(US%T_to_s*(bbl_time_int-dt)), CS%diag)
     ! Calculate the BBL properties and store them inside visc (u,h).
-    !$omp target update to(u, v, h)
     call cpu_clock_begin(id_clock_BBL_visc)
     call set_viscous_BBL(CS%u, CS%v, CS%h, CS%tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
     call cpu_clock_end(id_clock_BBL_visc)
@@ -1318,7 +1330,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
                   CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2b_CSp, calc_dtbt, CS%VarMix, &
                   CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
     else
-      !$omp target update to(u, v, h) if(bbl_time_int<=0.0)
       !$omp target update to(CS%uhtr, CS%vhtr)
       call step_MOM_dyn_split_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -626,8 +626,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   enddo
 
   call enable_averages(dt, Time_local, CS%diag)
+  ! NOTE: this is on CPU and conditionally called (using `if (..) return`)
+  !   It contains GPU/CPU data transfers for [uv]_inst and visc fields.
   call set_viscous_ML(u_inst, v_inst, h, tv, forces, visc, dt, G, GV, US, CS%set_visc_CSp)
-  ! TODO: !$omp target update to(visc%...)
   call disable_averaging(CS%diag)
 
   if (CS%debug) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -262,6 +262,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
          "Module must be initialized before it is used.")
 
   if (CS%calculate_cg1) then
+    !$omp target update from(h)
     if (.not. allocated(CS%cg1)) call MOM_error(FATAL, &
       "calc_resoln_function: %cg1 is not associated with Resoln_scaled_Kh.")
     if (CS%khth_use_ebt_struct .or. CS%kdgl90_use_ebt_struct &
@@ -285,8 +286,10 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
     call create_group_pass(CS%pass_cg1, CS%cg1, G%Domain)
     call do_group_pass(CS%pass_cg1, G%Domain)
   endif
+
   if (CS%BS_use_sqg_struct .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
       .or. CS%kdgl90_use_sqg_struct .or. CS%id_sqg_struct>0) then
+    !$omp target update from(h)
     call calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
     call pass_var(CS%sqg_struct, G%Domain)
   endif
@@ -535,7 +538,6 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
     call uvchksum("Res_fn_[uv]", CS%Res_fn_u, CS%Res_fn_v, G%HI, haloshift=0, &
                   unscale=1.0, scalar_pair=.true.)
   endif
-
 end subroutine calc_resoln_function
 
 !> Calculates and stores functions of SQG mode

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -384,8 +384,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
     mask_u(I,j) = G%mask2dCu(I,j)
   enddo
 
-  !$omp target update from(mask_u, mask_v, D_u, D_v) if(associated(OBC))
   if (associated(OBC)) then
+    !$omp target update from(mask_u, mask_v, D_u, D_v)
     ! Use a one-sided projection of bottom depths at OBC points.
     if (OBC%v_N_OBCs_on_PE) then
       Js_OBC = max(js-1, OBC%Js_v_N_obc) ; Je_OBC = min(je, OBC%Je_v_N_obc)
@@ -423,9 +423,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
         if (OBC%segnum_u(I,j) < 0) D_u(I,j) = G%bathyT(i+1,j) + G%Z_ref !  OBC_DIRECTION_W
       enddo ; enddo
     endif
-  endif
 
-  if (associated(OBC)) then
     do n=1,OBC%number_of_segments
     ! Now project bottom depths across cell-corner points in the OBCs.  The two
     ! projections have to occur in sequence and can not be combined easily.
@@ -450,8 +448,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
       enddo
     endif
     enddo
+    !$omp target update to(mask_u, mask_v, D_u, D_v)
   endif
-  !$omp target update to(mask_u, mask_v, D_u, D_v) if(associated(OBC))
 
   if (.not.use_BBL_EOS) then
     do concurrent (k=1:nz, j=G%jsdB:G%Jedb, i=G%isdB:G%iedB)
@@ -1127,8 +1125,6 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
       endif
     endif ; enddo ; enddo ! end of i & j loops
   enddo ! end of m loop
-  !!$omp target update from(visc%bbl_thick_u, visc%bbl_thick_v)
-  !!$omp target update from(visc%kv_bbl_u, visc%kv_bbl_v)
 
   !$omp target exit data map(release: dz, tv, tv%T, tv%S, S_vel, T_vel, SpV_vel, h_vel, h_at_vel, &
   !$omp   dz_vel, dz_at_vel, Rml, Rml_vel, p_ref, ustar, umag_avg, u2_bg, mask_u, mask_v, &
@@ -1153,17 +1149,22 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
     call post_data(CS%id_Ray_v, visc%Ray_v, CS%diag)
 
   if (CS%debug) then
-    if (allocated(visc%Ray_u) .and. allocated(visc%Ray_v)) &
-        call uvchksum("Ray [uv]", visc%Ray_u, visc%Ray_v, G%HI, haloshift=0, &
-                      unscale=GV%H_to_m*US%s_to_T, scalar_pair=.true.)
-    if (allocated(visc%kv_bbl_u) .and. allocated(visc%kv_bbl_v)) &
-        call uvchksum("kv_bbl_[uv]", visc%kv_bbl_u, visc%kv_bbl_v, G%HI, &
-                      haloshift=0, unscale=GV%HZ_T_to_m2_s, scalar_pair=.true.)
-    if (allocated(visc%bbl_thick_u) .and. allocated(visc%bbl_thick_v)) &
-        call uvchksum("bbl_thick_[uv]", visc%bbl_thick_u, visc%bbl_thick_v, &
-                      G%HI, haloshift=0, unscale=US%Z_to_m, scalar_pair=.true.)
+    if (allocated(visc%Ray_u) .and. allocated(visc%Ray_v)) then
+      !$omp target update from(visc%Ray_u, visc%Ray_v)
+      call uvchksum("Ray [uv]", visc%Ray_u, visc%Ray_v, G%HI, haloshift=0, &
+                    unscale=GV%H_to_m*US%s_to_T, scalar_pair=.true.)
+    endif
+    if (allocated(visc%kv_bbl_u) .and. allocated(visc%kv_bbl_v)) then
+      !$omp target update from(visc%Kv_bbl_u, visc%Kv_bbl_v)
+      call uvchksum("kv_bbl_[uv]", visc%kv_bbl_u, visc%kv_bbl_v, G%HI, &
+                    haloshift=0, unscale=GV%HZ_T_to_m2_s, scalar_pair=.true.)
+    endif
+    if (allocated(visc%bbl_thick_u) .and. allocated(visc%bbl_thick_v)) then
+      !$omp target update from(visc%bbl_thick_u, visc%bbl_thick_v)
+      call uvchksum("bbl_thick_[uv]", visc%bbl_thick_u, visc%bbl_thick_v, &
+                    G%HI, haloshift=0, unscale=US%Z_to_m, scalar_pair=.true.)
+    endif
   endif
-
 end subroutine set_viscous_BBL
 
 !> Determine the normalized open length of each interface, given the edge depths and normalized

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2121,8 +2121,13 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
   if (.not.CS%initialized) call MOM_error(FATAL,"MOM_set_viscosity(visc_ML): "//&
          "Module must be initialized before it is used.")
 
+  ! TODO: Remove this check and move it outside of the function call.
   if (.not.(CS%dynamic_viscous_ML .or. associated(forces%frac_shelf_u) .or. &
             associated(forces%frac_shelf_v)) ) return
+
+  ! NOTE: Requried since this is called by the GPU-enabled dycore, but it could
+  !   also be implicitly fixing other functions.
+  !$omp target update from(u, v)
 
   Rho0x400_G = 400.0*(GV%H_to_RZ / GV%g_Earth_Z_T2)
   cdrag_sqrt = sqrt(CS%cdrag)


### PR DESCRIPTION
This is a draft PR showing possible progress to moving the top-level fields from step_MOM onto GPU.

In principle, it should eliminate all unnecessary data transfers at the top level, although at the moment it is very conservative and does a sync whenever it hits a CPU function, regardless of whether the fields may be up-to-date.

I see no answer changes in double-gyre or benchmark, but I don't think I can guarantee the same on our larger experiments.

I'm not exactly sure how to clock something like this, which blends into some IO and other areas, but the double-gyre runtimes seems roughly unchanged.  Both average to around 5.8s for a 10-day run with the default MOM_override.

I'm flagging this as draft, since there are still a few obvious cleanups, but we can also take as-is if others are OK with it.