### PR TITLE
MOM CS  and find_eta() on GPU

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -490,7 +490,10 @@ subroutine pre_ALE_diagnostics(G, GV, US, h, u, v, tv, CS)
   if (CS%id_T_preale > 0) call post_data(CS%id_T_preale, tv%T, CS%diag)
   if (CS%id_S_preale > 0) call post_data(CS%id_S_preale, tv%S, CS%diag)
   if (CS%id_e_preale > 0) then
+    !$omp target update to(h)
+    !$omp target enter data map(alloc: eta_preale)
     call find_eta(h, tv, G, GV, US, eta_preale, dZref=G%Z_ref)
+    !$omp target exit data map(from: eta_preale)
     call post_data(CS%id_e_preale, eta_preale, CS%diag)
   endif
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -241,7 +241,8 @@ type, public :: MOM_control_struct ; private
     GV => NULL()    !< structure containing vertical grid info
   type(unit_scale_type), pointer :: &
     US => NULL()    !< structure containing various unit conversion factors
-  type(thermo_var_ptrs) :: tv !< structure containing pointers to available thermodynamic fields
+  type(thermo_var_ptrs), allocatable :: tv
+    !< structure containing pointers to available thermodynamic fields
   real :: t_dyn_rel_adv !< The time of the dynamics relative to tracer advection and lateral mixing
                     !! [T ~> s], or equivalently the elapsed time since advectively updating the
                     !! tracers.  t_dyn_rel_adv is invariably positive and may span multiple coupling timesteps.
@@ -257,8 +258,8 @@ type, public :: MOM_control_struct ; private
                     !! have been stored for use in diagnostics.
 
   type(diag_ctrl)     :: diag !< structure to regulate diagnostic output timing
-  type(vertvisc_type), allocatable :: visc !< structure containing vertical viscosities,
-                    !! bottom drag viscosities, and related fields
+  type(vertvisc_type), allocatable :: visc
+    !< structure containing vertical viscosities, bottom drag viscosities, and related fields
   type(MEKE_type) :: MEKE   !< Fields related to the Mesoscale Eddy Kinetic Energy
   logical :: adiabatic !< If true, there are no diapycnal mass fluxes, and no calls
                     !! to routines to calculate or apply diapycnal fluxes.
@@ -336,7 +337,7 @@ type, public :: MOM_control_struct ; private
   real, dimension(:,:), pointer :: frac_shelf_h => NULL() !< fraction of total area occupied
   !! by ice shelf [nondim]
   real, dimension(:,:), pointer :: mass_shelf => NULL() !< Mass of ice shelf [R Z ~> kg m-2]
-  type(accel_diag_ptrs) :: ADp  !< structure containing pointers to accelerations,
+  type(accel_diag_ptrs), allocatable :: ADp  !< structure containing pointers to accelerations,
                                 !! for derived diagnostics (e.g., energy budgets)
   type(cont_diag_ptrs)  :: CDp  !< structure containing pointers to continuity equation
                                 !! terms, for derived diagnostics (e.g., energy budgets)
@@ -422,7 +423,7 @@ type, public :: MOM_control_struct ; private
     !< Pointer to the control structure for the diabatic driver
   type(MEKE_CS) :: MEKE_CSp
     !< Pointer to the control structure for the MEKE updates
-  type(VarMix_CS) :: VarMix
+  type(VarMix_CS), allocatable :: VarMix
     !< Control structure for the variable mixing module
   type(tracer_registry_type),    pointer :: tracer_Reg => NULL()
     !< Pointer to the MOM tracer registry
@@ -796,7 +797,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
   if (cycle_start) then
     CS%time_in_cycle = 0.0
-    do j=js,je ; do i=is,ie ; CS%ssh_rint(i,j) = 0.0 ; enddo ; enddo
+    do concurrent (j=js:je, i=is:ie)
+      CS%ssh_rint(i,j) = 0.
+    enddo
 
     if (CS%VarMix%use_variable_mixing) then
       Time_end_diag = Time_start + real_to_time(cycle_time, unscale=US%T_to_s)
