### PR TITLE
benchmark_ALE: Remove PBCE data transfers

### DIFF
--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -720,10 +720,8 @@ subroutine Set_pbce_Bouss(e, tv, G, GV, US, Rho0, GFS_scale, pbce, rho_star)
         press(i,j) = -Rho0xG * (e(i,j,1) - G%meanSL(i,j))
       enddo
 
-      !$omp target update from(Ihtot, press)
       call calculate_density(tv%T(:,:,1), tv%S(:,:,1), press, rho_in_situ, &
                              tv%eqn_of_state, EOSdom)
-      !$omp target update to(rho_in_situ)
 
       do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
         pbce(i,j,1) = G_Rho0 * (GFS_scale * rho_in_situ(i,j)) * GV%H_to_Z
@@ -736,10 +734,8 @@ subroutine Set_pbce_Bouss(e, tv, G, GV, US, Rho0, GFS_scale, pbce, rho_star)
           S_int(i,j) = 0.5 * (tv%S(i,j,k-1) + tv%S(i,j,k))
         enddo
 
-        !$omp target update from(T_int, S_int, press)
         call calculate_density_derivs(T_int, S_int, press, dR_dT, dR_dS, &
                                       tv%eqn_of_state, EOSdom)
-        !$omp target update to(dR_dT, dR_dS)
 
         do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
           pbce(i,j,k) = pbce(i,j,k-1) + G_Rho0 * &


### PR DESCRIPTION
In set_PBCE_Bouss(), the `calculate_density` calls were wrapped in data transfers back to host.  But these two calls happen to already be on device (GPU), so these data transfers may inadvertently wipe out the calculations.

Before removing these, `benchmark` was blowing up.  Removing these transfers helped to stabilize the issue (although there are still outstanding issues).