### PR TITLE
Use blocking in k dimension for continuity reconstruction

### DIFF
--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1116,7 +1116,7 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
 end subroutine zonal_BT_mass_flux
 
 !> Evaluates the zonal mass or volume fluxes in an element.
-!NVF$ INLINE
+!DIR$ ATTRIBUTES FORCEINLINE :: flux_elem
 elemental subroutine flux_elem(u, h, h_p1, h_L, h_L_p1, h_R, h_R_p1, uh, duhdu, visc_rem, &
                                G_dy_Cu, G_IareaT, G_IareaT_p1, G_IdxT, G_IdxT_p1, dt, &
                                vol_CFL, por_face_area)
@@ -1179,7 +1179,7 @@ elemental subroutine flux_elem(u, h, h_p1, h_L, h_L_p1, h_R, h_R_p1, uh, duhdu, 
 
 end subroutine flux_elem
 
-!NVF$ INLINE
+!DIR$ ATTRIBUTES FORCEINLINE :: flux_elem_OBC
 elemental subroutine flux_elem_OBC(u, h, h_p1, uh, duhdu, visc_rem, por_face_area, &
                                      G_dy_Cu, OBC, l_seg)
   real,                     intent(in)    :: u        !< Zonal/meridional velocity [L T-1 ~> m s-1].
@@ -3116,7 +3116,6 @@ subroutine PPM_limit_CW84(h_in, h_L, h_R, G, GV, iis, iie, jis, jie, ks, ke)
 end subroutine PPM_limit_CW84
 
 !> Return the maximum ratio of a/b or maxrat.
-!NVF$ INLINE
 pure function ratio_max(a, b, maxrat) result(ratio)
   real, intent(in) :: a       !< Numerator, in arbitrary units [A]
   real, intent(in) :: b       !< Denominator, in arbitrary units [B]

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -33,11 +33,6 @@ public zonal_flux_thickness, meridional_flux_thickness
 public zonal_BT_mass_flux, meridional_BT_mass_flux
 public set_continuity_loop_bounds
 
-! These were found to give best performance in limited tests.
-integer, parameter :: default_niblock = 32 !< Default i block size for array calculations [nondim].
-integer, parameter :: default_njblock = 4  !< Default j block size for array calculations [nondim].
-integer, parameter :: default_nkblock = 1  !< Default k block size for reconstruction calculations [nondim].
-
 !>@{ CPU time clock IDs
 integer :: id_clock_reconstruct, id_clock_update, id_clock_correct
 !>@}
@@ -171,8 +166,6 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
   niblock = CS%niblock
   njblock = CS%njblock
-  if (niblock == 0) niblock = default_niblock
-  if (njblock == 0) njblock = default_njblock
 
   h_min = GV%Angstrom_H
 
@@ -191,11 +184,9 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
     !  First advect zonally, with loop bounds that accomodate the subsequent meridional advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.true.)
-    ! set default block sizes for OpenMP offload
-    !$ if (omp_get_num_devices() > 0) then
-      !$ if (CS%niblock == 0) niblock = LB%ieh-LB%ish+2
-      !$ if (CS%njblock == 0) njblock = LB%jeh-LB%jsh+1
-    !$ endif
+    ! set whole-domain block sizes when ni/jblock is 0
+    if (niblock == 0) niblock = LB%ieh-LB%ish+2
+    if (njblock == 0) njblock = LB%jeh-LB%jsh+1
 
     call zonal_edge_thickness(hin, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, hin, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
@@ -205,10 +196,8 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
     !  Now advect meridionally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
 
-    !$ if (omp_get_num_devices() > 0) then
-      !$ if (CS%niblock == 0) niblock = LB%ieh-LB%ish+1
-      !$ if (CS%njblock == 0) njblock = LB%jeh-LB%jsh+2
-    !$ endif
+    if (niblock == 0) niblock = LB%ieh-LB%ish+1
+    if (njblock == 0) njblock = LB%jeh-LB%jsh+2
 
     call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
@@ -219,10 +208,8 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
     !  First advect meridionally, with loop bounds that accomodate the subsequent zonal advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.true., j_stencil=.false.)
-    !$ if (omp_get_num_devices() > 0) then
-      !$ if (CS%niblock == 0) niblock = LB%ieh-LB%ish+1
-      !$ if (CS%njblock == 0) njblock = LB%jeh-LB%jsh+2
-    !$ endif
+    if (niblock == 0) niblock = LB%ieh-LB%ish+1
+    if (njblock == 0) njblock = LB%jeh-LB%jsh+2
     call meridional_edge_thickness(hin, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, hin, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
                               niblock, njblock, LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
@@ -230,10 +217,8 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
 
     !  Now advect zonally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
-    !$ if (omp_get_num_devices() > 0) then
-      !$ if (CS%niblock == 0) niblock = LB%ieh-LB%ish+2
-      !$ if (CS%njblock == 0) njblock = LB%jeh-LB%jsh+1
-    !$ endif
+    if (niblock == 0) niblock = LB%ieh-LB%ish+2
+    if (njblock == 0) njblock = LB%jeh-LB%jsh+1
     call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
                          niblock, njblock, LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
@@ -279,22 +264,16 @@ subroutine continuity_3d_fluxes(u, v, h, uh, vh, dt, G, GV, US, CS, OBC, pbv)
 
   niblock = CS%niblock
   njblock = CS%njblock
-  if (niblock == 0) niblock = default_niblock
-  if (njblock == 0) njblock = default_njblock
 
   call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  !$ if (omp_get_num_devices() > 0) then
-    !$ if (CS%niblock == 0) niblock = G%iec-G%isc+2
-    !$ if (CS%njblock == 0) njblock = G%jec-G%jsc+1
-  !$ endif
+  if (niblock == 0) niblock = G%iec-G%isc+2
+  if (njblock == 0) njblock = G%jec-G%jsc+1
   call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
                        niblock=niblock, njblock=njblock)
 
   call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  !$ if (omp_get_num_devices() > 0) then