@@ -914,9 +917,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
         !$omp target update to(u, v, h)
       endif
 
-      !!$omp target update from(u, v, h)
       call post_diabatic_halo_updates(CS, G, GV, US, u, v, h, CS%tv)
-      !!$omp target update to(u, v, h)
 
       CS%time_in_thermo_cycle = CS%time_in_thermo_cycle + dtdia
 
@@ -1039,9 +1040,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
         !$omp target update to(u, v, h)
       endif
 
-      !!$omp target update from(u, v, h)
       call post_diabatic_halo_updates(CS, G, GV, US, u, v, h, CS%tv)
-      !!$omp target update to(u, v, h)
 
       CS%time_in_thermo_cycle = CS%time_in_thermo_cycle + dtdia
 
@@ -1058,21 +1057,29 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif
 
     if (do_dyn) then
-      !$omp target update from(h)
+      !$omp target enter data map(alloc: ssh)
+
       call cpu_clock_begin(id_clock_dynamics)
       ! Determining the time-average sea surface height is part of the algorithm.
       ! This may be eta_av if Boussinesq, or need to be diagnosed if not.
       CS%time_in_cycle = CS%time_in_cycle + dt
-      call find_eta(h, CS%tv, G, GV, US, ssh, CS%eta_av_bc, dZref=G%Z_ref)
-      do j=js,je ; do i=is,ie
-        CS%ssh_rint(i,j) = CS%ssh_rint(i,j) + dt*ssh(i,j)
-      enddo ; enddo
+      !$omp target enter data map(to: CS%eta_av_bc)
+      call find_eta(h, CS%tv, G, GV, US, ssh, eta_bt=CS%eta_av_bc, dZref=G%Z_ref)
+      !$omp target exit data map(release: CS%eta_av_bc)
+
+      do concurrent (j=js:je, i=is:ie)
+        CS%ssh_rint(i,j) = CS%ssh_rint(i,j) + dt * ssh(i,j)
+      enddo
+
       if (CS%IDs%id_ssh_inst > 0) then
+        !$omp target update from(ssh)
         call enable_averages(dt, Time_local, CS%diag)
         call post_data(CS%IDs%id_ssh_inst, ssh, CS%diag)
         call disable_averaging(CS%diag)
       endif
       call cpu_clock_end(id_clock_dynamics)
+
+      !$omp target exit data map(delete: ssh)
     endif
 
     !===========================================================================
@@ -1108,12 +1115,20 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   call cpu_clock_begin(id_clock_other)
 
   if (CS%time_in_cycle > 0.0) then
+    !$omp target enter data map(alloc: ssh)
+
     I_wt_ssh = 1.0/CS%time_in_cycle
-    do j=js,je ; do i=is,ie
-      ssh(i,j) = CS%ssh_rint(i,j)*I_wt_ssh
+    do concurrent (j=js:je, i=is:ie)
+      ssh(i,j) = CS%ssh_rint(i,j) * I_wt_ssh
       CS%ave_ssh_ibc(i,j) = ssh(i,j)
-    enddo ; enddo
-    if (associated(CS%HA_CSp)) call HA_accum('ssh', ssh, Time_local, G, CS%HA_CSp)
+    enddo
+    !$omp target update from(CS%ave_ssh_ibc)
+
+    if (associated(CS%HA_CSp)) then
+      !$omp target update from(ssh)
+      call HA_accum('ssh', ssh, Time_local, G, CS%HA_CSp)
+    endif
+
     if (do_dyn) then
       call adjust_ssh_for_p_atm(CS%tv, G, GV, US, CS%ave_ssh_ibc, forces%p_surf_SSH, &
                                 CS%calc_rho_for_sea_lev)
