### PR TITLE
step_mom tracer and array updates

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1120,7 +1120,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ssh(i,j) = CS%ssh_rint(i,j) * I_wt_ssh
       CS%ave_ssh_ibc(i,j) = ssh(i,j)
     enddo
-    !$omp target update from(CS%ave_ssh_ibc)
 
     if (associated(CS%HA_CSp)) then
       !$omp target update from(ssh)
@@ -1174,6 +1173,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif
 
     if (CS%time_in_thermo_cycle > 0.0) then
+      !$omp target update from(CS%ave_ssh_ibc)
       call enable_averages(CS%time_in_thermo_cycle, Time_local, CS%diag)
       call post_surface_thermo_diags(CS%sfc_IDs, G, GV, US, CS%diag, CS%time_in_thermo_cycle, &
                                      sfc_state_diag, CS%tv, ssh, CS%ave_ssh_ibc)
@@ -4141,6 +4141,7 @@ subroutine adjust_ssh_for_p_atm(tv, G, GV, US, ssh, p_atm, use_EOS)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   EOSdom(:) = EOS_domain(G%HI)
   if (associated(p_atm)) then
+    !$omp target update from(ssh)
     calc_rho = use_EOS .and. associated(tv%eqn_of_state)
     ! Correct the output sea surface height for the contribution from the ice pressure.
     do j=js,je
@@ -4158,8 +4159,8 @@ subroutine adjust_ssh_for_p_atm(tv, G, GV, US, ssh, p_atm, use_EOS)
         enddo
       endif
     enddo
+    !$omp target update to(ssh)
   endif
-
 end subroutine adjust_ssh_for_p_atm
 
 !> Set the surface (return) properties of the ocean model by

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -996,12 +996,10 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       endif
 
       if (do_advection) then ! Do advective transport and lateral tracer mixing.
-        !$omp target update from(h, CS%uhtr, CS%vhtr)
         call step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
         if (CS%diabatic_first .and. abs(CS%t_dyn_rel_thermo) > 1e-6*dt) call MOM_error(FATAL, &
                 "step_MOM: Mismatch between the dynamics and diabatic times "//&
                 "with DIABATIC_FIRST.")
-        !$omp target update to(CS%uhtr, CS%vhtr)
       endif
     endif ! end of (do_dyn)
 
@@ -1606,9 +1604,12 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   integer :: halo_sz ! The size of a halo where data must be valid.
   logical :: x_first ! If true, advect tracers first in the x-direction, then y.
   logical :: showCallTree
+  integer :: i, j, k
+
   showCallTree = callTree_showQuery()
 
   if (CS%debug) then
+    !$omp target update from(h, CS%uhtr, CS%vhtr)
     call cpu_clock_begin(id_clock_other)
     call hchksum(h,"Pre-advection h", G%HI, haloshift=1, unscale=GV%H_to_MKS)
     call uvchksum("Pre-advection uhtr", CS%uhtr, CS%vhtr, G%HI, &
@@ -1627,11 +1628,11 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   call enable_averages(CS%t_dyn_rel_adv, Time_local, CS%diag)
 
   if (CS%use_particles .and. CS%use_uh_particles .and. (.not. CS%uh_particles_bug)) then
+    !$omp target update from(CS%uhtr, CS%vhtr, CS%h)
     ! Run particles using thickness-weighted velocity
     call particles_run(CS%particles, Time_local, CS%uhtr, CS%vhtr, CS%h, &
                        CS%tv, CS%t_dyn_rel_adv, CS%use_uh_particles)
   endif
-
 
   if (CS%alternate_first_direction) then
     ! This calculation of the value of G%first_direction from the start of the accumulation of
@@ -1650,9 +1651,11 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   if (CS%debug) call MOM_tracer_chksum("Post-diffuse ", CS%tracer_Reg, G)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
   if (associated(CS%OBC)) then
+    !$omp target update from(CS%uhtr, CS%vhtr)
     call pass_vector(CS%uhtr, CS%vhtr, G%Domain)
     call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
                      CS%tracer_Reg)
+    !$omp target update to(CS%uhtr, CS%vhtr)
   endif
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
@@ -1669,8 +1672,14 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   ! Reset the accumulated transports to 0 and record that the dynamics
   ! and advective times now agree.
   call cpu_clock_begin(id_clock_thermo) ; call cpu_clock_begin(id_clock_tracer)