-    !$ if (CS%niblock == 0) niblock = G%iec-G%isc+1
-    !$ if (CS%njblock == 0) njblock = G%jec-G%jsc+2
-  !$ endif
+  if (niblock == 0) niblock = G%iec-G%isc+1
+  if (njblock == 0) njblock = G%jec-G%jsc+2
   call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
                             niblock=niblock, njblock=njblock)
 
@@ -400,8 +379,6 @@ subroutine continuity_adjust_vel(u, v, h, dt, G, GV, US, CS, OBC, pbv, uhbt, vhb
 
   niblock = CS%niblock
   njblock = CS%njblock
-  if (niblock == 0) niblock = default_niblock
-  if (njblock == 0) njblock = default_njblock
 
   ! It might not be necessary to separate the input velocity array from the adjusted velocities,
   ! but it seems safer to do so, even if it might be less efficient.
@@ -409,19 +386,15 @@ subroutine continuity_adjust_vel(u, v, h, dt, G, GV, US, CS, OBC, pbv, uhbt, vhb
   v_in(:,:,:) = v(:,:,:)
 
   call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  !$ if (omp_get_num_devices() > 0) then
-    !$ if (CS%niblock == 0) niblock = G%iec-G%isc+2
-    !$ if (CS%njblock == 0) njblock = G%jec-G%jsc+1
-  !$ endif
+  if (niblock == 0) niblock = G%iec-G%isc+2
+  if (njblock == 0) njblock = G%jec-G%jsc+1
   call zonal_mass_flux(u_in, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
                        niblock=niblock, njblock=njblock, &
                        uhbt=uhbt, visc_rem_u=visc_rem_u, u_cor=u)
 
   call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  !$ if (omp_get_num_devices() > 0) then
-    !$ if (CS%niblock == 0) niblock = G%iec-G%isc+1
-    !$ if (CS%njblock == 0) njblock = G%jec-G%jsc+2
-  !$ endif
+  if (niblock == 0) niblock = G%iec-G%isc+1
+  if (njblock == 0) njblock = G%jec-G%jsc+2
   call meridional_mass_flux(v_in, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
                             niblock=niblock, njblock=njblock, &
                             vhbt=vhbt, visc_rem_v=visc_rem_v, v_cor=v)
@@ -537,10 +510,7 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
   endif
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
   nkblock = CS%nkblock
-  if (nkblock == 0) nkblock = default_nkblock
-  !$ if (omp_get_num_devices() > 0) then
-    !$ if (CS%nkblock == 0) nkblock = nz
-  !$ endif
+  if (nkblock == 0) nkblock = nz
 
   if (CS%upwind_1st) then
     do concurrent (k=1:nz, j=jsh:jeh, i=ish-1:ieh+1)
@@ -585,10 +555,7 @@ subroutine meridional_edge_thickness(h_in, h_S, h_N, G, GV, US, CS, OBC, LB_in)
   endif
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
   nkblock = CS%nkblock
-  if (nkblock == 0) nkblock = default_nkblock
-  !$ if (omp_get_num_devices() > 0) then
-    !$ if (CS%nkblock == 0) nkblock = nz
-  !$ endif
+  if (nkblock == 0) nkblock = nz
 
   if (CS%upwind_1st) then
     ! untested
@@ -3150,6 +3117,16 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
   character(len=40)  :: mdl = "MOM_continuity_PPM" ! This module's name.
   character(len=256) :: mesg
   character(len=10) :: niblock_dflt_str, njblock_dflt_str, nkblock_dflt_str
+#ifdef __NVCOMPILER_OPENMP_GPU
+  integer, parameter :: default_niblock = 0 !< Default i block size for array calculations [nondim].
+  integer, parameter :: default_njblock = 0 !< Default j block size for array calculations [nondim].
+  integer, parameter :: default_nkblock = 0 !< Default k block size for reconstruction calculations [nondim].
+#else
+  ! These were found to give best performance in limited tests.
+  integer, parameter :: default_niblock = 32 !< Default i block size for array calculations [nondim].
+  integer, parameter :: default_njblock = 4  !< Default j block size for array calculations [nondim].
+  integer, parameter :: default_nkblock = 1  !< Default k block size for reconstruction calculations [nondim].
+#endif
 
   CS%initialized = .true.
 
@@ -3159,7 +3136,7 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
   endif
 
 ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version, "")
+  call log_version(param_file, mdl, version, "", log_to_all=.true., layout=.true.)
   call get_param(param_file, mdl, "MONOTONIC_CONTINUITY", CS%monotonic, &
                  "If true, CONTINUITY_PPM uses the Colella and Woodward "//&
                  "monotonic limiter.  The default (false) is to use a "//&
@@ -3223,20 +3200,17 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
   write(njblock_dflt_str, '(I0)') default_njblock
   write(nkblock_dflt_str, '(I0)') default_nkblock
   call get_param(param_file, mdl, "CONTINUITY_NIBLOCK", CS%niblock, &
-                 "The i-direction block size used in the continuity solver. "//&
-                 "If 0, defaults to "//trim(niblock_dflt_str)//", except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=0)
+                 "The i-direction block size used in the mass and volume flux calculations. "//&
+                 "the default 0 setting is dynamic and fits the "//&
+                 "full computational i-domain length.", default=default_niblock, layoutParam=.true.)
   call get_param(param_file, mdl, "CONTINUITY_NJBLOCK", CS%njblock, &
-                 "The j-direction block size used in the continuity solver. "//&
-                 "If 0, defaults to "//trim(njblock_dflt_str)//", except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=0)
+                 "The j-direction block size used in the mass and volume flux calculations. "//&
+                 "the default 0 setting is dynamic and fits the "//&
+                 "full computational j-domain length.", default=default_njblock, layoutParam=.true.)
   call get_param(param_file, mdl, "CONTINUITY_NKBLOCK", CS%nkblock, &
-                 "The k-direction block size used in continuity reconstruction. "//&
-                 "If 0, defaults to "//trim(nkblock_dflt_str)//", except when "//&
-                 "running with OpenMP offload, in which case the full vertical "//&
-                 "column is used.", default=0)
+                 "The k-direction block size used in PPM reconstruction edge value calculations. "//&
+                 "the default 0 setting is dynamic and fits the "//&
+                 "full vertical column.", default=default_nkblock, layoutParam=.true.)
   if (CS%niblock < 0) &
     call MOM_error(FATAL, "CONTINUITY_NIBLOCK must be nonnegative; "//&
                           "use 0 to select the default block size.")

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2743,7 +2743,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkblock, h_min, monot
   real :: dMx, dMn     ! The difference between the local thickness and the maximum (dMx) or
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
-  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil, ks, ke, nkblock_use
+  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil, ks, ke
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -2772,9 +2772,8 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkblock, h_min, monot
 
   !$omp target enter data map(alloc: slp)
 
-  nkblock_use = max(1, nkblock)
-  do ks = 1, nz, nkblock_use
-    ke = min(ks + nkblock_use - 1, nz)
+  do ks = 1, nz, nkblock
+    ke = min(ks + nkblock - 1, nz)
 
     if (simple_2nd) then
       ! untested
@@ -2899,7 +2898,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkblock, h_min, monot
   real :: dMx, dMn     ! The difference between the local thickness and the maximum (dMx) or
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
-  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil, ks, ke, nkblock_use
+  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil, ks, ke
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -2928,9 +2927,8 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkblock, h_min, monot
 
   !$omp target enter data map(alloc: slp)
 
-  nkblock_use = max(1, nkblock)
-  do ks = 1, nz, nkblock_use
-    ke = min(ks + nkblock_use - 1, nz)
+  do ks = 1, nz, nkblock
+    ke = min(ks + nkblock - 1, nz)
 
     if (simple_2nd) then
       ! untested
@@ -3240,6 +3238,15 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
                  "If 0, defaults to "//trim(nkblock_dflt_str)//", except when "//&
                  "running with OpenMP offload, in which case the full vertical "//&
                  "column is used.", default=0)