@@ -1151,15 +1166,24 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif
 
     call cpu_clock_begin(id_clock_diagnostics)
+
+    !$omp target update from(ssh) &
+    !$omp   if (CS%time_in_cycle > 0. .or. CS%time_in_thermo_cycle > 0.)
+
     if (CS%time_in_cycle > 0.0) then
       call enable_averages(CS%time_in_cycle, Time_local, CS%diag)
       call post_surface_dyn_diags(CS%sfc_IDs, G, CS%diag, sfc_state_diag, ssh)
     endif
+
     if (CS%time_in_thermo_cycle > 0.0) then
       call enable_averages(CS%time_in_thermo_cycle, Time_local, CS%diag)
       call post_surface_thermo_diags(CS%sfc_IDs, G, GV, US, CS%diag, CS%time_in_thermo_cycle, &
                                      sfc_state_diag, CS%tv, ssh, CS%ave_ssh_ibc)
     endif
+
+    !$omp target exit data map(delete: ssh) &
+    !$omp   if (CS%time_in_cycle > 0. .or. CS%time_in_thermo_cycle > 0.)
+
     call disable_averaging(CS%diag)
     call cpu_clock_end(id_clock_diagnostics)
     if (CS%rotate_index) then
@@ -2523,6 +2547,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
        "FPMIX=True only works when SPLIT=True.")
   endif
 
