### PR TITLE
Remove extra eta_bt transfer

### DIFF
--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -247,8 +247,6 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
 
   dZ_ref = 0.0 ; if (present(dZref)) dZ_ref = dZref
 
-  !$omp target enter data map(to: eta_bt) if (present(eta_bt))
-
   if (GV%Boussinesq) then
     if (present(eta_bt)) then
       do concurrent (j=js:je, i=is:ie)


### PR DESCRIPTION
Extra transfer of eta_bt in find_eta_2d was causing crashes on Stellar with nvfortran 25.5, this one line PR removes that transfer