+  if (CS%niblock < 0) &
+    call MOM_error(FATAL, "CONTINUITY_NIBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%njblock < 0) &
+    call MOM_error(FATAL, "CONTINUITY_NJBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%nkblock < 0) &
+    call MOM_error(FATAL, "CONTINUITY_NKBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
   CS%diag => diag
   !$omp target update to(CS)
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -36,6 +36,7 @@ public set_continuity_loop_bounds
 ! These were found to give best performance in limited tests.
 integer, parameter :: default_niblock = 32 !< Default i block size for array calculations [nondim].
 integer, parameter :: default_njblock = 4  !< Default j block size for array calculations [nondim].
+integer, parameter :: default_nkblock = 1  !< Default k block size for reconstruction calculations [nondim].
 
 !>@{ CPU time clock IDs
 integer :: id_clock_reconstruct, id_clock_update, id_clock_correct
@@ -79,6 +80,7 @@ type, public :: continuity_PPM_CS ; private
                              !! averaged areas.
   integer :: niblock         !< The i block size used in array calculations [nondim].
   integer :: njblock         !< The j block size used in array calculations [nondim].
+  integer :: nkblock         !< The k block size used in reconstruction calculations [nondim].
 
 end type continuity_PPM_CS
 
@@ -524,7 +526,7 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
 
   ! Local variables
   type(cont_loop_bounds_type) :: LB
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz, nkblock
 
   call cpu_clock_begin(id_clock_reconstruct)
 
@@ -534,6 +536,11 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
   endif
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
+  nkblock = CS%nkblock
+  if (nkblock == 0) nkblock = default_nkblock
+  !$ if (omp_get_num_devices() > 0) then
+    !$ if (CS%nkblock == 0) nkblock = nz
+  !$ endif
 
   if (CS%upwind_1st) then
     do concurrent (k=1:nz, j=jsh:jeh, i=ish-1:ieh+1)
@@ -541,7 +548,7 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
     enddo
   else
     call PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, &
-                              2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
+                              nkblock, 2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
   endif
 
   call cpu_clock_end(id_clock_reconstruct)
@@ -567,7 +574,7 @@ subroutine meridional_edge_thickness(h_in, h_S, h_N, G, GV, US, CS, OBC, LB_in)
 
   ! Local variables
   type(cont_loop_bounds_type) :: LB
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz, nkblock
 
   call cpu_clock_begin(id_clock_reconstruct)
 
@@ -577,6 +584,11 @@ subroutine meridional_edge_thickness(h_in, h_S, h_N, G, GV, US, CS, OBC, LB_in)
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
   endif
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
+  nkblock = CS%nkblock
+  if (nkblock == 0) nkblock = default_nkblock
+  !$ if (omp_get_num_devices() > 0) then
+    !$ if (CS%nkblock == 0) nkblock = nz
+  !$ endif
 
   if (CS%upwind_1st) then
     ! untested
@@ -585,7 +597,7 @@ subroutine meridional_edge_thickness(h_in, h_S, h_N, G, GV, US, CS, OBC, LB_in)
     enddo
   else
     call PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, &
-                              2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
+                              nkblock, 2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
   endif
 
   call cpu_clock_end(id_clock_reconstruct)
@@ -2702,7 +2714,7 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, 
 end subroutine set_merid_BT_cont
 
 !> Calculates left/right edge values for PPM reconstruction.
-subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, simple_2nd, OBC)
+subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkblock, h_min, monotonic, simple_2nd, OBC)
   type(ocean_grid_type),             intent(in)  :: G    !< Ocean's grid structure.
   type(verticalGrid_type),           intent(in)  :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h_in !< Layer thickness [H ~> m or kg m-2].
@@ -2711,6 +2723,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, sim
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out) :: h_E  !< East edge thickness in the reconstruction,
                                                          !! [H ~> m or kg m-2].
   type(cont_loop_bounds_type),       intent(in)  :: LB   !< Active loop bounds structure.
+  integer,                           intent(in)  :: nkblock !< k block size for reconstruction calculations [nondim].
   real,                              intent(in)  :: h_min !< The minimum thickness
                     !! that can be obtained by a concave parabolic fit [H ~> m or kg m-2]
   logical,                           intent(in)  :: monotonic !< If true, use the
@@ -2720,16 +2733,17 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, sim
                     !! arithmetic mean thicknesses as the default edge values
                     !! for a simple 2nd order scheme.
   type(ocean_OBC_type),              pointer     :: OBC !< Open boundaries control structure.
-  integer :: k      !< vertical grid index
+  integer :: k, kk  !< vertical grid and k-block indices
 
   ! Local variables with useful mnemonic names.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: slp ! The slopes per grid point [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),max(1,nkblock)) :: &