+  ! NOTE: tv is used, even if there is no thermodynamics
+  allocate(CS%tv)
+
   call get_param(param_file, "MOM", "BOUSSINESQ", Boussinesq, &
                  "If true, make the Boussinesq approximation.", default=.true., do_not_log=.true.)
   call get_param(param_file, "MOM", "SEMI_BOUSSINESQ", semi_Boussinesq, &
@@ -3146,6 +3173,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   CS%t_dyn_rel_adv = 0.0 ; CS%t_dyn_rel_thermo = 0.0 ; CS%t_dyn_rel_diag = 0.0
   CS%n_dyn_steps_in_adv = 0
 
+  allocate(CS%ADp)
+  !$omp target enter data map(alloc: CS%ADp)
+
   if (debug_truncations) then
     allocate(CS%u_prev(IsdB:IedB,jsd:jed,nz), source=0.0)
     allocate(CS%v_prev(isd:ied,JsdB:JedB,nz), source=0.0)
@@ -3171,9 +3201,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   if (CS%interp_p_surf) allocate(CS%p_surf_prev(isd:ied,jsd:jed), source=0.0)
 
   ALLOC_(CS%ssh_rint(isd:ied,jsd:jed)) ; CS%ssh_rint(:,:) = 0.0
+  !$omp target enter data map(to: CS%ssh_rint)
   ALLOC_(CS%ave_ssh_ibc(isd:ied,jsd:jed)) ; CS%ave_ssh_ibc(:,:) = 0.0
+  !$omp target enter data map(to: CS%ave_ssh_ibc)
   ALLOC_(CS%eta_av_bc(isd:ied,jsd:jed)) ; CS%eta_av_bc(:,:) = 0.0 ! -G%Z_ref
-  !$omp target enter data map(alloc: CS%eta_av_bc)
+  !$omp target enter data map(to: CS%eta_av_bc)
   CS%time_in_cycle = 0.0 ; CS%time_in_thermo_cycle = 0.0
 
   !allocate porous topography variables
@@ -3657,7 +3689,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   CS%useMEKE = MEKE_init(Time, G, GV, US, param_file, diag, CS%dbcomms_CS, CS%MEKE_CSp, CS%MEKE, &
                          restart_CSp, CS%MEKE_in_dynamics)
 
+  allocate(CS%VarMix)
+  !$omp target enter data map(alloc: CS%VarMix)
   call VarMix_init(Time, G, GV, US, param_file, diag, CS%VarMix)
+
   !$omp target enter data map(to: CS%set_visc_CSp)
   call set_visc_init(Time, G, GV, US, param_file, diag, CS%visc, CS%set_visc_CSp, restart_CSp, CS%OBC)
   call thickness_diffuse_init(Time, G, GV, US, param_file, diag, CS%CDp, CS%thickness_diffuse_CSp)
@@ -3853,11 +3888,15 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
 
   if (.not.query_initialized(CS%ave_ssh_ibc, "ave_ssh", restart_CSp)) then
+    !$omp target update to(CS%h)
     if (CS%split) then
-      call find_eta(CS%h, CS%tv, G, GV, US, CS%ave_ssh_ibc, eta, dZref=G%Z_ref)
+      !$omp target enter data map(to: eta)
+      call find_eta(CS%h, CS%tv, G, GV, US, CS%ave_ssh_ibc, eta_bt=eta, dZref=G%Z_ref)
+      !$omp target exit data map(release: eta)
     else
       call find_eta(CS%h, CS%tv, G, GV, US, CS%ave_ssh_ibc, dZref=G%Z_ref)
     endif
+    !$omp target update from(CS%ave_ssh_ibc)
     call set_initialized(CS%ave_ssh_ibc, "ave_ssh", restart_CSp)
   endif
   if (CS%split) deallocate(eta)
@@ -3914,7 +3953,10 @@ subroutine finish_MOM_initialization(Time, dirs, CS)
     restart_CSp_tmp = CS%restart_CS
     call restart_registry_lock(restart_CSp_tmp, unlocked=.true.)
     allocate(z_interface(SZI_(G),SZJ_(G),SZK_(GV)+1))
+    !$omp target update to(CS%h)
+    !$omp target enter data map(alloc: z_interface)
     call find_eta(CS%h, CS%tv, G, GV, US, z_interface, dZref=G%Z_ref)
+    !$omp target exit data map(from: z_interface)
     call register_restart_field(z_interface, "eta", .true., restart_CSp_tmp, &
                                 "Interface heights", "meter", z_grid='i', conversion=US%Z_to_m)
     ! NOTE: write_ic=.true. routes routine to fms2 IO write_initial_conditions interface
@@ -4697,6 +4739,9 @@ subroutine MOM_end(CS)
   if (associated(CS%tv%TempxPmE)) deallocate(CS%tv%TempxPmE)
 
   DEALLOC_(CS%ave_ssh_ibc) ; DEALLOC_(CS%ssh_rint) ; DEALLOC_(CS%eta_av_bc)
+  !$omp target exit data map(delete: CS%ave_ssh_ibc)
+  !$omp target exit data map(delete: CS%ssh_rint)
+  !$omp target exit data map(delete: CS%eta_av_bc)
 
   ! TODO: debug_truncations deallocation
 

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -158,19 +158,21 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
   dZ_ref = 0.0 ; if (present(dZref)) dZ_ref = dZref
 
   if (GV%Boussinesq) then
-    !$OMP parallel default(shared) private(dilate,htot)
-    !$OMP do
-    do j=jsv,jev ; do i=isv,iev ; eta(i,j,nz+1) = -(G%bathyT(i,j) + dZ_ref) ; enddo ; enddo
-    !$OMP do
-    do j=jsv,jev ; do k=nz,1,-1 ; do i=isv,iev
-      eta(i,j,K) = eta(i,j,K+1) + h(i,j,k)*GV%H_to_Z
-    enddo ; enddo ; enddo
+    do concurrent (j=jsv:jev, i=isv:iev)
+      eta(i,j,nz+1) = -(G%bathyT(i,j) + dZ_ref)
+    enddo
+
+    do concurrent (j=jsv:jev, i=isv:iev)
+      do k=nz,1,-1
+        eta(i,j,K) = eta(i,j,K+1) + h(i,j,k)*GV%H_to_Z
+      enddo
+    enddo
+
     if (present(eta_bt)) then
       ! Dilate the water column to agree with the free surface height
       ! that is used for the dynamics.
-      !$OMP do
-      do j=jsv,jev    !$OMP parallel do default(shared)
-
+      !$omp target update from(eta)
+      do j=jsv,jev
         do i=isv,iev
           dilate(i) = (eta_bt(i,j)*GV%H_to_Z + G%bathyT(i,j)) / &
                       (eta(i,j,1) + (G%bathyT(i,j) + dZ_ref))
@@ -180,12 +182,12 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
                        (G%bathyT(i,j) + dZ_ref)
         enddo ; enddo
       enddo
+      !$omp target update to(eta)
     endif
-    !$OMP end parallel
   else
+    !$omp target update from(eta)
     call find_dz_for_eta(h, tv, G, GV, US, dz_lay, halo_size)
-    !$OMP parallel default(shared) private(dilate,htot)
-    !$OMP do
+
     do j=jsv,jev
       do i=isv,iev ; eta(i,j,nz+1) = -(G%bathyT(i,j) + dZ_ref) ; enddo
       do k=nz,1,-1 ; do i=isv,iev
@@ -196,7 +198,6 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
     if (present(eta_bt)) then
       ! Dilate the water column to agree with the free surface height
       ! from the time-averaged barotropic solution.
-      !$OMP do
       do j=jsv,jev
         do i=isv,iev ; htot(i) = GV%H_subroundoff ; enddo
         do k=1,nz ; do i=isv,iev ; htot(i) = htot(i) + h(i,j,k) ; enddo ; enddo
@@ -207,9 +208,8 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
         enddo ; enddo
       enddo
     endif
-    !$OMP end parallel
+    !$omp target update to(eta)
   endif
-
 end subroutine find_eta_3d
 
 !> Calculates the free surface height, using the appropriate form for consistency
@@ -247,35 +247,38 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
 
   dZ_ref = 0.0 ; if (present(dZref)) dZ_ref = dZref
 
+  !$omp target enter data map(to: eta_bt) if (present(eta_bt))
+
   if (GV%Boussinesq) then
     if (present(eta_bt)) then
-      !$OMP parallel do default(shared)
-      do j=js,je ; do i=is,ie
+      do concurrent (j=js:je, i=is:ie)
         eta(i,j) = GV%H_to_Z*eta_bt(i,j) - dZ_ref
-      enddo ; enddo
+      enddo
     else
-      !$OMP parallel do default(shared)
-      do j=js,je
-        do i=is,ie ; eta(i,j) = -(G%bathyT(i,j) + dZ_ref) ; enddo
-        do k=1,nz ; do i=is,ie
+      do concurrent (j=js:je)
+        do concurrent (i=is:ie)
+          eta(i,j) = -G%bathyT(i,j) + dZ_ref
+        enddo
+
+        do k=1,nz ; do concurrent (i=is:ie)
           eta(i,j) = eta(i,j) + h(i,j,k)*GV%H_to_Z
         enddo ; enddo
       enddo
     endif
   else
+    !$omp target update from(eta)
     call find_dz_for_eta(h, tv, G, GV, US, dz_lay, halo_size)
-    !$OMP parallel default(shared) private(htot)
-    !$OMP do
+
     do j=js,je
       do i=is,ie ; eta(i,j) = -(G%bathyT(i,j) + dZ_ref) ; enddo
       do k=1,nz ; do i=is,ie
         eta(i,j) = eta(i,j) + dz_lay(i,j,k)
       enddo ; enddo
     enddo
+
     if (present(eta_bt)) then
       !   Dilate the water column to agree with the time-averaged column
       ! mass from the barotropic solution.
-      !$OMP do
       do j=js,je
         do i=is,ie ; htot(i) = GV%H_subroundoff ; enddo
         do k=1,nz ; do i=is,ie ; htot(i) = htot(i) + h(i,j,k) ; enddo ; enddo
@@ -284,10 +287,9 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
                      (G%bathyT(i,j) + dZ_ref)
         enddo
       enddo
+      !$omp target update to(eta)
     endif
-    !$OMP end parallel
   endif
-
 end subroutine find_eta_2d
 
 

--- a/src/core/MOM_porous_barriers.F90
+++ b/src/core/MOM_porous_barriers.F90
@@ -313,7 +313,10 @@ subroutine calc_eta_at_uv(eta_u, eta_v, interp, dmask, h, tv, G, GV, US, eta_bt)
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
   ! currently no treatment for using optional find_eta arguments if present
+  !$omp target update to(h)
+  !$omp target enter data map(alloc: eta)
   call find_eta(h, tv, G, GV, US, eta, halo_size=1)
+  !$omp target exit data map(from: eta)
 
   dz_neglect = GV%dZ_subroundoff
 

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -967,7 +967,10 @@ subroutine calculate_vertical_integrals(h, tv, p_surf, G, GV, US, CS)
   endif
 
   if (CS%id_col_ht > 0) then
+    !$omp target update to(h)
+    !$omp target enter data map(alloc: z_top)
     call find_eta(h, tv, G, GV, US, z_top)
+    !$omp target exit data map(from: z_top)
     do j=js,je ; do i=is,ie
       z_bot(i,j) = z_top(i,j) + G%bathyT(i,j)
     enddo ; enddo

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -566,7 +566,10 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     do k=1,nz ; vol_lay(k) = (1.0 / GV%Rho0) * mass_lay(k) ; enddo
   else
     if (CS%do_APE_calc) then
+      !$omp target update to(h)
+      !$omp target enter data map(alloc: eta)
       call find_eta(h, tv, G, GV, US, eta, dZref=G%Z_ref)
+      !$omp target exit data map(from: eta)
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = (eta(i,j,K)-eta(i,j,K+1)) * areaTm(i,j)
       enddo ; enddo ; enddo

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1222,7 +1222,10 @@ subroutine depress_surface(h, G, GV, US, param_file, tv, just_read, z_top_shelf)
   endif
 
   ! Convert thicknesses to interface heights.
+  !$omp target update from(h)
+  !$omp target enter data map(alloc: eta)
   call find_eta(h, tv, G, GV, US, eta, dZref=G%Z_ref)
+  !$omp target exit data map(from: eta)
 
   do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
 !    if (eta_sfc(i,j) < eta(i,j,nz+1)) then
@@ -1404,7 +1407,10 @@ subroutine calc_sfc_displacement(PF, G, GV, US, mass_shelf, tv, h)
   max_iter = 1e3
   call MOM_mesg("Started calculating initial interface position under ice shelf ")
   ! Convert thicknesses to interface heights.
+  !$omp target update to(h)
+  !$omp target enter data map(alloc: eta)
   call find_eta(h, tv, G, GV, US, eta, dZref=G%Z_ref)
+  !$omp target exit data map(from: eta)
   do j=js,je ; do i=is,ie
     iter = 1
     z_top_shelf(i,j) = 0.0

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1875,7 +1875,10 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
     h_u(I,j,k) = 0.5*(h(i,j,k)*G%mask2dT(i,j) + h(i+1,j,k)*G%mask2dT(i+1,j)) + GV%Angstrom_H
     h_v(i,J,k) = 0.5*(h(i,j,k)*G%mask2dT(i,j) + h(i,j+1,k)*G%mask2dT(i,j+1)) + GV%Angstrom_H
   enddo ; enddo ; enddo
+  !$omp target update to(h)
+  !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=2)
+  !$omp target exit data map(from: e)
   ! Note the hard-coded dimenisional constant in the following line.
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y)
   call pass_vector(slope_x, slope_y, G%Domain)