-  CS%uhtr(:,:,:) = 0.0
-  CS%vhtr(:,:,:) = 0.0
+
+  do concurrent (k=1:GV%ke, j=G%jsd:G%jed, I=G%IsdB:G%IedB)
+    CS%uhtr(I,j,k) = 0.
+  enddo
+  do concurrent (k=1:GV%ke, J=G%JsdB:G%JedB, i=G%isd:G%ied)
+    CS%vhtr(i,J,k) = 0.
+  enddo
+
   CS%n_dyn_steps_in_adv = 0
   CS%t_dyn_rel_adv = 0.0
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
@@ -1704,6 +1713,7 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
 
     ! Update derived thermodynamic quantities.
     if (allocated(CS%tv%SpV_avg)) then
+      !$omp target update from(h)
       call calc_derived_thermo(CS%tv, h, G, GV, US, halo=halo_sz, debug=CS%debug)
     endif
   endif

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1822,6 +1822,10 @@ subroutine post_transport_diagnostics(G, GV, US, uhtr, vhtr, h, IDs, diag_pre_dy
   call diag_save_grids(diag)
   call diag_copy_storage_to_diag(diag, diag_pre_dyn)
 
+  !$omp target update from(uhtr) if (any([IDs%id_umo_2d, IDs%id_umo, IDs%id_uhtr] > 0))
+  !$omp target update from(vhtr) if (any([IDs%id_vmo_2d, IDs%id_vmo, IDs%id_vhtr] > 0))
+  !$omp target update from(h) if (IDs%id_dynamics_h_tendency > 0)
+
   if (IDs%id_umo_2d > 0) then
     umo2d(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do I=is-1,ie

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -132,8 +132,6 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
        "register_tracer must be called before advect_tracer.")
   if (Reg%ntr==0) return
 
-  !$omp target update to(uhtr, vhtr, h_end)
-
   !$omp target enter data map(to: OBC, Reg, Reg%Tr(:)) map(alloc: domore_u, domore_v, uhr, vhr, uh_neglect, &
   !$omp   vh_neglect, hprev, local_advect_scheme)
 
@@ -185,8 +183,6 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
     call create_group_pass(CS%pass_uhr_vhr_t_hprev, Reg%Tr(m)%t, G%Domain)
   enddo
   call cpu_clock_end(id_clock_pass)
-
-  !!$omp target enter data map(to: local_advect_scheme)
 
   ! This initializes the halos of uhr and vhr because pass_vector might do
   ! calculations on them, even though they are never used.

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -427,6 +427,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
   enddo
 
   if (CS%use_hor_bnd_diffusion) then
+    !$omp target update from(h)
 
     if (CS%show_call_tree) call callTree_waypoint("Calling horizontal boundary diffusion (tracer_hordiff)")
     !$omp target update from(khdt_x, khdt_y)
@@ -495,6 +496,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
   endif
 
   if (CS%use_neutral_diffusion) then
+    !$omp target update from(h)
 
     if (CS%show_call_tree) call callTree_waypoint("Calling neutral diffusion coeffs (tracer_hordiff)")
 
@@ -915,7 +917,7 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
   if (PEmax_kRho > nz) PEmax_kRho = nz ! PEmax_kRho could have been nz+1.
 
   h_exclude = 10.0*(GV%Angstrom_H + GV%H_subroundoff)
-  !$omp target update to(h)
+
   do concurrent (j=js-1:je+1) DO_LOCALITY(local(k, ns))
     do k=1,nkmb ; do concurrent (i=is-1:ie+1, G%mask2dT(i,j) > 0.0) DO_LOCALITY(local(ns))
       if (h(i,j,k) > h_exclude) then


### PR DESCRIPTION
Some additional cleanup of `step_MOM` transfers.

* Redundant updates around `step_MOM_tracer_dyn` and related transfers

* CS%ave_sst_ibc transfer reduction.

Not done, there's a lot to do around diagnostics and `write_energy`, but I think this is close to done.

Also, there's a chance that this fixes some transfers related to neutral diffusion that may have been missing.