+    slp ! The slopes per grid point in a k block [H ~> m or kg m-2]
   real, parameter :: oneSixth = 1./6.  ! [nondim]
   real :: h_ip1, h_im1 ! Neighboring thicknesses or sensibly extrapolated values [H ~> m or kg m-2]
   real :: dMx, dMn     ! The difference between the local thickness and the maximum (dMx) or
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
-  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil
+  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil, ks, ke, nkblock_use
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -2758,95 +2772,105 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, h_min, monotonic, sim
 
   !$omp target enter data map(alloc: slp)
 
-  if (simple_2nd) then
-    ! untested
-    do concurrent (k =1:nz, j=jsl:jel, i=isl:iel)
-      h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j,k) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j,k)
-      h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j,k) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j,k)
-      h_W(i,j,k) = 0.5*( h_im1 + h_in(i,j,k) )
-      h_E(i,j,k) = 0.5*( h_ip1 + h_in(i,j,k) )
-    enddo
-  else
-    do concurrent (k=1:nz, j=jsl:jel, i=isl-1:iel+1)
-      if ((G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j)) == 0.0) then
-        slp(i,j,k) = 0.0
-      else
-        ! This uses a simple 2nd order slope.
-        slp(i,j,k) = 0.5 * (h_in(i+1,j,k) - h_in(i-1,j,k))
-        ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
-        dMx = max(h_in(i+1,j,k), h_in(i-1,j,k), h_in(i,j,k)) - h_in(i,j,k)
-        dMn = h_in(i,j,k) - min(h_in(i+1,j,k), h_in(i-1,j,k), h_in(i,j,k))
-        slp(i,j,k) = sign(1.,slp(i,j,k)) * min(abs(slp(i,j,k)), 2. * min(dMx, dMn))
-                ! * (G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j))
+  nkblock_use = max(1, nkblock)
+  do ks = 1, nz, nkblock_use
+    ke = min(ks + nkblock_use - 1, nz)
+
+    if (simple_2nd) then
+      ! untested
+      do concurrent (k=ks:ke, j=jsl:jel, i=isl:iel) DO_LOCALITY(local(h_im1,h_ip1))
+        h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j,k) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j,k)
+        h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j,k) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j,k)
+        h_W(i,j,k) = 0.5*( h_im1 + h_in(i,j,k) )
+        h_E(i,j,k) = 0.5*( h_ip1 + h_in(i,j,k) )
+      enddo
+    else
+      do concurrent (k=ks:ke, j=jsl:jel, i=isl-1:iel+1) DO_LOCALITY(local(dMx,dMn,kk))
+        kk = k - ks + 1
+        if ((G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j)) == 0.0) then
+          slp(i,j,kk) = 0.0
+        else
+          ! This uses a simple 2nd order slope.
+          slp(i,j,kk) = 0.5 * (h_in(i+1,j,k) - h_in(i-1,j,k))
+          ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
+          dMx = max(h_in(i+1,j,k), h_in(i-1,j,k), h_in(i,j,k)) - h_in(i,j,k)
+          dMn = h_in(i,j,k) - min(h_in(i+1,j,k), h_in(i-1,j,k), h_in(i,j,k))
+          slp(i,j,kk) = sign(1.,slp(i,j,kk)) * min(abs(slp(i,j,kk)), 2. * min(dMx, dMn))
+                  ! * (G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j))
+        endif
+      enddo
+
+      if (local_open_BC) then
+        ! untested
+        do n=1, OBC%number_of_segments
+          segment => OBC%segment(n)
+          if (.not. segment%on_pe) cycle
+          if (segment%is_E_or_W) then
+            I=segment%HI%IsdB
+            do concurrent (k=ks:ke, j=segment%HI%jsd:segment%HI%jed) DO_LOCALITY(local(kk))
+              kk = k - ks + 1
+              slp(i+1,j,kk) = 0.0
+              slp(i,j,kk) = 0.0
+            enddo
+          endif
+        enddo
       endif