--- a/src/parameterizations/lateral/MOM_interface_filter.F90
+++ b/src/parameterizations/lateral/MOM_interface_filter.F90
@@ -111,7 +111,10 @@ subroutine interface_filter(h, uhtr, vhtr, tv, dt, G, GV, US, CDp, CS)
     "order specified by INTERFACE_FILTER_ORDER.")
 
   ! Calculates interface heights, e, in [Z ~> m].
+  !$omp target update to(h)
+  !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=filter_itts)
+  !$omp target exit data map(from: e)
 
   ! Set the smoothing length scales to apply at each iteration.
   if (filter_itts == 1) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -682,7 +682,10 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
         f(i,j) = max(0.25 * abs((G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J-1)) + &
                          (G%CoriolisBu(I-1,J) + G%CoriolisBu(I,J-1))), f_subround)
       enddo ; enddo
+      !$omp target update to(h)
+      !$omp target enter data map(alloc: e)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
+      !$omp target exit data map(from: e)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
@@ -779,7 +782,10 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
          "Module must be initialized before it is used.")
 
   if (CS%calculate_Eady_growth_rate) then
+    !$omp target update to(h)
+    !$omp target enter data map(alloc: e)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
+    !$omp target exit data map(from: e)
     if (CS%use_simpler_Eady_growth_rate) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
