### PR TITLE
Allocate MOM CS and both viscosity CS on GPU

### DIFF
--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -279,6 +279,7 @@ program MOM6
 
   ! Call initialize MOM with an optional Ice Shelf CS which, if present triggers
   ! initialization of ice shelf parameters and arrays.
+  !$omp target enter data map(alloc: MOM_CSp)
   if (segment_start_time_set) then
     ! In this case, the segment starts at a time fixed by ocean_solo.res
     Time = segment_start_time
@@ -632,6 +633,7 @@ program MOM6
   call cpu_clock_end(termClock)
 
   call MOM_end(MOM_CSp)
+  !$omp target exit data map(delete: MOM_CSp)
 
   ! This closes out the infrastructure, including clocks, I/O and message passing communicators.
   call io_infra_end() ; call MOM_infra_end()

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -230,7 +230,7 @@ type, public :: MOM_control_struct ; private
   real :: time_in_thermo_cycle !< The running time of the current time-stepping
                     !! cycle in calls that step the thermodynamics [T ~> s].
 
-  type(ocean_grid_type) :: G_in                   !< Input grid metric
+  type(ocean_grid_type), allocatable  :: G_in     !< Input grid metric
   type(ocean_grid_type), pointer :: G => NULL()   !< Model grid metric
   logical :: rotate_index = .false.   !< True if index map is rotated
   logical :: homogenize_forcings = .false. !< True if all inputs are homogenized
@@ -257,7 +257,7 @@ type, public :: MOM_control_struct ; private
                     !! have been stored for use in diagnostics.
 
   type(diag_ctrl)     :: diag !< structure to regulate diagnostic output timing
-  type(vertvisc_type) :: visc !< structure containing vertical viscosities,
+  type(vertvisc_type), allocatable :: visc !< structure containing vertical viscosities,
                     !! bottom drag viscosities, and related fields
   type(MEKE_type) :: MEKE   !< Fields related to the Mesoscale Eddy Kinetic Energy
   logical :: adiabatic !< If true, there are no diapycnal mass fluxes, and no calls
@@ -2942,6 +2942,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 #else
   symmetric = .false.
 #endif
+  allocate(CS%G_in)
   G_in => CS%G_in
 #ifdef STATIC_MEMORY_
   call MOM_domains_init(G_in%domain, param_file, symmetric=symmetric, &
@@ -2990,7 +2991,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   ! Copy the grid metrics and bathymetry to the ocean_grid_type
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)
 
-  !$omp target enter data map(to: G)
+  !$omp target enter data map(to: CS%G_in)
   !$omp target enter data map(to: G%dxT, G%dxCu, G%dxCv, G%dxBu)
   !$omp target enter data map(to: G%dyT, G%dyCu, G%dyCv, G%dyBu)
   !$omp target enter data map(to: G%dx_Cv, G%dy_Cu)
@@ -3059,6 +3060,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call MOM_timing_init(CS)
 
   call tracer_registry_init(param_file, CS%tracer_Reg)
+
+  !$omp target update to(CS)
 
   ! Allocate and initialize space for the primary time-varying MOM variables.
   is   = HI%isc   ; ie   = HI%iec  ; js   = HI%jsc  ; je   = HI%jec ; nz = GV%ke
@@ -3226,8 +3229,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   call MEKE_alloc_register_restart(HI, US, param_file, CS%MEKE, restart_CSp)
 
+  allocate(CS%visc)
   !$omp target enter data map(alloc: CS%visc)
   call set_visc_register_restarts(HI, G, GV, US, param_file, CS%visc, restart_CSp, use_ice_shelf)
+
   call mixedlayer_restrat_register_restarts(HI, GV, US, param_file, &
            CS%mixedlayer_restrat_CSp, restart_CSp)
 
@@ -3653,6 +3658,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                          restart_CSp, CS%MEKE_in_dynamics)
 
   call VarMix_init(Time, G, GV, US, param_file, diag, CS%VarMix)
+  !$omp target enter data map(to: CS%set_visc_CSp)
   call set_visc_init(Time, G, GV, US, param_file, diag, CS%visc, CS%set_visc_CSp, restart_CSp, CS%OBC)
   call thickness_diffuse_init(Time, G, GV, US, param_file, diag, CS%CDp, CS%thickness_diffuse_CSp)
   if (CS%interface_filter) &
@@ -4680,7 +4686,11 @@ subroutine MOM_end(CS)
   call thickness_diffuse_end(CS%thickness_diffuse_CSp, CS%CDp)
   if (CS%interface_filter) call interface_filter_end(CS%interface_filter_CSp, CS%CDp)
   call VarMix_end(CS%VarMix)
+
   call set_visc_end(CS%visc, CS%set_visc_CSp)
+  !$omp target exit data map(delete: CS%visc, CS%set_visc_CSp)
+  deallocate(CS%visc)
+
   call MEKE_end(CS%MEKE)
 
   if (associated(CS%tv%internal_heat)) deallocate(CS%tv%internal_heat)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -3320,6 +3320,8 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
 
   CS%Hbbl = CS%dz_bbl * (US%Z_to_m * GV%m_to_H)  ! Rescaled for use in expressions in thickness units.
 
+  !$omp target update to(CS)
+
   if (CS%RiNo_mix .and. kappa_shear_at_vertex(param_file)) then
     ! This is necessary for reproducibility across restarts in non-symmetric mode.
     call pass_var(visc%Kv_shear_Bu, G%Domain, position=CORNER, complete=.true.)


### PR DESCRIPTION
This patch allocates the top-level MOM control structure (CS) onto the GPU, along with the following:

* vertvisc_type (visc)
* set_visc_CS (set_visc_CSp)

The following control structures are now declared as allocatables

* ocean_grid_type (G_in)
* vertvisc_type (visc)

This change was made to prevent some ambiguous "partial presence" errors with fields on the top-level CS in associated work.

For the issue above, only CS upload and the visc allocation was necessary to prevent partial presence errors.  The declaration of G_in as allocatable was necessary to prevent excessive grid transfers, which was severely degrading performance.

I see a consistent speedup after this change (5.7->5.5s of the dycore) but it may not hold up to scrutiny.

Note that one change here breaks our derived type handling rules: We do an "update(CS)" after the grid has been uploaded.  This does not appear to trigger any errors or undesired data transfers, possibly because of the declaration as allocatable (and perhaps decoupled from the type itself).  But this needs exploration.