-    enddo
+
+      do concurrent (k=ks:ke, j=jsl:jel, i=isl:iel) DO_LOCALITY(local(h_im1,h_ip1,kk))
+        kk = k - ks + 1
+        ! Neighboring values should take into account any boundaries.  The 3
+        ! following sets of expressions are equivalent.
+      ! h_im1 = h_in(i-1,j,k) ; if (G%mask2dT(i-1,j) < 0.5) h_im1 = h_in(i,j)
+      ! h_ip1 = h_in(i+1,j,k) ; if (G%mask2dT(i+1,j) < 0.5) h_ip1 = h_in(i,j)
+        h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j,k) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j,k)
+        h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j,k) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j,k)
+        ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
+        h_W(i,j,k) = 0.5*( h_im1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i-1,j,kk) - slp(i,j,kk) )
+        h_E(i,j,k) = 0.5*( h_ip1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i,j,kk) - slp(i+1,j,kk) )
+      enddo
+    endif
 
     if (local_open_BC) then
       ! untested
       do n=1, OBC%number_of_segments
         segment => OBC%segment(n)
         if (.not. segment%on_pe) cycle
-        if (segment%is_E_or_W) then
+        if (segment%direction == OBC_DIRECTION_E) then
           I=segment%HI%IsdB
-          do concurrent (k=1:nz, j=segment%HI%jsd:segment%HI%jed)
-            slp(i+1,j,k) = 0.0
-            slp(i,j,k) = 0.0
+          do concurrent (k=ks:ke, j=segment%HI%jsd:segment%HI%jed)
+            h_W(i+1,j,k) = h_in(i,j,k)
+            h_E(i+1,j,k) = h_in(i,j,k)
+            h_W(i,j,k) = h_in(i,j,k)
+            h_E(i,j,k) = h_in(i,j,k)
+          enddo
+        elseif (segment%direction == OBC_DIRECTION_W) then
+          I=segment%HI%IsdB
+          do concurrent (k=ks:ke, j=segment%HI%jsd:segment%HI%jed)
+            h_W(i,j,k) = h_in(i+1,j,k)
+            h_E(i,j,k) = h_in(i+1,j,k)
+            h_W(i+1,j,k) = h_in(i+1,j,k)
+            h_E(i+1,j,k) = h_in(i+1,j,k)
           enddo
         endif
       enddo
     endif
 
-    do concurrent (k=1:nz, j=jsl:jel, i=isl:iel)
-      ! Neighboring values should take into account any boundaries.  The 3
-      ! following sets of expressions are equivalent.
-    ! h_im1 = h_in(i-1,j,k) ; if (G%mask2dT(i-1,j) < 0.5) h_im1 = h_in(i,j)
-    ! h_ip1 = h_in(i+1,j,k) ; if (G%mask2dT(i+1,j) < 0.5) h_ip1 = h_in(i,j)
-      h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j,k) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j,k)
-      h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j,k) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j,k)
-      ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
-      h_W(i,j,k) = 0.5*( h_im1 + h_in(i,j,k) ) + oneSixth*( slp(i-1,j,k) - slp(i,j,k) )
-      h_E(i,j,k) = 0.5*( h_ip1 + h_in(i,j,k) ) + oneSixth*( slp(i,j,k) - slp(i+1,j,k) )
-    enddo
-  endif
-
-  if (local_open_BC) then
-    ! untested
-    do n=1, OBC%number_of_segments
-      segment => OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (segment%direction == OBC_DIRECTION_E) then
-        I=segment%HI%IsdB
-        do concurrent (k=1:nz, j=segment%HI%jsd:segment%HI%jed)
-          h_W(i+1,j,k) = h_in(i,j,k)
-          h_E(i+1,j,k) = h_in(i,j,k)
-          h_W(i,j,k) = h_in(i,j,k)
-          h_E(i,j,k) = h_in(i,j,k)
-        enddo
-      elseif (segment%direction == OBC_DIRECTION_W) then
-        I=segment%HI%IsdB
-        do concurrent (k=1:nz, j=segment%HI%jsd:segment%HI%jed)
-          h_W(i,j,k) = h_in(i+1,j,k)
-          h_E(i,j,k) = h_in(i+1,j,k)
-          h_W(i+1,j,k) = h_in(i+1,j,k)
-          h_E(i+1,j,k) = h_in(i+1,j,k)
-        enddo
-      endif
-    enddo
-  endif
-
-  if (monotonic) then
-    ! untested
-    call PPM_limit_CW84(h_in, h_W, h_E, G, GV, isl, iel, jsl, jel, nz)
-  else
-    call PPM_limit_pos(h_in, h_W, h_E, h_min, G, GV, isl, iel, jsl, jel, nz)
-  endif
+    if (monotonic) then
+      ! untested
+      call PPM_limit_CW84(h_in, h_W, h_E, G, GV, isl, iel, jsl, jel, ks, ke)
+    else
+      call PPM_limit_pos(h_in, h_W, h_E, h_min, G, GV, isl, iel, jsl, jel, ks, ke)
+    endif
+  enddo
 
   !$omp target exit data map(release: slp)
 
 end subroutine PPM_reconstruction_x
 
 !> Calculates left/right edge values for PPM reconstruction.
-subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, simple_2nd, OBC)
+subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkblock, h_min, monotonic, simple_2nd, OBC)
   type(ocean_grid_type),             intent(in)  :: G    !< Ocean's grid structure.
   type(verticalGrid_type),           intent(in)  :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h_in !< Layer thickness [H ~> m or kg m-2].
@@ -2855,6 +2879,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, sim
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out) :: h_N  !< North edge thickness in the reconstruction,
                                                          !! [H ~> m or kg m-2].
   type(cont_loop_bounds_type),       intent(in)  :: LB   !< Active loop bounds structure.
+  integer,                           intent(in)  :: nkblock !< k block size for reconstruction calculations [nondim].
   real,                              intent(in)  :: h_min !< The minimum thickness
                     !! that can be obtained by a concave parabolic fit [H ~> m or kg m-2]
   logical,                           intent(in)  :: monotonic !< If true, use the
@@ -2864,16 +2889,17 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, sim
                     !! arithmetic mean thicknesses as the default edge values
                     !! for a simple 2nd order scheme.
   type(ocean_OBC_type),              pointer     :: OBC !< Open boundaries control structure.
-  integer :: k      !< vertical grid index
+  integer :: k, kk  !< vertical grid and k-block indices
 
   ! Local variables with useful mnemonic names.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: slp ! The slopes per grid point [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),max(1,nkblock)) :: &
+    slp ! The slopes per grid point in a k block [H ~> m or kg m-2]
   real, parameter :: oneSixth = 1./6.      ! [nondim]
   real :: h_jp1, h_jm1 ! Neighboring thicknesses or sensibly extrapolated values [H ~> m or kg m-2]
   real :: dMx, dMn     ! The difference between the local thickness and the maximum (dMx) or
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
-  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil
+  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil, ks, ke, nkblock_use
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -2902,86 +2928,96 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, h_min, monotonic, sim
 
   !$omp target enter data map(alloc: slp)
 
-  if (simple_2nd) then
-    ! untested
-    do concurrent (k=1:nz, j=jsl:jel, i=isl:iel)
-      h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1,k) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j,k)
-      h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1,k) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j,k)
-      h_S(i,j,k) = 0.5*( h_jm1 + h_in(i,j,k) )
-      h_N(i,j,k) = 0.5*( h_jp1 + h_in(i,j,k) )
-    enddo
-  else
-    do concurrent (k=1:nz, j=jsl-1:jel+1, i=isl:iel)
-      if ((G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1)) == 0.0) then
-        slp(i,j,k) = 0.0
-      else
-        ! This uses a simple 2nd order slope.
-        slp(i,j,k) = 0.5 * (h_in(i,j+1,k) - h_in(i,j-1,k))
-        ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
-        dMx = max(h_in(i,j+1,k), h_in(i,j-1,k), h_in(i,j,k)) - h_in(i,j,k)
-        dMn = h_in(i,j,k) - min(h_in(i,j+1,k), h_in(i,j-1,k), h_in(i,j,k))
-        slp(i,j,k) = sign(1.,slp(i,j,k)) * min(abs(slp(i,j,k)), 2. * min(dMx, dMn))
-                ! * (G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1))
+  nkblock_use = max(1, nkblock)
+  do ks = 1, nz, nkblock_use
+    ke = min(ks + nkblock_use - 1, nz)
+
+    if (simple_2nd) then
+      ! untested
+      do concurrent (k=ks:ke, j=jsl:jel, i=isl:iel) DO_LOCALITY(local(h_jm1,h_jp1))
+        h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1,k) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j,k)
+        h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1,k) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j,k)
+        h_S(i,j,k) = 0.5*( h_jm1 + h_in(i,j,k) )
+        h_N(i,j,k) = 0.5*( h_jp1 + h_in(i,j,k) )
+      enddo
+    else
+      do concurrent (k=ks:ke, j=jsl-1:jel+1, i=isl:iel) DO_LOCALITY(local(dMx,dMn,kk))
+        kk = k - ks + 1
+        if ((G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1)) == 0.0) then
+          slp(i,j,kk) = 0.0
+        else
+          ! This uses a simple 2nd order slope.
+          slp(i,j,kk) = 0.5 * (h_in(i,j+1,k) - h_in(i,j-1,k))
+          ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
+          dMx = max(h_in(i,j+1,k), h_in(i,j-1,k), h_in(i,j,k)) - h_in(i,j,k)
+          dMn = h_in(i,j,k) - min(h_in(i,j+1,k), h_in(i,j-1,k), h_in(i,j,k))
+          slp(i,j,kk) = sign(1.,slp(i,j,kk)) * min(abs(slp(i,j,kk)), 2. * min(dMx, dMn))
+                  ! * (G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1))
+        endif
+      enddo
+
+      if (local_open_BC) then
+        ! untested
+        do n=1, OBC%number_of_segments
+          segment => OBC%segment(n)
+          if (.not. segment%on_pe) cycle
+          if (segment%is_N_or_S) then
+            J=segment%HI%JsdB
+            do concurrent (k=ks:ke, i=segment%HI%isd:segment%HI%ied) DO_LOCALITY(local(kk))
+              kk = k - ks + 1
+              slp(i,j+1,kk) = 0.0
+              slp(i,j,kk) = 0.0
+            enddo
+          endif
+        enddo
       endif