@@ -1368,7 +1374,10 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   if (.not. CS%initialized) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_QG_slopes: "//&
          "Module must be initialized before it is used.")
 
+  !$omp target update to(h)
+  !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=3)
+  !$omp target exit data map(from: e)
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                               slope_x, slope_y, halo=2, OBC=OBC, OBC_N2=CS%OBC_friendly)
 

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -235,7 +235,10 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   enddo ; enddo
 
   ! Calculates interface heights, e, in [Z ~> m].
+  !$omp target update to(h)
+  !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=1)
+  !$omp target exit data map(from: e)
 
   ! Set the diffusivities.
   !$OMP parallel default(shared)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -343,7 +343,10 @@ subroutine diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, &
   if (CS%id_T_predia > 0) call post_data(CS%id_T_predia, tv%T, CS%diag)
   if (CS%id_S_predia > 0) call post_data(CS%id_S_predia, tv%S, CS%diag)
   if (CS%id_e_predia > 0) then
+    !$omp target update to(h)
+    !$omp target enter data map(alloc: eta)
     call find_eta(h, tv, G, GV, US, eta, dZref=G%Z_ref)
+    !$omp target exit data map(from: eta)
     call post_data(CS%id_e_predia, eta, CS%diag)
   endif
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1434,13 +1434,13 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
 
   ! First do u-points
 