-    enddo
+
+      do concurrent (k=ks:ke, j=jsl:jel, i=isl:iel) DO_LOCALITY(local(h_jm1,h_jp1,kk))
+        kk = k - ks + 1
+        ! Neighboring values should take into account any boundaries.  The 3
+        ! following sets of expressions are equivalent.
+        h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1,k) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j,k)
+        h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1,k) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j,k)
+        ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
+        h_S(i,j,k) = 0.5*( h_jm1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i,j-1,kk) - slp(i,j,kk) )
+        h_N(i,j,k) = 0.5*( h_jp1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i,j,kk) - slp(i,j+1,kk) )
+      enddo
+    endif
 
     if (local_open_BC) then
       ! untested
       do n=1, OBC%number_of_segments
         segment => OBC%segment(n)
         if (.not. segment%on_pe) cycle
-        if (segment%is_N_or_S) then
+        if (segment%direction == OBC_DIRECTION_N) then
           J=segment%HI%JsdB
-          do concurrent (k=1:nz, i=segment%HI%isd:segment%HI%ied)
-            slp(i,j+1,k) = 0.0
-            slp(i,j,k) = 0.0
+          do concurrent (k=ks:ke, i=segment%HI%isd:segment%HI%ied)
+            h_S(i,j+1,k) = h_in(i,j,k)
+            h_N(i,j+1,k) = h_in(i,j,k)
+            h_S(i,j,k) = h_in(i,j,k)
+            h_N(i,j,k) = h_in(i,j,k)
+          enddo
+        elseif (segment%direction == OBC_DIRECTION_S) then
+          J=segment%HI%JsdB
+          do concurrent (k=ks:ke, i=segment%HI%isd:segment%HI%ied)
+            h_S(i,j,k) = h_in(i,j+1,k)
+            h_N(i,j,k) = h_in(i,j+1,k)
+            h_S(i,j+1,k) = h_in(i,j+1,k)
+            h_N(i,j+1,k) = h_in(i,j+1,k)
           enddo
         endif
       enddo
     endif
 
-    do concurrent (k=1:nz, j=jsl:jel, i=isl:iel)
-      ! Neighboring values should take into account any boundaries.  The 3
-      ! following sets of expressions are equivalent.
-      h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1,k) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j,k)
-      h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1,k) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j,k)
-      ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
-      h_S(i,j,k) = 0.5*( h_jm1 + h_in(i,j,k) ) + oneSixth*( slp(i,j-1,k) - slp(i,j,k) )
-      h_N(i,j,k) = 0.5*( h_jp1 + h_in(i,j,k) ) + oneSixth*( slp(i,j,k) - slp(i,j+1,k) )
-    enddo
-  endif
-
-  if (local_open_BC) then
-    ! untested
-    do n=1, OBC%number_of_segments
-      segment => OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (segment%direction == OBC_DIRECTION_N) then
-        J=segment%HI%JsdB
-        do concurrent (k=1:nz, i=segment%HI%isd:segment%HI%ied)
-          h_S(i,j+1,k) = h_in(i,j,k)
-          h_N(i,j+1,k) = h_in(i,j,k)
-          h_S(i,j,k) = h_in(i,j,k)
-          h_N(i,j,k) = h_in(i,j,k)
-        enddo
-      elseif (segment%direction == OBC_DIRECTION_S) then
-        J=segment%HI%JsdB
-        do concurrent (k=1:nz, i=segment%HI%isd:segment%HI%ied)
-          h_S(i,j,k) = h_in(i,j+1,k)
-          h_N(i,j,k) = h_in(i,j+1,k)
-          h_S(i,j+1,k) = h_in(i,j+1,k)
-          h_N(i,j+1,k) = h_in(i,j+1,k)
-        enddo
-      endif
-    enddo
-  endif
-
-  if (monotonic) then
-    ! untested
-    call PPM_limit_CW84(h_in, h_S, h_N, G, GV, isl, iel, jsl, jel, nz)
-  else
-    call PPM_limit_pos(h_in, h_S, h_N, h_min, G, GV, isl, iel, jsl, jel, nz)
-  endif
+    if (monotonic) then
+      ! untested
+      call PPM_limit_CW84(h_in, h_S, h_N, G, GV, isl, iel, jsl, jel, ks, ke)
+    else
+      call PPM_limit_pos(h_in, h_S, h_N, h_min, G, GV, isl, iel, jsl, jel, ks, ke)
+    endif
+  enddo
 
   !$omp target exit data map(release: slp)
 
@@ -2991,7 +3027,7 @@ end subroutine PPM_reconstruction_y
 !! to give a reconstruction that is positive-definite.  Here this is
 !! reinterpreted as giving a constant thickness if the mean thickness is less
 !! than h_min, with a minimum of h_min otherwise.
-subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, GV, iis, iie, jis, jie, nz)
+subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, GV, iis, iie, jis, jie, ks, ke)
   type(ocean_grid_type),             intent(in)    :: G    !< Ocean's grid structure.
   type(verticalGrid_type),           intent(in)    :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -3006,7 +3042,8 @@ subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, GV, iis, iie, jis, jie, nz)
   integer,                           intent(in)    :: iie      !< End of i index range.
   integer,                           intent(in)    :: jis      !< Start of j index range.
   integer,                           intent(in)    :: jie      !< End of j index range.
-  integer,                           intent(in)    :: nz       !< End of k index range.
+  integer,                           intent(in)    :: ks       !< Start of k index range.
+  integer,                           intent(in)    :: ke       !< End of k index range.
 
 ! Local variables
   real    :: curv  ! The grid-normalized curvature of the three thicknesses  [H ~> m or kg m-2]
@@ -3014,7 +3051,7 @@ subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, GV, iis, iie, jis, jie, nz)
   real    :: scale ! A scaling factor to reduce the curvature of the fit               [nondim]
   integer :: i,j,k
 
-  do concurrent (k=1:nz, j=jis:jie, i=iis:iie)
+  do concurrent (k=ks:ke, j=jis:jie, i=iis:iie)
     ! This limiter prevents undershooting minima within the domain with
     ! values less than h_min.
     curv = 3.0*((h_L(i,j,k) + h_R(i,j,k)) - 2.0*h_in(i,j,k))
@@ -3038,7 +3075,7 @@ end subroutine PPM_limit_pos
 
 !> This subroutine limits the left/right edge values of the PPM reconstruction
 !! according to the monotonic prescription of Colella and Woodward, 1984.
-subroutine PPM_limit_CW84(h_in, h_L, h_R, G, GV, iis, iie, jis, jie, nz)
+subroutine PPM_limit_CW84(h_in, h_L, h_R, G, GV, iis, iie, jis, jie, ks, ke)
   type(ocean_grid_type),             intent(in)  :: G     !< Ocean's grid structure.
   type(verticalGrid_type),           intent(in)  :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h_in  !< Layer thickness [H ~> m or kg m-2].
@@ -3050,7 +3087,8 @@ subroutine PPM_limit_CW84(h_in, h_L, h_R, G, GV, iis, iie, jis, jie, nz)
   integer,                           intent(in)  :: iie   !< End of i index range.
   integer,                           intent(in)  :: jis   !< Start of j index range.
   integer,                           intent(in)  :: jie   !< End of j index range.
-  integer,                           intent(in)  :: nz    !< End of k index range.
+  integer,                           intent(in)  :: ks    !< Start of k index range.
+  integer,                           intent(in)  :: ke    !< End of k index range.
 
   ! Local variables
   real    :: h_i      ! A copy of the cell-average layer thickness                [H ~> m or kg m-2]
@@ -3061,7 +3099,7 @@ subroutine PPM_limit_CW84(h_in, h_L, h_R, G, GV, iis, iie, jis, jie, nz)
   integer :: i, j, k
 
   ! untested
-  do concurrent (k=1:nz, j=jis:jie, i=iis:iie)
+  do concurrent (k=ks:ke, j=jis:jie, i=iis:iie) DO_LOCALITY(local(h_i,RLdiff,RLdiff2,RLmean,FunFac))
     ! This limiter monotonizes the parabola following
     ! Colella and Woodward, 1984, Eq. 1.10
     h_i = h_in(i,j,k)
@@ -3114,7 +3152,7 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_continuity_PPM" ! This module's name.
   character(len=256) :: mesg
-  character(len=10) :: niblock_dflt_str, njblock_dflt_str
+  character(len=10) :: niblock_dflt_str, njblock_dflt_str, nkblock_dflt_str
 
   CS%initialized = .true.
 
@@ -3186,6 +3224,7 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
                  "minimum is 0.", default=.false.)
   write(niblock_dflt_str, '(I0)') default_niblock
   write(njblock_dflt_str, '(I0)') default_njblock
+  write(nkblock_dflt_str, '(I0)') default_nkblock
   call get_param(param_file, mdl, "CONTINUITY_NIBLOCK", CS%niblock, &
                  "The i-direction block size used in the continuity solver. "//&
                  "If 0, defaults to "//trim(niblock_dflt_str)//", except when "//&
@@ -3196,6 +3235,11 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
                  "If 0, defaults to "//trim(njblock_dflt_str)//", except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
                  "domain height is used.", default=0)
+  call get_param(param_file, mdl, "CONTINUITY_NKBLOCK", CS%nkblock, &
+                 "The k-direction block size used in continuity reconstruction. "//&
+                 "If 0, defaults to "//trim(nkblock_dflt_str)//", except when "//&
+                 "running with OpenMP offload, in which case the full vertical "//&
+                 "column is used.", default=0)
   CS%diag => diag
   !$omp target update to(CS)
 


### PR DESCRIPTION
`PPM_reconstruction_x/y` in `dev/gpu` is significantly slower on CPU than `dev/gfdl`. This is because it `dev/gfdl` works by layer, whereas `dev/gpu` works by entire domain, therefore being less cache friendly.

This PR introduces blocking in the k-dimension, so we can switch between working by layer or with the whole domain.

Some CPU numbers from double gyre:

Problem size means NIGLOBAL = NJGLOBAL = N

compiled with `ifort -O2 -qno-opt-dynamic-align -fp-model source`

MOM_override:
```
#override COORD_CONFIG = "linear"
DENSITY_RAGE = 2.0
#override NIGLOBAL = 600
#override NJGLOBAL = 600
#override NK = 100
#override RESTINT = 0.0
#override DAYMAX = 1.0
```

executed with `mpiexec -n 100 --map-by package`

<img width="1064" height="526" alt="image" src="https://github.com/user-attachments/assets/a348ebda-9665-4a11-a519-092bc3658d26" />

The timings for continuity reconstruction are about the same between this PR and dev/gfdl.