+  ! TODO: tv and VarMix probably should be conditionally transferred (if at all)
   !$omp target enter data map(alloc: z_i, z_i_gl90, dz_harm, hvel, dz_vel, a_cpl, a_cpl_gl90, &
   !$omp& tv, varmix, hvel_shelf, dz_vel_shelf, a_shelf)
 
   ! These are used in diagnostics, so they need to be mapped back and forth
   !$omp target enter data map(to: hML_u, kv_u, kv_gl90_u )
   !$omp target enter data map(to: hML_v, kv_v, kv_gl90_v)
-
 
   !$omp target teams distribute parallel do collapse(2) &
   !$omp   private(z_i, z_i_gl90, dz_harm, hvel, dz_vel, a_cpl, a_cpl_gl90, &


### PR DESCRIPTION
This PR builds on #152 and includes the following:

* `find_eta()` and its imputs are moved to GPU
* Several derived-type fields of `MOM_control_struct` are defined from locals to allocatables.
* Arrays in MOM CS and associated loops are also moved to GPU 

Moving `find_eta()` and internal loops exposed dependency issues with locally nested derived types.  If local, then the NVIDIA GPU compilers assume that touching any field in the CS requires a full up/download sync.

By redefining as allocatable and indepndently allocating them, it seems to create a sufficient separation between the type and its components and prevents these redundant copies.

This PR is very much a consequence of #152 so it is submitted on top of this PR.  But I'll leave #152 up in case it needs to be independently evaluated.