### PR TITLE
Add k blocking in horizontal viscosity

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -54,7 +54,7 @@ use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
 use MOM_grid,                  only : ocean_grid_type
 use MOM_harmonic_analysis,     only : HA_init, harmonic_analysis_CS
 use MOM_hor_index,             only : hor_index_type
-use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_CS, hor_visc_vel_stencil
+use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_nkblock, hor_visc_CS, hor_visc_vel_stencil
 use MOM_hor_visc,              only : hor_visc_init, hor_visc_end
 use MOM_interface_heights,     only : thickness_to_dz, find_col_avg_SpV
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
@@ -960,7 +960,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
   call horizontal_viscosity(u_av, v_av, h_av, uh, vh, CS%diffu, CS%diffv, &
-                            MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt, &
+                            MEKE, Varmix, G, GV, US, CS%hor_visc, hor_visc_nkblock(CS%hor_visc, GV), tv, dt, &
                             OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                             ADp=CS%ADp, hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v, STOCH=STOCH)
 
@@ -1750,8 +1750,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
       .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
     !$omp target update to(u, v, h, uh, vh)
     call horizontal_viscosity(u, v, h, uh, vh, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
-                              tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
-                              hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
+                              hor_visc_nkblock(CS%hor_visc, GV), tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, &
+                              TD=thickness_diffuse_CSp, hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
     !$omp target update from(CS%diffu, CS%diffv)
     call set_initialized(CS%diffu, "diffu", restart_CS)
     call set_initialized(CS%diffv, "diffv", restart_CS)

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -53,7 +53,7 @@ use MOM_debugging,             only : check_redundant
 use MOM_grid,                  only : ocean_grid_type
 use MOM_harmonic_analysis,     only : HA_init, harmonic_analysis_CS
 use MOM_hor_index,             only : hor_index_type
-use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_CS
+use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_nkblock, hor_visc_CS
 use MOM_hor_visc,              only : hor_visc_init, hor_visc_end
 use MOM_interface_heights,     only : thickness_to_dz, find_col_avg_SpV
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
@@ -575,7 +575,8 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
   call horizontal_viscosity(u_av, v_av, h_av, uh, vh, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc, &
-                            tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, ADp=CS%AD_pred)
+                            hor_visc_nkblock(CS%hor_visc, GV), tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, &
+                            TD=thickness_diffuse_CSp, ADp=CS%AD_pred)
   call cpu_clock_end(id_clock_horvisc)
   if (showCallTree) call callTree_wayPoint("done with predictor horizontal_viscosity (step_MOM_dyn_split_RK2b)")
 
@@ -885,7 +886,8 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
   call horizontal_viscosity(u_av, v_av, h_av, uh, vh, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc, &
-                            tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, ADp=CS%ADp)
+                            hor_visc_nkblock(CS%hor_visc, GV), tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, &
+                            TD=thickness_diffuse_CSp, ADp=CS%ADp)
   call cpu_clock_end(id_clock_horvisc)
   if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2b)")
 

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -80,7 +80,7 @@ use MOM_CoriolisAdv, only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_CS, Corioli
 use MOM_debugging, only : check_redundant
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
-use MOM_hor_visc, only : horizontal_viscosity, hor_visc_init, hor_visc_CS
+use MOM_hor_visc, only : horizontal_viscosity, hor_visc_nkblock, hor_visc_init, hor_visc_CS
 use MOM_interface_heights, only : find_eta, thickness_to_dz
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types, only : MEKE_type
@@ -269,8 +269,8 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
 ! diffu = horizontal viscosity terms (u,h)
   call enable_averages(dt, Time_local, CS%diag)
   call cpu_clock_begin(id_clock_horvisc)
-  call horizontal_viscosity(u, v, h, uh, vh, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt, &
-    STOCH=STOCH)
+  call horizontal_viscosity(u, v, h, uh, vh, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc, &
+    hor_visc_nkblock(CS%hor_visc, GV), tv, dt, STOCH=STOCH)
   call cpu_clock_end(id_clock_horvisc)
   call disable_averaging(CS%diag)
 

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -79,7 +79,7 @@ use MOM_CoriolisAdv, only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_CS, Corioli
 use MOM_debugging, only : check_redundant
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
-use MOM_hor_visc, only : horizontal_viscosity, hor_visc_init, hor_visc_CS
+use MOM_hor_visc, only : horizontal_viscosity, hor_visc_nkblock, hor_visc_init, hor_visc_CS
 use MOM_interface_heights, only : thickness_to_dz
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types, only : MEKE_type
@@ -282,7 +282,7 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   call enable_averages(dt,Time_local, CS%diag)
   call cpu_clock_begin(id_clock_horvisc)
   call horizontal_viscosity(u_in, v_in, h_in, uh, vh, CS%diffu, CS%diffv, MEKE, VarMix, &
-                            G, GV, US, CS%hor_visc, tv, dt, STOCH=STOCH)
+                            G, GV, US, CS%hor_visc, hor_visc_nkblock(CS%hor_visc, GV), tv, dt, STOCH=STOCH)
   call cpu_clock_end(id_clock_horvisc)
   call disable_averaging(CS%diag)
   call pass_vector(CS%diffu, CS%diffv, G%Domain, clock=id_clock_pass)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -315,7 +315,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
     div_xx_dx, &  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
     ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJB_(G)) :: &
+  real, dimension(SZI_(G),SZJB_(G),nkblock) :: &
     Del2v, &      ! The v-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
     h_v, &        ! Thickness interpolated to v points [H ~> m or kg m-2].
     vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
@@ -575,17 +575,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     str_xy_GME(:,:) = 0.0
 
     ! Get barotropic velocities and their gradients
-    call barotropic_get_tav(BT, ubtav(:,:,1), vbtav, G, US)
+    call barotropic_get_tav(BT, ubtav(:,:,1), vbtav(:,:,1), G, US)
 
-    call pass_vector(ubtav(:,:,1), vbtav, G%Domain)
+    call pass_vector(ubtav(:,:,1), vbtav(:,:,1), G%Domain)
     call pass_var(h, G%domain, halo=2)
 
     ! Calculate the barotropic horizontal tension
     do j=js-2,je+2 ; do i=is-2,ie+2
       dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j,1)) - &
                                      (G%IdyCu(I-1,j) * ubtav(I-1,j,1)))
-      dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J)) - &
-                                     (G%IdxCv(i,J-1) * vbtav(i,J-1)))
+      dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J,1)) - &
+                                     (G%IdxCv(i,J-1) * vbtav(i,J-1,1)))
     enddo ; enddo
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
@@ -593,8 +593,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Components for the barotropic shearing strain
     do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
-      dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J)*G%IdyCv(i+1,J)) &
-                                    - (vbtav(i,J)*G%IdyCv(i,J)))
+      dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J,1)*G%IdyCv(i+1,J)) &
+                                    - (vbtav(i,J,1)*G%IdyCv(i,J)))
       dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1,1)*G%IdxCu(I,j+1)) &
                                     - (ubtav(I,j,1)*G%IdxCu(I,j)))
     enddo ; enddo
@@ -776,21 +776,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         h_u(I,j,1) = hu_cont(I,j,k)
       enddo ; enddo
       do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J) = hv_cont(i,J,k)
+        h_v(i,J,1) = hv_cont(i,J,k)
       enddo ; enddo
     elseif (CS%use_land_mask) then
       do j=js-2,je+2 ; do I=is-2,Ieq+1
         h_u(I,j,1) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
       enddo ; enddo
       do J=js-2,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
+        h_v(i,J,1) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
       enddo ; enddo
     else
       do j=js-2,je+2 ; do I=is-2,Ieq+1
         h_u(I,j,1) = 0.5 * (h(i,j,k) + h(i+1,j,k))
       enddo ; enddo
       do J=js-2,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
+        h_v(i,J,1) = 0.5 * (h(i,j,k) + h(i,j+1,k))
       enddo ; enddo
     endif
 
@@ -863,13 +863,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! becomes do i=is-1,ie+1. -RWH
         if ((J >= js-2) .and. (J <= Jeq+1)) then
           do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
-            h_v(i,J) = h(i,j,k)
+            h_v(i,J,1) = h(i,j,k)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-2) .and. (J <= Jeq+1)) then
           do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
-            h_v(i,J) = h(i,j+1,k)
+            h_v(i,J,1) = h(i,j+1,k)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
@@ -904,13 +904,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= ie)) then
           do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
-            h_v(i+1,J) = h_v(i,J)
+            h_v(i+1,J,1) = h_v(i,J,1)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-1) .and. (I <= ie+1)) then
           do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
-            h_v(i,J) = h_v(i+1,J)
+            h_v(i,J,1) = h_v(i+1,J,1)
           enddo
         endif
       endif
@@ -951,7 +951,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                      CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j)) - (CS%dy2h(i,j)*sh_xx(i,j)))
       enddo ; enddo
       do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
-        Del2v(i,J) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
+        Del2v(i,J,1) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
                      CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1)) - (CS%dx2h(i,j)*sh_xx(i,j)))
       enddo ; enddo
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
@@ -959,7 +959,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
             do I=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
-              Del2v(i,J) = 0.
+              Del2v(i,J,1) = 0.
             enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
             do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
@@ -1010,7 +1010,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Vorticity gradient
       do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-        vort_xy_dx(i,J) = DY_dxBu * ((vort_xy(I,J) * G%IdyCu(I,j)) - (vort_xy(I-1,J) * G%IdyCu(I-1,j)))
+        vort_xy_dx(i,J,1) = DY_dxBu * ((vort_xy(I,J) * G%IdyCu(I,j)) - (vort_xy(I-1,J) * G%IdyCu(I-1,j)))
       enddo ; enddo
 
       do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
@@ -1022,7 +1022,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Gradient of smoothed vorticity
         do J=js_Kh-1,je_Kh ; do i=is_Kh,ie_Kh
           DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-          vort_xy_dx_smooth(i,J) = DY_dxBu * &
+          vort_xy_dx_smooth(i,J,1) = DY_dxBu * &
                       ((vort_xy_smooth(I,J) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J) * G%IdyCu(I-1,j)))
         enddo ; enddo
 
@@ -1039,7 +1039,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
 
-        Del2vort_q(I,J) = DY_dxBu * ((vort_xy_dx(i+1,J) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J) * G%IdyCv(i,J))) + &
+        Del2vort_q(I,J) = DY_dxBu * ((vort_xy_dx(i+1,J,1) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J,1) * G%IdyCv(i,J))) + &
                           DX_dyBu * ((vort_xy_dy(I,j+1,1) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,1) * G%IdyCu(I,j)))
       enddo ; enddo
       ! endif
@@ -1056,17 +1056,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           div_xx_dx(I,j,1) = G%IdxCu(I,j)*(div_xx(i+1,j) - div_xx(i,j))
         enddo ; enddo
         do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
-          div_xx_dy(i,J) = G%IdyCv(i,J)*(div_xx(i,j+1) - div_xx(i,j))
+          div_xx_dy(i,J,1) = G%IdyCv(i,J)*(div_xx(i,j+1) - div_xx(i,j))
         enddo ; enddo
 
         ! Magnitude of divergence gradient
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           grad_div_mag_h(i,j) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I-1,j,1)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J) + div_xx_dy(i,J-1)))**2))
+                                     ((0.5*(div_xx_dy(i,J,1) + div_xx_dy(i,J-1,1)))**2))
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
           grad_div_mag_q(I,J) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I,j+1,1)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J) + div_xx_dy(i+1,J)))**2))
+                                     ((0.5*(div_xx_dy(i,J,1) + div_xx_dy(i+1,J,1)))**2))
         enddo ; enddo
 
       else
@@ -1075,7 +1075,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           div_xx_dx(I,j,1) = 0.0
         enddo ; enddo
         do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
-          div_xx_dy(i,J) = 0.0
+          div_xx_dy(i,J,1) = 0.0
         enddo ; enddo
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           grad_div_mag_h(i,j) = 0.0
@@ -1089,7 +1089,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Add in beta for the Leith viscosity
       if (CS%use_beta_in_Leith) then
         do J=js-2,Jeq+1 ; do i=is-1,ie+1
-          vort_xy_dx(i,J) = vort_xy_dx(i,J) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
+          vort_xy_dx(i,J,1) = vort_xy_dx(i,J,1) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
         enddo ; enddo
         do j=js-1,je+1 ; do I=is-2,Ieq+1
           vort_xy_dy(I,j,1) = vort_xy_dy(I,j,1) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
@@ -1099,33 +1099,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%use_QG_Leith_visc) then
 
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_vort_mag_h_2d(i,j) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2) + &
+          grad_vort_mag_h_2d(i,j) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
                                          ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_vort_mag_q_2d(I,J) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2) + &
+          grad_vort_mag_q_2d(I,J) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
                                          ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
         enddo ; enddo
 
         ! This accumulates terms, some of which are in VarMix.
-        call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,1), div_xx_dy, &
-                                     slope_x, slope_y, vort_xy_dx, vort_xy_dy(:,:,1))
+        call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,1), div_xx_dy(:,:,1), &
+                                     slope_x, slope_y, vort_xy_dx(:,:,1), vort_xy_dy(:,:,1))
 
       endif
 
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        grad_vort_mag_h(i,j) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2) + &
+        grad_vort_mag_h(i,j) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
                                     ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
       enddo ; enddo
       do J=js-1,Jeq ; do I=is-1,Ieq
-        grad_vort_mag_q(I,J) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2) + &
+        grad_vort_mag_q(I,J) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
                                     ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
       enddo ; enddo
 
       if (CS%use_Leithy) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          vert_vort_mag_smooth(i,j) = SQRT(((0.5*(vort_xy_dx_smooth(i,J) + &
-                                                  vort_xy_dx_smooth(i,J-1)))**2) + &
+          vert_vort_mag_smooth(i,j) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,1) + &
+                                                  vort_xy_dx_smooth(i,J-1,1)))**2) + &
                                            ((0.5*(vort_xy_dy_smooth(I,j,1) + &
                                                   vort_xy_dy_smooth(I-1,j,1)))**2) )
         enddo ; enddo
@@ -1144,7 +1144,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        h_min = min(h_u(I,j,1), h_u(I-1,j,1), h_v(i,J), h_v(i,J-1))
+        h_min = min(h_u(I,j,1), h_u(I-1,j,1), h_v(i,J,1), h_v(i,J-1,1))
         hrat_min(i,j) = min(1.0, h_min / (h(i,j,k) + h_neglect))
       enddo ; enddo
     endif
@@ -1455,7 +1455,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j,1)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,1))
-        d_del2v = (G%IdxCv(i,J) * Del2v(i,J)) - (G%IdxCv(i,J-1) * Del2v(i,J-1))
+        d_del2v = (G%IdxCv(i,J) * Del2v(i,J,1)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,1))
         d_str = Ah(i,j) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
 
         str_xx(i,j) = str_xx(i,j) + d_str
@@ -1499,7 +1499,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
       do J=js-1,Jeq ; do I=is-1,Ieq
-        dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J)*G%IdyCv(i+1,J)) - (Del2v(i,J)*G%IdyCv(i,J)))
+        dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J,1)*G%IdyCv(i+1,J)) - (Del2v(i,J,1)*G%IdyCv(i,J)))
         dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,1)*G%IdxCu(I,j+1)) - (Del2u(I,j,1)*G%IdxCu(I,j)))
       enddo ; enddo
       ! Adjust contributions to shearing strain on open boundaries.
@@ -1539,14 +1539,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     do J=js-1,Jeq ; do I=is-1,Ieq
       h2uq = 4.0 * (h_u(I,j,1) * h_u(I,j+1,1))
-      h2vq = 4.0 * (h_v(i,J) * h_v(i+1,J))
+      h2vq = 4.0 * (h_v(i,J,1) * h_v(i+1,J,1))
       hq(I,J) = (2.0 * (h2uq * h2vq)) &
-          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,1) + h_u(I,j+1,1)) + (h_v(i,J) + h_v(i+1,J))))
+          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,1) + h_u(I,j+1,1)) + (h_v(i,J,1) + h_v(i+1,J,1))))
     enddo ; enddo
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
       do J=js-1,Jeq ; do I=is-1,Ieq
-        h_min = min(h_u(I,j,1), h_u(I,j+1,1), h_v(i,J), h_v(i+1,J))
+        h_min = min(h_u(I,j,1), h_u(I,j+1,1), h_v(i,J,1), h_v(i+1,J,1))
         hrat_min(I,J) = min(1.0, h_min / (hq(I,J) + h_neglect))
       enddo ; enddo
 
@@ -1560,7 +1560,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             ! This is a coastal vorticity point, so modify hq and hrat_min.
 
             hu = G%mask2dCu(I,j) * h_u(I,j,1) + G%mask2dCu(I,j+1) * h_u(I,j+1,1)
-            hv = G%mask2dCv(i,J) * h_v(i,J) + G%mask2dCv(i+1,J) * h_v(i+1,J)
+            hv = G%mask2dCv(i,J) * h_v(i,J,1) + G%mask2dCv(i+1,J) * h_v(i+1,J,1)
             if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) * &
                 (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
               ! Only one of hu and hv is nonzero, so just add them.
@@ -1947,7 +1947,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     do J=Jsq,Jeq ; do i=is,ie
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j)) - (CS%dx2h(i,j+1)*str_xx(i,j+1)))) * &
-                     G%IareaCv(i,J)) / (h_v(i,J) + h_neglect)
+                     G%IareaCv(i,J)) / (h_v(i,J,1) + h_neglect)
     enddo ; enddo
 
     if (apply_OBC) then
@@ -1991,28 +1991,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
            - (str_xx(i,j)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
           + (0.25*(((str_xy(I,J)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
                 +(str_xy(I-1,J-1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
                +((str_xy(I-1,J)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
                 +(str_xy(I,J-1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)))) )) ) )) )
 
         enddo ; enddo
       endif
@@ -2053,28 +2053,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
            - (bhstr_xx(i,j)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
           + (0.25*(((bhstr_xy(I,J)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
                 +(bhstr_xy(I-1,J-1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
                +((bhstr_xy(I-1,J)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
                 +(bhstr_xy(I,J-1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)))) )) ) )) )
         enddo ; enddo
       endif
 
@@ -2111,28 +2111,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
            - (str_xx_GME(i,j)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
        + (0.25*(((str_xy_GME(I,J)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
                 +(str_xy_GME(I-1,J-1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
                +((str_xy_GME(I-1,J)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
                 +(str_xy_GME(I,J-1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)))) )) ) )) )
       enddo ; enddo ; endif
     endif
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1350,53 +1350,53 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Determine the biharmonic viscosity at h points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Ah(i,j,1) = CS%Ah_bg_xx(i,j)
-      enddo ; enddo
+      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        Ah(i,j,kk) = CS%Ah_bg_xx(i,j)
+      enddo ; enddo ; enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              AhSm = Shear_mag(i,j,1) * (CS%Biharm_const_xx(i,j) &
-                  + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j,1))
-              Ah(i,j,1) = max(Ah(i,j,1), AhSm)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              AhSm = Shear_mag(i,j,kk) * (CS%Biharm_const_xx(i,j) &
+                  + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j,kk))
+              Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
+            enddo ; enddo ; enddo
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j,1)
-              Ah(i,j,1) = max(Ah(i,j,1), AhSm)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j,kk)
+              Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
+            enddo ; enddo ; enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
-                                 (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                                 (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
-            Ah(i,j,1) = max(Ah(i,j,1), AhLth)
-          enddo ; enddo
+            Ah(i,j,kk) = max(Ah(i,j,kk), AhLth)
+          enddo ; enddo ; enddo
         endif
 
         if (CS%use_Leithy) then
           ! Get m_leithy
           if (CS%smooth_Ah) m_leithy(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
-                                 (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                                 (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
             if (AhLth <= CS%Ah_bg_xx(i,j)) then
-              m_leithy(i,j,1) = 0.0
+              m_leithy(i,j,kk) = 0.0
             else
-              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j,1)) < abs(vort_xy_smooth(i,j,1))) then
-                m_leithy(i,j,1) = CS%c_K * (vert_vort_mag(i,j,1) / vort_xy_smooth(i,j,1))**2
+              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j,kk)) < abs(vort_xy_smooth(i,j,kk))) then
+                m_leithy(i,j,kk) = CS%c_K * (vert_vort_mag(i,j,kk) / vort_xy_smooth(i,j,kk))**2
               else
-                m_leithy(i,j,1) = CS%m_leithy_max(i,j)
+                m_leithy(i,j,kk) = CS%m_leithy_max(i,j)
               endif
-              m_leithy(i,j,1) = G%mask2dBu(i,j) * m_leithy(i,j,1)
+              m_leithy(i,j,kk) = G%mask2dBu(i,j) * m_leithy(i,j,kk)
             endif
-          enddo ; enddo
+          enddo ; enddo ; enddo
 
           if (CS%smooth_Ah) then
             ! Smooth m_leithy.  A single call smoothes twice.
@@ -1405,31 +1405,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             call pass_var(m_leithy(:,:,1), G%Domain)
           endif
           ! Get Ah
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
-                                 (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                                 (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
-                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,1)*vert_vort_mag_smooth(i,j,1)**2))
-            Ah(i,j,1) = max(CS%Ah_bg_xx(i,j), AhLthy)
-          enddo ; enddo
+                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,kk)*vert_vort_mag_smooth(i,j,kk)**2))
+            Ah(i,j,kk) = max(CS%Ah_bg_xx(i,j), AhLthy)
+          enddo ; enddo ; enddo
           if (CS%smooth_Ah) then
             ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
             Ah_sq(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_sq(i,j,1) = Ah(i,j,1)**2
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Ah_sq(i,j,kk) = Ah(i,j,kk)**2
+            enddo ; enddo ; enddo
             call pass_var(Ah_sq(:,:,1), G%Domain, halo=2)
             ! A single call smoothes twice.
             call smooth_x9_h(G, Ah_sq(:,:,1), zero_land=.false.)
             call pass_var(Ah_sq(:,:,1), G%Domain)
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,1))))
-              Ah(i,j,1)     = Ah_h(i,j,k)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              k = kstart + kk - 1
+              Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,kk))))
+              Ah(i,j,kk)    = Ah_h(i,j,k)
+            enddo ; enddo ; enddo
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_h(i,j,k) = Ah(i,j,1)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              k = kstart + kk - 1
+              Ah_h(i,j,k) = Ah(i,j,kk)
+            enddo ; enddo ; enddo
           endif
         endif
 
@@ -1437,76 +1439,82 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Ah(i,j,1) = Ah(i,j,1) + MEKE%Au(i,j)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          Ah(i,j,kk) = Ah(i,j,kk) + MEKE%Au(i,j)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = kstart + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
-          Ah(i,j,1) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
-        enddo ; enddo
+          Ah(i,j,kk) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Ah(i,j,1) = min(Ah(i,j,1), visc_bound_rem(i,j,1) * hrat_min(i,j,1) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Ah(i,j,kk) = min(Ah(i,j,kk), visc_bound_rem(i,j,kk) * hrat_min(i,j,kk) * CS%Ah_Max_xx(i,j))
+          enddo ; enddo ; enddo
         else
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Ah(i,j,1) = min(Ah(i,j,1), hrat_min(i,j,1) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Ah(i,j,kk) = min(Ah(i,j,kk), hrat_min(i,j,kk) * CS%Ah_Max_xx(i,j))
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            tmp = CS%KS_coef * hrat_min(i,j,1) * CS%Ah_Max_xx_KS(i,j)
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            k = kstart + kk - 1
+            tmp = CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xx_KS(i,j)
             visc_limit_h(i,j,k) = tmp
-            visc_limit_h_frac(i,j,k) = Ah(i,j,1) / (CS%KS_coef * hrat_min(i,j,1) * CS%Ah_Max_xx_KS(i,j))
-            if (Ah(i,j,1) >= tmp) then
+            visc_limit_h_frac(i,j,k) = Ah(i,j,kk) / (CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xx_KS(i,j))
+            if (Ah(i,j,kk) >= tmp) then
               visc_limit_h_flag(i,j,k) = 1.
             endif
-          enddo ; enddo
+          enddo ; enddo ; enddo
       endif
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Ah_h(i,j,k) = Ah(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = kstart + kk - 1
+          Ah_h(i,j,k) = Ah(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%use_Leithy) then
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j,1) = -m_leithy(i,j,1) * Ah(i,j,1)
-          Kh_h(i,j,k) = Kh(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = kstart + kk - 1
+          Kh(i,j,kk) = -m_leithy(i,j,kk) * Ah(i,j,kk)
+          Kh_h(i,j,k) = Kh(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Ah > 0) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I-1,j,k))**2) + ((v(i,J,k) + v(i,J-1,k))**2))
-          grid_Ah = max(Ah(i,j,1), CS%min_grid_Ah)
+          grid_Ah = max(Ah(i,j,kk), CS%min_grid_Ah)
           grid_Re_Ah(i,j,k) = (sqrt(KE) * CS%grid_sp_h3(i,j)) / grid_Ah
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        d_del2u = (G%IdyCu(I,j) * Del2u(I,j,1)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,1))
-        d_del2v = (G%IdxCv(i,J) * Del2v(i,J,1)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,1))
-        d_str = Ah(i,j,1) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = kstart + kk - 1
+        d_del2u = (G%IdyCu(I,j) * Del2u(I,j,kk)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,kk))
+        d_del2v = (G%IdxCv(i,J) * Del2v(i,J,kk)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,kk))
+        d_str = Ah(i,j,kk) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
 
-        str_xx(i,j,1) = str_xx(i,j,1) + d_str
+        str_xx(i,j,kk) = str_xx(i,j,kk) + d_str
 
-        if (CS%use_Leithy) str_xx(i,j,1) = str_xx(i,j,1) - Kh(i,j,1) * sh_xx_smooth(i,j,1)
+        if (CS%use_Leithy) str_xx(i,j,kk) = str_xx(i,j,kk) - Kh(i,j,kk) * sh_xx_smooth(i,j,kk)
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        bhstr_xx(i,j,1) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
+        bhstr_xx(i,j,kk) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo ; enddo
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
     ! Backscatter using MEKE

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -337,8 +337,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real, dimension(SZI_(G),SZJ_(G)) :: &
     GME_effic_h   ! The filtered efficiency of the GME terms at h points [nondim]
   real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
-    m_leithy, &   ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
-    Ah_sq         ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
+    m_leithy      ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
   real :: Del2vort_h ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
 
   real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
@@ -409,7 +408,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     v_smooth         ! Meridional velocity, smoothed with a spatial low-pass filter [L T-1 ~> m s-1]
   real :: AhSm       ! Smagorinsky biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: AhLth      ! 2D Leith biharmonic viscosity [L4 T-1 ~> m4 s-1]
-  real :: AhLthy     ! 2D Leith+E biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: Shear_mag_bc  ! Shear_mag value in backscatter [T-1 ~> s-1]
   real :: sh_xx_sq   ! Square of tension (sh_xx) [T-2 ~> s-2]
   real :: sh_xy_sq   ! Square of shearing strain (sh_xy) [T-2 ~> s-2]
@@ -638,7 +636,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp   if (CS%EY24_EBT_BS)
   !$omp target enter data map(alloc: vert_vort_mag, vert_vort_mag_smooth) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
-  !$omp target enter data map(alloc: m_leithy, Ah_sq) if (CS%use_Leithy)
+  !$omp target enter data map(alloc: m_leithy) if (CS%use_Leithy)
   !$omp target enter data map(alloc: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
   !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
   !$omp target enter data map(alloc: vort_xy, vort_xy_smooth) &
@@ -1199,69 +1197,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
 
         if (CS%use_Leithy) then
-          ! Get m_leithy
-          if (CS%smooth_Ah) then
-            do kk=1,kmax
-              m_leithy(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
-            enddo
-          endif
-          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Del2vort_h, AhLth))
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
-                                 (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
-            AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
-            if (AhLth <= CS%Ah_bg_xx(i,j)) then
-              m_leithy(i,j,kk) = 0.0
-            else
-              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j,kk)) < abs(vort_xy_smooth(i,j,kk))) then
-                m_leithy(i,j,kk) = CS%c_K * (vert_vort_mag(i,j,kk) / vort_xy_smooth(i,j,kk))**2
-              else
-                m_leithy(i,j,kk) = CS%m_leithy_max(i,j)
-              endif
-              m_leithy(i,j,kk) = G%mask2dBu(i,j) * m_leithy(i,j,kk)
-            endif
-          enddo
-
-          if (CS%smooth_Ah) then
-            do kk=1,kmax
-              ! Smooth m_leithy.  A single call smoothes twice.
-              call pass_var(m_leithy(:,:,kk), G%Domain, halo=2)
-              call smooth_x9_h(G, m_leithy(:,:,kk), zero_land=.true.)
-              call pass_var(m_leithy(:,:,kk), G%Domain)
-            enddo
-          endif
-          ! Get Ah
-          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Del2vort_h, AhLthy))
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
-                                 (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
-            AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
-                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,kk)*vert_vort_mag_smooth(i,j,kk)**2))
-            Ah(i,j,kk) = max(CS%Ah_bg_xx(i,j), AhLthy)
-          enddo
-          if (CS%smooth_Ah) then
-            ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
-            do kk=1,kmax
-              Ah_sq(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
-            enddo
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-              Ah_sq(i,j,kk) = Ah(i,j,kk)**2
-            enddo
-            do kk=1,kmax
-              call pass_var(Ah_sq(:,:,kk), G%Domain, halo=2)
-              ! A single call smoothes twice.
-              call smooth_x9_h(G, Ah_sq(:,:,kk), zero_land=.false.)
-              call pass_var(Ah_sq(:,:,kk), G%Domain)
-            enddo
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
-              k = kstart + kk - 1
-              Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,kk))))
-              Ah(i,j,kk)    = Ah_h(i,j,k)
-            enddo
-          else
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
-              k = kstart + kk - 1
-              Ah_h(i,j,k) = Ah(i,j,kk)
-            enddo
-          endif
+          call hor_visc_Leithy_Ah(G, GV, CS, nkblock, kstart, kmax, is_Kh, ie_Kh, js_Kh, je_Kh, inv_PI6, &
+                                  Del2vort_q, vert_vort_mag, vert_vort_mag_smooth, vort_xy_smooth, &
+                                  Ah, Ah_h, m_leithy)
         endif
 
       endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
@@ -2101,7 +2039,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp   if (CS%EY24_EBT_BS)
   !$omp target exit data map(delete: vert_vort_mag, vert_vort_mag_smooth) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
-  !$omp target exit data map(delete: m_leithy, Ah_sq) if (CS%use_Leithy)
+  !$omp target exit data map(delete: m_leithy) if (CS%use_Leithy)
   !$omp target exit data map(delete: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
   !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
   !$omp target exit data map(delete: vort_xy, vort_xy_smooth) &
@@ -2560,6 +2498,113 @@ subroutine hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, nkbloc
   enddo
 
 end subroutine hor_visc_backscatter_q
+
+!> Computes the Leith+E antisymmetric-viscosity ratio m_leithy, and updates the
+!! biharmonic viscosity Ah (and Ah_h) to include the Leith+E contribution, optionally
+!! smoothing m_leithy and Ah in the process. The caller must only invoke this
+!! routine when CS%use_Leithy is true.
+subroutine hor_visc_Leithy_Ah(G, GV, CS, nkblock, kstart, kmax, is_Kh, ie_Kh, js_Kh, je_Kh, inv_PI6, &
+                               Del2vort_q, vert_vort_mag, vert_vort_mag_smooth, vort_xy_smooth, &
+                               Ah, Ah_h, m_leithy)
+  type(ocean_grid_type),   intent(in)    :: G   !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV  !< The ocean's vertical grid structure.
+  type(hor_visc_CS),       intent(in)    :: CS  !< Horizontal viscosity control structure
+  integer,                 intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
+  integer,                 intent(in)    :: kstart  !< The first absolute k-layer of the current k-block
+  integer,                 intent(in)    :: kmax    !< The number of active k-layers in the current k-block
+  integer,                 intent(in)    :: is_Kh, ie_Kh, js_Kh, je_Kh !< Loop ranges for the
+                                                 !! thickness point viscosities
+  real,                    intent(in)    :: inv_PI6 !< The inverse of pi to the sixth power [nondim]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                           intent(in)    :: Del2vort_q !< Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                           intent(in)    :: vert_vort_mag !< Magnitude of the vertical vorticity
+                                                 !! gradient (h or q) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                           intent(in)    :: vert_vort_mag_smooth !< Magnitude of gradient of smoothed
+                                                 !! vertical vorticity (h or q) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                           intent(in)    :: vort_xy_smooth !< Vertical vorticity including metric
+                                                 !! terms, smoothed [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                           intent(inout) :: Ah  !< biharmonic viscosity (h or q) [L4 T-1 ~> m4 s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(inout) :: Ah_h !< biharmonic viscosity at thickness points [L4 T-1 ~> m4 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                           intent(out)   :: m_leithy !< Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
+  ! Local variables
+  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
+    Ah_sq  ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
+  real :: Del2vort_h ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
+  real :: AhLth      ! 2D Leith biharmonic viscosity [L4 T-1 ~> m4 s-1]
+  real :: AhLthy     ! 2D Leith+E biharmonic viscosity [L4 T-1 ~> m4 s-1]
+  integer :: i, j, k, kk
+
+  ! Get m_leithy
+  if (CS%smooth_Ah) then
+    do kk=1,kmax
+      m_leithy(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
+    enddo
+  endif
+  do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Del2vort_h, AhLth))
+    Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                         (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
+    AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
+    if (AhLth <= CS%Ah_bg_xx(i,j)) then
+      m_leithy(i,j,kk) = 0.0
+    else
+      if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j,kk)) < abs(vort_xy_smooth(i,j,kk))) then
+        m_leithy(i,j,kk) = CS%c_K * (vert_vort_mag(i,j,kk) / vort_xy_smooth(i,j,kk))**2
+      else
+        m_leithy(i,j,kk) = CS%m_leithy_max(i,j)
+      endif
+      m_leithy(i,j,kk) = G%mask2dBu(i,j) * m_leithy(i,j,kk)
+    endif
+  enddo
+
+  if (CS%smooth_Ah) then
+    do kk=1,kmax
+      ! Smooth m_leithy.  A single call smoothes twice.
+      call pass_var(m_leithy(:,:,kk), G%Domain, halo=2)
+      call smooth_x9_h(G, m_leithy(:,:,kk), zero_land=.true.)
+      call pass_var(m_leithy(:,:,kk), G%Domain)
+    enddo
+  endif
+  ! Get Ah
+  do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Del2vort_h, AhLthy))
+    Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                         (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
+    AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
+            sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,kk)*vert_vort_mag_smooth(i,j,kk)**2))
+    Ah(i,j,kk) = max(CS%Ah_bg_xx(i,j), AhLthy)
+  enddo
+  if (CS%smooth_Ah) then
+    ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
+    do kk=1,kmax
+      Ah_sq(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
+    enddo
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      Ah_sq(i,j,kk) = Ah(i,j,kk)**2
+    enddo
+    do kk=1,kmax
+      call pass_var(Ah_sq(:,:,kk), G%Domain, halo=2)
+      ! A single call smoothes twice.
+      call smooth_x9_h(G, Ah_sq(:,:,kk), zero_land=.false.)
+      call pass_var(Ah_sq(:,:,kk), G%Domain)
+    enddo
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
+      k = kstart + kk - 1
+      Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,kk))))
+      Ah(i,j,kk)    = Ah_h(i,j,k)
+    enddo
+  else
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
+      k = kstart + kk - 1
+      Ah_h(i,j,k) = Ah(i,j,kk)
+    enddo
+  endif
+
+end subroutine hor_visc_Leithy_Ah
 
 !> Returns the effective k-block size for horizontal_viscosity calls.
 integer function hor_visc_nkblock(CS, GV)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -253,6 +253,8 @@ type, public :: hor_visc_CS ; private
 
 end type hor_visc_CS
 
+  integer, parameter :: nkblock = 1
+
 contains
 
 !> Calculates the acceleration due to the horizontal viscosity.
@@ -306,7 +308,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   type(stochastic_CS), intent(inout), optional :: STOCH !< Stochastic control structure
 
   ! Local variables
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
+  real, dimension(SZIB_(G),SZJ_(G),nkblock) :: &
     Del2u, &      ! The u-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
     h_u, &        ! Thickness interpolated to u points [H ~> m or kg m-2].
     vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
@@ -447,7 +449,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   logical :: rescale_Kh
   logical :: find_FrictWork
-  logical :: find_FrictWork_bh
   logical :: apply_OBC = .false.
   logical :: apply_OBC_strain
   logical :: use_MEKE_Ku
@@ -477,15 +478,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     vert_vort_mag_smooth, &  ! magnitude of gradient of smoothed vertical vorticity (h or q) [L-1 T-1 ~> m-1 s-1]
     hrat_min, &     ! h_min divided by the thickness at the stress point (h or q) [nondim]
     visc_bound_rem  ! fraction of overall viscous bounds that remain to be applied (h or q) [nondim]
-
-  ! New variables: move these up once ready
-  logical :: use_Leith    ! True if any Leith parameterizations are enabled
-  logical :: use_vort_xy  ! True if vort_xy must be computed
-  logical :: use_Smag     ! True if a Smagorinsky viscosity is enabled
-
-  use_Leith = CS%Leith_Kh .or. CS%Leith_Ah .or. CS%use_Leithy
-  use_vort_xy = use_Leith .or. CS%id_vort_xy_q > 0 .or. CS%use_ZB2020
-  use_Smag = CS%Smagorinsky_Kh .or. CS%Smagorinsky_Ah
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -527,11 +519,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   if (.not.(CS%Laplacian .or. CS%biharmonic)) return
 
-  find_FrictWork = CS%id_FrictWork > 0 .or. CS%id_FrictWorkIntz > 0 &
-      .or. allocated(MEKE%mom_src)
-  find_FrictWork_bh = CS%id_FrictWork_bh > 0 .or. CS%id_FrictWorkIntz_bh > 0 &
-      .or. allocated(MEKE%mom_src_bh)
+  find_FrictWork = (CS%id_FrictWork > 0)
+  if (CS%id_FrictWorkIntz > 0) find_FrictWork = .true.
 
+  if (allocated(MEKE%mom_src)) find_FrictWork = .true.
   use_kh_struct = allocated(VarMix%BS_struct)
   backscat_subround = 0.0
   if (find_FrictWork .and. allocated(MEKE%mom_src) .and. (MEKE%backscatter_Ro_c > 0.0) .and. &
@@ -584,15 +575,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     str_xy_GME(:,:) = 0.0
 
     ! Get barotropic velocities and their gradients
-    call barotropic_get_tav(BT, ubtav, vbtav, G, US)
+    call barotropic_get_tav(BT, ubtav(:,:,1), vbtav, G, US)
 
-    call pass_vector(ubtav, vbtav, G%Domain)
+    call pass_vector(ubtav(:,:,1), vbtav, G%Domain)
     call pass_var(h, G%domain, halo=2)
 
     ! Calculate the barotropic horizontal tension
     do j=js-2,je+2 ; do i=is-2,ie+2
-      dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j)) - &
-                                     (G%IdyCu(I-1,j) * ubtav(I-1,j)))
+      dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j,1)) - &
+                                     (G%IdyCu(I-1,j) * ubtav(I-1,j,1)))
       dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J)) - &
                                      (G%IdxCv(i,J-1) * vbtav(i,J-1)))
     enddo ; enddo
@@ -604,8 +595,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
       dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J)*G%IdyCv(i+1,J)) &
                                     - (vbtav(i,J)*G%IdyCv(i,J)))
-      dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1)*G%IdxCu(I,j+1)) &
-                                    - (ubtav(I,j)*G%IdxCu(I,j)))
+      dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1,1)*G%IdxCu(I,j+1)) &
+                                    - (ubtav(I,j,1)*G%IdxCu(I,j)))
     enddo ; enddo
 
     if (CS%no_slip) then
@@ -685,50 +676,70 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! call pass_vector(slope_x, slope_y, G%Domain, halo=2)
   endif
 
-  !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-  !$omp target enter data map(alloc: h_u, h_v, hq)
-  !$omp target enter data map(alloc: str_xx, str_xy)
-  !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
-  !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
-  !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
-  !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
-  !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
-  ! TODO: Only needed if FrictWork_bh is true, and currently only used on CPU,
-  !   but I do not yet see any benefit to breaking up the calculation.
-  !$omp target enter data map(alloc: bhstr_xx, bhstr_xy) if (CS%biharmonic)
-
-  !$omp target enter data map(alloc: hrat_min) &
-  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
-  !$omp target enter data map(alloc: visc_bound_rem) &
-  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
-  !$omp target enter data map(alloc: sh_xy_q) &
-  !$omp   if (CS%id_sh_xy_q > 0)
-
+  !$OMP parallel do default(none) if (.not. CS%smooth_AH) &
+  !$OMP shared( &
+  !$OMP   CS, G, GV, US, OBC, VarMix, MEKE, u, v, h, uh, vh, &
+  !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
+  !$OMP   is_vort, ie_vort, js_vort, je_vort, &
+  !$OMP   is_Kh, ie_Kh, js_Kh, je_Kh, &
+  !$OMP   apply_OBC, apply_OBC_strain, rescale_Kh, find_FrictWork, use_kh_struct, skeb_use_frict, &
+  !$OMP   use_MEKE_Ku, use_MEKE_Au, u_smooth, v_smooth, use_cont_huv, slope_x, slope_y, dz, &
+  !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
+  !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
+  !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_bh, FrictWork_GME, &
+  !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
+  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont, STOCH &
+  !$OMP ) &
+  !$OMP private( &
+  !$OMP   i, j, k, n, tmp, &
+  !$OMP   dudx, dudy, dvdx, dvdy, sh_xx, sh_xy, h_u, h_v, &
+  !$OMP   Del2u, Del2v, DY_dxBu, DX_dyBu, sh_xx_bt, sh_xy_bt, &
+  !$OMP   str_xx, str_xy, bhstr_xx, bhstr_xy, str_xx_GME, str_xy_GME, &
+  !$OMP   vort_xy, vort_xy_dx, vort_xy_dy, div_xx, div_xx_dx, div_xx_dy, &
+  !$OMP   grad_div_mag_h, grad_div_mag_q, grad_vort_mag_h, grad_vort_mag_q, &
+  !$OMP   grad_vort, grad_vort_qg, grad_vort_mag_h_2d, grad_vort_mag_q_2d, &
+  !$OMP   sh_xx_sq, sh_xy_sq, meke_res_fn, Shear_mag, Shear_mag_bc, vert_vort_mag, &
+  !$OMP   h_min, hrat_min, visc_bound_rem, Kh_max_here, &
+  !$OMP   grid_Ah, grid_Kh, d_Del2u, d_Del2v, d_str, &
+  !$OMP   Kh, Ah, AhSm, AhLth, local_strain, Sh_F_pow, &
+  !$OMP   dDel2vdx, dDel2udy, Del2vort_q, Del2vort_h, KE, &
+  !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff, &
+  !$OMP   dudx_smooth, dudy_smooth, dvdx_smooth, dvdy_smooth, &
+  !$OMP   vort_xy_smooth, vort_xy_dx_smooth, vort_xy_dy_smooth, &
+  !$OMP   sh_xx_smooth, sh_xy_smooth, &
+  !$OMP   vert_vort_mag_smooth, m_leithy, Ah_sq, AhLthy, &
+  !$OMP   Kh_BS, str_xx_bs, str_xy_bs, bs_coeff_h, bs_coeff_q &
+  !$OMP ) &
+  !$OMP firstprivate( &
+  !$OMP   visc_limit_h, visc_limit_h_frac, visc_limit_h_flag, &
+  !$OMP   visc_limit_q, visc_limit_q_frac, visc_limit_q_flag &
+  !$OMP )
   do k=1,nz
+
     ! The following are the forms of the horizontal tension and horizontal
     ! shearing strain advocated by Smagorinsky (1993) and discussed in
     ! Griffies and Hallberg (2000).
 
+    ! NOTE: There is a ~1% speedup when the tension and shearing loops below
+    !   are fused (presumably due to shared access of Id[xy]C[uv]).  However,
+    !   this breaks the center/vertex index case convention, and also evaluates
+    !   the dudx and dvdy terms beyond their valid bounds.
+    ! TODO: Explore methods for retaining both the syntax and speedup.
+
     ! Calculate horizontal tension
-    do concurrent (j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
+    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                   (G%IdyCu(I-1,j) * u(I-1,j,k)))
-    enddo
-
-    do concurrent (j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
       dvdy(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
                                   (G%IdxCv(i,J-1) * v(i,J-1,k)))
-    enddo
-
-    do concurrent (j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
       sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
-    enddo
+    enddo ; enddo
 
     ! Components for the shearing strain
-    do concurrent (J=js_vort:je_vort, I=is_vort:ie_vort)
+    do J=js_vort,je_vort ; do I=is_vort,ie_vort
       dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
-    enddo
+    enddo ; enddo
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
@@ -750,7 +761,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! use Leith+E
 
     if (CS%id_normstress > 0) then
-      !$omp target update from(sh_xx)
       do j=js,je ; do i=is,ie
         NoSt(i,j,k) = sh_xx(i,j)
       enddo ; enddo
@@ -762,35 +772,31 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
     if (use_cont_huv) then
-      do concurrent (j=js-2:je+2, I=Isq-1:Ieq+1)
-        h_u(I,j) = hu_cont(I,j,k)
-      enddo
-      do concurrent (J=Jsq-1:Jeq+1, i=is-2:ie+2)
+      do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+        h_u(I,j,1) = hu_cont(I,j,k)
+      enddo ; enddo
+      do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
         h_v(i,J) = hv_cont(i,J,k)
-      enddo
+      enddo ; enddo
     elseif (CS%use_land_mask) then
-      do concurrent (j=js-2:je+2, I=is-2:Ieq+1)
-        h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
-      enddo
-      do concurrent (J=js-2:Jeq+1, i=is-2:ie+2)
+      do j=js-2,je+2 ; do I=is-2,Ieq+1
+        h_u(I,j,1) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
+      enddo ; enddo
+      do J=js-2,Jeq+1 ; do i=is-2,ie+2
         h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
-      enddo
+      enddo ; enddo
     else
-      do concurrent (j=js-2:je+2, I=is-2:Ieq+1)
-        h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
-      enddo
-      do concurrent (J=js-2:Jeq+1, i=is-2:ie+2)
+      do j=js-2,je+2 ; do I=is-2,Ieq+1
+        h_u(I,j,1) = 0.5 * (h(i,j,k) + h(i+1,j,k))
+      enddo ; enddo
+      do J=js-2,Jeq+1 ; do i=is-2,ie+2
         h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
-      enddo
+      enddo ; enddo
     endif
 
     ! Adjust contributions to shearing strain and interpolated values of
     ! thicknesses on open boundaries.
-    if (apply_OBC) then
-      !$omp target update from(dvdx, dudy, h_u, h_v)
-      ! TODO: Reindent this later
-      do n=1,OBC%number_of_segments
-
+    if (apply_OBC) then ; do n=1,OBC%number_of_segments
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (apply_OBC_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
@@ -869,13 +875,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
           do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
-            h_u(I,j) = h(i,j,k)
+            h_u(I,j,1) = h(i,j,k)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
           do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
-            h_u(I,j) = h(i+1,j,k)
+            h_u(I,j,1) = h(i+1,j,k)
           enddo
         endif
       endif
@@ -886,13 +892,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
         if ((J >= js-2) .and. (J <= je)) then
           do I = max(is-2,OBC%segment(n)%HI%IsdB), min(Ieq+1,OBC%segment(n)%HI%IedB)
-            h_u(I,j+1) = h_u(I,j)
+            h_u(I,j+1,1) = h_u(I,j,1)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-1) .and. (J <= je+1)) then
           do I = max(is-2,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
-            h_u(I,j) = h_u(I,j+1)
+            h_u(I,j,1) = h_u(I,j+1,1)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
@@ -908,27 +914,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
         endif
       endif
-    enddo
-    ! TODO: Fix indentation
-    !$omp target update to(dvdx, dudy, h_u, h_v)
-    endif
+    enddo ; endif
 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
-      do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
+      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
         sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
-      enddo
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
+      enddo ; enddo
     else
-      do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
+      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
         sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
-      enddo
-    endif
-
-    if (CS%id_shearstress > 0) then
-      do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
-        ShSt(I,J,k) = sh_xy(I,J)
-      enddo
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
+      enddo ; enddo
     endif
 
     if (CS%use_Leithy) then
@@ -947,18 +946,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
-      do concurrent (j=js-1:Jeq+1, I=Isq-1:Ieq+1)
-        Del2u(I,j) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
+      do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        Del2u(I,j,1) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
                      CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j)) - (CS%dy2h(i,j)*sh_xx(i,j)))
-      enddo
-
-      do concurrent (J=Jsq-1:Jeq+1, i=is-1:Ieq+1)
+      enddo ; enddo
+      do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
         Del2v(i,J) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
                      CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1)) - (CS%dx2h(i,j)*sh_xx(i,j)))
-      enddo
-
+      enddo ; enddo
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
-        !$omp target update from(Del2u, Del2v)
         do n=1,OBC%number_of_segments
           I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
@@ -967,21 +963,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
             do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
-              Del2u(I,j) = 0.
+              Del2u(I,j,1) = 0.
             enddo
           endif
         enddo
-        !$omp target update to(Del2u, Del2v)
       endif ; endif
     endif
 
     ! Vorticity
-
-    ! NOTE: Keep Leith code on CPU for now, but moving it should be
-    ! straightforward.
-
-    if (use_vort_xy) then
-      !$omp target update from(dvdx, dudy)
+    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
       if (CS%no_slip) then
         do J=js_vort,je_vort ; do I=is_vort,ie_vort
           vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
@@ -1014,7 +1004,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
     endif
 
-    if (use_Leith) then
+
+    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
 
       ! Vorticity gradient
       do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
@@ -1024,7 +1015,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-        vort_xy_dy(I,j) = DX_dyBu * ((vort_xy(I,J) * G%IdxCv(i,J)) - (vort_xy(I,J-1) * G%IdxCv(i,J-1)))
+        vort_xy_dy(I,j,1) = DX_dyBu * ((vort_xy(I,J) * G%IdxCv(i,J)) - (vort_xy(I,J-1) * G%IdxCv(i,J-1)))
       enddo ; enddo
 
       if (CS%use_Leithy) then
@@ -1037,7 +1028,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         do j=js_Kh,je_Kh ; do I=is_Kh-1,ie_Kh
           DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-          vort_xy_dy_smooth(I,j) = DX_dyBu * &
+          vort_xy_dy_smooth(I,j,1) = DX_dyBu * &
                       ((vort_xy_smooth(I,J) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1) * G%IdxCv(i,J-1)))
         enddo ; enddo
       endif ! If Leithy
@@ -1049,12 +1040,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
 
         Del2vort_q(I,J) = DY_dxBu * ((vort_xy_dx(i+1,J) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J) * G%IdyCv(i,J))) + &
-                          DX_dyBu * ((vort_xy_dy(I,j+1) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j) * G%IdyCu(I,j)))
+                          DX_dyBu * ((vort_xy_dy(I,j+1,1) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,1) * G%IdyCu(I,j)))
       enddo ; enddo
       ! endif
 
       if (CS%modified_Leith) then
-        !$omp target update from(dudx, dvdy)
 
         ! Divergence
         do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
@@ -1063,7 +1053,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         ! Divergence gradient
         do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
-          div_xx_dx(I,j) = G%IdxCu(I,j)*(div_xx(i+1,j) - div_xx(i,j))
+          div_xx_dx(I,j,1) = G%IdxCu(I,j)*(div_xx(i+1,j) - div_xx(i,j))
         enddo ; enddo
         do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
           div_xx_dy(i,J) = G%IdyCv(i,J)*(div_xx(i,j+1) - div_xx(i,j))
@@ -1071,18 +1061,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         ! Magnitude of divergence gradient
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_div_mag_h(i,j) = sqrt(((0.5*(div_xx_dx(I,j) + div_xx_dx(I-1,j)))**2) + &
+          grad_div_mag_h(i,j) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I-1,j,1)))**2) + &
                                      ((0.5*(div_xx_dy(i,J) + div_xx_dy(i,J-1)))**2))
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_div_mag_q(I,J) = sqrt(((0.5*(div_xx_dx(I,j) + div_xx_dx(I,j+1)))**2) + &
+          grad_div_mag_q(I,J) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I,j+1,1)))**2) + &
                                      ((0.5*(div_xx_dy(i,J) + div_xx_dy(i+1,J)))**2))
         enddo ; enddo
 
       else
 
         do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
-          div_xx_dx(I,j) = 0.0
+          div_xx_dx(I,j,1) = 0.0
         enddo ; enddo
         do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
           div_xx_dy(i,J) = 0.0
@@ -1097,14 +1087,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif ! CS%modified_Leith
 
       ! Add in beta for the Leith viscosity
-      ! TODO: Move G%dF_dx, G%dF_dy to GPU
-
       if (CS%use_beta_in_Leith) then
         do J=js-2,Jeq+1 ; do i=is-1,ie+1
           vort_xy_dx(i,J) = vort_xy_dx(i,J) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
         enddo ; enddo
         do j=js-1,je+1 ; do I=is-2,Ieq+1
-          vort_xy_dy(I,j) = vort_xy_dy(I,j) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
+          vort_xy_dy(I,j,1) = vort_xy_dy(I,j,1) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
         enddo ; enddo
       endif ! CS%use_beta_in_Leith
 
@@ -1112,53 +1100,53 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           grad_vort_mag_h_2d(i,j) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I-1,j)))**2) )
+                                         ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
           grad_vort_mag_q_2d(I,J) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I,j+1)))**2) )
+                                         ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
         enddo ; enddo
 
         ! This accumulates terms, some of which are in VarMix.
-        call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx, div_xx_dy, &
-                                     slope_x, slope_y, vort_xy_dx, vort_xy_dy)
+        call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,1), div_xx_dy, &
+                                     slope_x, slope_y, vort_xy_dx, vort_xy_dy(:,:,1))
 
       endif
 
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         grad_vort_mag_h(i,j) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I-1,j)))**2) )
+                                    ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
       enddo ; enddo
       do J=js-1,Jeq ; do I=is-1,Ieq
         grad_vort_mag_q(I,J) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I,j+1)))**2) )
+                                    ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
       enddo ; enddo
 
       if (CS%use_Leithy) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           vert_vort_mag_smooth(i,j) = SQRT(((0.5*(vort_xy_dx_smooth(i,J) + &
                                                   vort_xy_dx_smooth(i,J-1)))**2) + &
-                                           ((0.5*(vort_xy_dy_smooth(I,j) + &
-                                                  vort_xy_dy_smooth(I-1,j)))**2) )
+                                           ((0.5*(vort_xy_dy_smooth(I,j,1) + &
+                                                  vort_xy_dy_smooth(I-1,j,1)))**2) )
         enddo ; enddo
       endif ! Leithy
 
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         sh_xx_sq = sh_xx(i,j)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1)**2) + (sh_xy(I,J)**2)) &
                           + ((sh_xy(I-1,J)**2) + (sh_xy(I,J-1)**2)) )
         Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
-      enddo
+      enddo ; enddo
     endif
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-        h_min = min(h_u(I,j), h_u(I-1,j), h_v(i,J), h_v(i,J-1))
+      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        h_min = min(h_u(I,j,1), h_u(I-1,j,1), h_v(i,J), h_v(i,J-1))
         hrat_min(i,j) = min(1.0, h_min / (h(i,j,k) + h_neglect))
-      enddo
+      enddo ; enddo
     endif
 
     if (CS%Laplacian) then
@@ -1181,55 +1169,40 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Static (pre-computed) background viscosity
-      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Kh(i,j) = CS%Kh_bg_xx(i,j)
-      enddo
+      enddo ; enddo
 
-      if (CS%add_LES_viscosity) then
-        if (CS%Smagorinsky_Kh) then
-          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      ! NOTE: The following do-block can be decomposed and vectorized after the
+      !   stack size has been reduced.
+      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        if (CS%add_LES_viscosity) then
+          if (CS%Smagorinsky_Kh) &
             Kh(i,j) = Kh(i,j) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j)
-          enddo
-        endif
-
-        if (CS%Leith_Kh) then
-          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-            Kh(i,j) = Kh(i,j) &
-                + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3
-          enddo
-        endif
-      else
-        if (CS%Smagorinsky_Kh) then
-          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          if (CS%Leith_Kh) &
+            Kh(i,j) = Kh(i,j) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3
+        else
+          if (CS%Smagorinsky_Kh) &
             Kh(i,j) = max(Kh(i,j), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j))
-          enddo
+          if (CS%Leith_Kh) &
+            Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
         endif
-
-        if (CS%Leith_Kh) then
-          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-            Kh(i,j) = max(Kh(i,j), &
-                CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
-          enddo
-        endif
-      endif
+      enddo ; enddo
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = VarMix%Res_fn_h(i,j) * Kh(i,j)
         enddo ; enddo
-        !$omp target update to(Kh)
       endif
 
       ! Place a floor on the viscosity, if desired.
-      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
-      enddo
+      enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
-        !$omp target update from(Kh)
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
@@ -1252,24 +1225,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo ; enddo
           endif
         endif
-        !$omp target update to(Kh)
       endif
 
       if (CS%anisotropic) then
-        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           ! *Add* the tension component of anisotropic viscosity
           Kh(i,j) = Kh(i,j) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
         enddo ; enddo
-        !$omp target update to(Kh)
       endif
-
-      !$omp target update to(Kh) &
-      !$omp   if ((use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) .or. CS%anisotropic)
 
       ! Newer method of bounding for stability
       if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-        do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           visc_bound_rem(i,j) = 1.0
           Kh_max_here = hrat_min(i,j) * CS%Kh_Max_xx(i,j)
           if (Kh(i,j) >= Kh_max_here) then
@@ -1278,32 +1245,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           elseif ((Kh(i,j) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
             visc_bound_rem(i,j) = 1.0 - Kh(i,j) / Kh_max_here
           endif
-        enddo
+        enddo ; enddo
       elseif (CS%bound_Kh) then
-        do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = min(Kh(i,j), hrat_min(i,j) * CS%Kh_Max_xx(i,j))
-        enddo
+        enddo ; enddo
       endif
 
       ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
       ! The harmonic component of str_xx is added in the biharmonic loop.
       if (CS%use_Leithy) then
-        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = 0.
         enddo ; enddo
-        !$omp target update to(Kh)
       endif
 
       if (CS%id_Kh_h>0 .or. CS%debug) then
-        !$omp target update from(Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh_h(i,j,k) = Kh(i,j)
         enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Kh>0) then
-        !$omp target update from(Kh)
         do j=js,je ; do i=is,ie
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           grid_Kh = max(Kh(i,j), CS%min_grid_Kh)
@@ -1312,77 +1275,69 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_div_xx_h>0) then
-        !$omp target update from(dudx, dvdy)
         do j=js,je ; do i=is,ie
           div_xx_h(i,j,k) = dudx(i,j) + dvdy(i,j)
         enddo ; enddo
       endif
 
       if (CS%id_sh_xx_h>0) then
-        !$omp target update from(sh_xx)
         do j=js,je ; do i=is,ie
           sh_xx_h(i,j,k) = sh_xx(i,j)
         enddo ; enddo
       endif
 
-      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = -Kh(i,j) * sh_xx(i,j)
-      enddo
+      enddo ; enddo
     else
-      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = 0.0
-      enddo
+      enddo ; enddo
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then
-      !$omp target update from(str_xx, sh_xy)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         ! Shearing-strain averaged to h-points
         local_strain = 0.25 * ( (sh_xy(I,J) + sh_xy(I-1,J-1)) + (sh_xy(I-1,J) + sh_xy(I,J-1)) )
         ! *Add* the shear-strain contribution to the xx-component of stress
         str_xx(i,j) = str_xx(i,j) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
       enddo ; enddo
-      !$omp target update to(str_xx)
     endif
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at h points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
-      do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         Ah(i,j) = CS%Ah_bg_xx(i,j)
-      enddo
+      enddo ; enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               AhSm = Shear_mag(i,j) * (CS%Biharm_const_xx(i,j) &
                   + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j))
               Ah(i,j) = max(Ah(i,j), AhSm)
-            enddo
+            enddo ; enddo
           else
-            do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j)
               Ah(i,j) = max(Ah(i,j), AhSm)
-            enddo
+            enddo ; enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          !$omp target update from(Ah)
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
                                  (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
             Ah(i,j) = max(Ah(i,j), AhLth)
           enddo ; enddo
-          !$omp target update to(Ah)
         endif
 
         if (CS%use_Leithy) then
-          ! TODO: !$omp target update from(...?)
-
           ! Get m_leithy
           if (CS%smooth_Ah) m_leithy(:,:) = 0.0 ! This is here to initialize domain edge halo values.
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
@@ -1435,52 +1390,47 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo ; enddo
           endif
         endif
+
       endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Ah(i,j) = Ah(i,j) + MEKE%Au(i,j)
         enddo ; enddo
-        !$omp target update to(Ah)
       endif
 
       if (CS%Re_Ah > 0.0) then
-        !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           Ah(i,j) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
         enddo ; enddo
-        !$omp target update to(Ah)
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Ah(i,j) = min(Ah(i,j), visc_bound_rem(i,j) * hrat_min(i,j) * CS%Ah_Max_xx(i,j))
-          enddo
+          enddo ; enddo
         else
-          do concurrent (j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Ah(i,j) = min(Ah(i,j), hrat_min(i,j) * CS%Ah_Max_xx(i,j))
-          enddo
+          enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-        !$omp target update from(Ah)
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          tmp = CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j)
-          visc_limit_h(i,j,k) = tmp
-          visc_limit_h_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j))
-          if (Ah(i,j) >= tmp) then
-            visc_limit_h_flag(i,j,k) = 1.
-          endif
-        enddo ; enddo
+          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            tmp = CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j)
+            visc_limit_h(i,j,k) = tmp
+            visc_limit_h_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j))
+            if (Ah(i,j) >= tmp) then
+              visc_limit_h_flag(i,j,k) = 1.
+            endif
+          enddo ; enddo
       endif
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
-        !$omp target update from(Ah)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Ah_h(i,j,k) = Ah(i,j)
         enddo ; enddo
@@ -1489,16 +1439,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%use_Leithy) then
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
-        !$omp target update from(Ah, Kh)
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j) = -m_leithy(i,j) * Ah(i,j)
           Kh_h(i,j,k) = Kh(i,j)
         enddo ; enddo
-        !$omp target update to(Kh)
       endif
 
       if (CS%id_grid_Re_Ah > 0) then
-        !$omp target update from(Ah)
         do j=js,je ; do i=is,ie
           KE = 0.125 * (((u(I,j,k) + u(I-1,j,k))**2) + ((v(i,J,k) + v(i,J-1,k))**2))
           grid_Ah = max(Ah(i,j), CS%min_grid_Ah)
@@ -1506,30 +1453,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       endif
 
-      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
-        d_del2u = (G%IdyCu(I,j) * Del2u(I,j)) - (G%IdyCu(I-1,j) * Del2u(I-1,j))
+      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        d_del2u = (G%IdyCu(I,j) * Del2u(I,j,1)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,1))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J)) - (G%IdxCv(i,J-1) * Del2v(i,J-1))
         d_str = Ah(i,j) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
 
         str_xx(i,j) = str_xx(i,j) + d_str
 
-        ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        ! XXX: Need to get out of the loop somehow
-        if (find_FrictWork_bh) &
-          bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo
+        if (CS%use_Leithy) str_xx(i,j) = str_xx(i,j) - Kh(i,j) * sh_xx_smooth(i,j)
 
-      if (CS%use_Leithy) then
-        !$omp target update from(Kh)
-        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-          str_xx(i,j) = str_xx(i,j) - Kh(i,j) * sh_xx_smooth(i,j)
-        enddo ; enddo
-      endif
+        ! Keep a copy of the biharmonic contribution for backscatter parameterization
+        bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      !$omp target update from(sh_xx)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         if (visc_limit_h_flag(i,j,k) > 0) then
           Kh_BS(i,j) = 0.
@@ -1555,20 +1494,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = str_xx(i,j) + str_xx_BS(i,j)
       enddo ; enddo
-      !$omp target update to(str_xx)
     endif ! Backscatter
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+      do J=js-1,Jeq ; do I=is-1,Ieq
         dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J)*G%IdyCv(i+1,J)) - (Del2v(i,J)*G%IdyCv(i,J)))
-        dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1)*G%IdxCu(I,j+1)) - (Del2u(I,j)*G%IdxCu(I,j)))
-      enddo
-
+        dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,1)*G%IdxCu(I,j+1)) - (Del2u(I,j,1)*G%IdxCu(I,j)))
+      enddo ; enddo
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if ((OBC%strain_config == OBC_STRAIN_ZERO) .or. &
                                 (OBC%strain_config == OBC_STRAIN_FREESLIP)) then
-        !$omp target update from(dDel2vdx, dDel2udy)
         do n=1,OBC%number_of_segments
           J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
@@ -1589,34 +1525,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo
           endif
         enddo
-        !$omp target update to(dDel2vdx, dDel2udy)
       endif ; endif
     endif
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+      do J=js-1,Jeq ; do I=is-1,Ieq
         sh_xy_sq = sh_xy(I,J)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j)**2) + (sh_xx(i+1,j+1)**2)) &
                           + ((sh_xx(i,j+1)**2) + (sh_xx(i+1,j)**2)) )
         Shear_mag(I,J) = sqrt(sh_xy_sq + sh_xx_sq)
-      enddo
+      enddo ; enddo
     endif
 
-    do concurrent (J=js-1:Jeq, I=is-1:Ieq)
-      h2uq = 4.0 * (h_u(I,j) * h_u(I,j+1))
+    do J=js-1,Jeq ; do I=is-1,Ieq
+      h2uq = 4.0 * (h_u(I,j,1) * h_u(I,j+1,1))
       h2vq = 4.0 * (h_v(i,J) * h_v(i+1,J))
       hq(I,J) = (2.0 * (h2uq * h2vq)) &
-          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j) + h_u(I,j+1)) + (h_v(i,J) + h_v(i+1,J))))
-    enddo
+          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,1) + h_u(I,j+1,1)) + (h_v(i,J) + h_v(i+1,J))))
+    enddo ; enddo
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
-        h_min = min(h_u(I,j), h_u(I,j+1), h_v(i,J), h_v(i+1,J))
+      do J=js-1,Jeq ; do I=is-1,Ieq
+        h_min = min(h_u(I,j,1), h_u(I,j+1,1), h_v(i,J), h_v(i+1,J))
         hrat_min(I,J) = min(1.0, h_min / (hq(I,J) + h_neglect))
-      enddo
+      enddo ; enddo
+
     endif
 
-    ! TODO: GPU??  Are h_[uv] on CPU?  update to hrat_min?
     if (CS%no_slip) then
       do J=js-1,Jeq ; do I=is-1,Ieq
         if (CS%no_slip .and. (G%mask2dBu(I,J) < 0.5)) then
@@ -1624,7 +1559,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
               (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) > 0.0) then
             ! This is a coastal vorticity point, so modify hq and hrat_min.
 
-            hu = G%mask2dCu(I,j) * h_u(I,j) + G%mask2dCu(I,j+1) * h_u(I,j+1)
+            hu = G%mask2dCu(I,j) * h_u(I,j,1) + G%mask2dCu(I,j+1) * h_u(I,j+1,1)
             hv = G%mask2dCv(i,J) * h_v(i,J) + G%mask2dCv(i+1,J) * h_v(i+1,J)
             if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) * &
                 (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
@@ -1643,19 +1578,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then
-      !$omp target update to(sh_xx, sh_xy, vort_xy, hq)
-      call ZB2020_copy_gradient_and_thickness( &
-           sh_xx, sh_xy, vort_xy,              &
-           hq,                                 &
-           G, GV, CS%ZB2020, k)
+      call ZB2020_copy_gradient_and_thickness(sh_xx, sh_xy, vort_xy, hq, G, GV, CS%ZB2020, k)
     endif
-
-    !!$omp target update from(sh_xx, sh_xy)
-    !!$omp target update from(h_u, h_v, hq)
-    !!$omp target update from(str_xx)
-    !!$omp target update from(Shear_mag) if (use_Smag)
-    !!$omp target update from(Del2u, Del2v) if (CS%biharmonic)
-    !!$omp target update from(dDel2vdx, dDel2udy) if (CS%biharmonic)
 
     if (CS%Laplacian) then
       ! Determine the Laplacian viscosity at q points, using the
@@ -1677,24 +1601,23 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       ! Static (pre-computed) background viscosity
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+      do J=js-1,Jeq ; do I=is-1,Ieq
         Kh(I,J) = CS%Kh_bg_xy(I,J)
-      enddo
+      enddo ; enddo
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
-          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+          do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = Kh(I,J) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J)
-          enddo
+          enddo ; enddo
         else
-          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+          do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = max(Kh(I,J), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J) )
-          enddo
+          enddo ; enddo
         endif
       endif
 
       if (CS%Leith_Kh) then
-        !$omp target update from(Kh)
         if (CS%add_LES_viscosity) then
           do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = Kh(I,J) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3 ! Is this right? -AJA
@@ -1704,25 +1627,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Kh(I,J) = max(Kh(I,J), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3)
           enddo ; enddo
         endif
-        !$omp target update to(Kh)
       endif
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        !$omp target update from(Kh)
         do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J) = VarMix%Res_fn_q(I,J) * Kh(I,J)
         enddo ; enddo
-        !$omp target update to(Kh)
       endif
 
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+      do J=js-1,Jeq ; do I=is-1,Ieq
         Kh(I,J) = max(Kh(I,J), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
-      enddo
+      enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
-        !$omp target update from(Kh)
         if (use_kh_struct) then
           do J=js-1,Jeq ; do I=is-1,Ieq
             meke_res_fn = 1.
@@ -1744,21 +1663,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                         MEKE%Ku(i,j+1)) ) * meke_res_fn
           enddo ; enddo
         endif
-        !$omp target update to(Kh)
       endif
 
       if (CS%anisotropic) then
-        !$omp target update from(Kh)
         ! *Add* the shear component of anisotropic viscosity
         do J=js-1,Jeq ; do I=is-1,Ieq
             Kh(I,J) = Kh(I,J) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
         enddo ; enddo
-        !$omp target update to(Kh)
       endif
 
-      if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
+      do J=js-1,Jeq ; do I=is-1,Ieq
         ! Newer method of bounding for stability
-        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+        if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
           visc_bound_rem(I,J) = 1.0
           Kh_max_here = hrat_min(I,J) * CS%Kh_Max_xy(I,J)
           if (Kh(I,J) >= Kh_max_here) then
@@ -1767,24 +1683,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           elseif ((Kh(I,J) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
             visc_bound_rem(I,J) = 1.0 - Kh(I,J) / Kh_max_here
           endif
-        enddo
-      elseif (CS%bound_Kh) then
-        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+        elseif (CS%bound_Kh) then
           Kh(I,J) = min(Kh(I,J), hrat_min(I,J) * CS%Kh_Max_xy(I,J))
-        enddo
-      endif
+        endif
+      enddo ; enddo
 
       if (CS%use_Leithy) then
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
         do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
         enddo ; enddo
-        !$omp target update to(Kh)
       endif
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
-        !$omp target update from (Kh)
-        do J=js-1,Jeq; do I=is-1,Ieq
+        do J=js-1,Jeq ; do I=is-1,Ieq
           Kh_q(I,J,k) = Kh(I,J)
         enddo ; enddo
       endif
@@ -1796,107 +1708,95 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_sh_xy_q > 0) then
-        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+        do J=js-1,Jeq ; do I=is-1,Ieq
           sh_xy_q(I,J,k) = sh_xy(I,J)
-        enddo
+        enddo ; enddo
       endif
 
       if (.not. CS%use_Leithy) then
-        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+        do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
-        enddo
+        enddo ; enddo
       else
-        !$omp target update from(Kh)
         do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = -Kh(I,J) * sh_xy_smooth(I,J)
         enddo ; enddo
-        !$omp target update to(str_xy)
       endif
     else
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+      do J=js-1,Jeq ; do I=is-1,Ieq
         str_xy(I,J) = 0.
-      enddo
+      enddo ; enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then
-      !$omp target update from(sh_xx, str_xy)
       do J=js-1,Jeq ; do I=is-1,Ieq
         ! Horizontal-tension averaged to q-points
         local_strain = 0.25 * ( (sh_xx(i,j) + sh_xx(i+1,j+1)) + (sh_xx(i+1,j) + sh_xx(i,j+1)) )
         ! *Add* the tension contribution to the xy-component of stress
         str_xy(I,J) = str_xy(I,J) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
       enddo ; enddo
-      !$omp target update to(str_xy)
     endif
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+      do J=js-1,Jeq ; do I=is-1,Ieq
         Ah(I,J) = CS%Ah_bg_xy(I,J)
-      enddo
+      enddo ; enddo
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+            do J=js-1,Jeq ; do I=is-1,Ieq
               AhSm = Shear_mag(I,J) * (CS%Biharm_const_xy(I,J) &
                   + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J))
               Ah(I,J) = max(Ah(I,J), AhSm)
-            enddo
+            enddo ; enddo
           else
-            do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+            do J=js-1,Jeq ; do I=is-1,Ieq
               AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J)
               Ah(I,J) = max(Ah(I,J), AhSm)
-            enddo
+            enddo ; enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          !$omp target update from(Ah)
           do J=js-1,Jeq ; do I=is-1,Ieq
             AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J)) * inv_PI6
             Ah(I,J) = max(Ah(I,J), AhLth)
           enddo ; enddo
-          !$omp target update to(Ah)
         endif
       endif ! Smagorinsky_Ah or Leith_Ah
 
       if (use_MEKE_Au) then
-        !$omp target update from(Ah)
         ! *Add* the MEKE contribution
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah(I,J) = Ah(I,J) + 0.25 * ( &
               (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) + (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
         enddo ; enddo
-        !$omp target update to(Ah)
       endif
 
-      ! XXX: It is just overwrites the values!
       if (CS%Re_Ah > 0.0) then
         do J=js-1,Jeq ; do I=is-1,Ieq
           KE = 0.125 * (((u(I,j,k) + u(I,j+1,k))**2) + ((v(i,J,k) + v(i+1,J,k))**2))
           Ah(I,J) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
         enddo ; enddo
-        !$omp target update to(Ah)
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+          do J=js-1,Jeq ; do I=is-1,Ieq
             Ah(I,J) = min(Ah(I,J), visc_bound_rem(I,J) * hrat_min(I,J) * CS%Ah_Max_xy(I,J))
-          enddo
+          enddo ; enddo
         else
-          do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+          do J=js-1,Jeq ; do I=is-1,Ieq
             Ah(I,J) = min(Ah(I,J), hrat_min(I,J) * CS%Ah_Max_xy(I,J))
-          enddo
+          enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-        ! TODO: Fix indent!
-        !$omp target update from(Ah, hrat_min)
           do J=js-1,Jeq ; do I=is-1,Ieq
             tmp = CS%KS_coef *hrat_min(I,J) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
@@ -1912,31 +1812,27 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah(I,J) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
         enddo ; enddo
-        !$omp target update to(Ah)
       endif
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
-        !$omp target update from(Ah)
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah_q(I,J,k) = Ah(I,J)
         enddo ; enddo
       endif
 
       ! Again, need to initialize str_xy as if its biharmonic
-      do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+      do J=js-1,Jeq ; do I=is-1,Ieq
         d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
 
         str_xy(I,J) = str_xy(I,J) + d_str
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        ! NOTE: computing this ought to be conditional!  But it uses d_str...
         bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-      enddo
+      enddo ; enddo
     endif ! Get Ah at q points and biharmonic part of str_xy
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      !$omp target update from(sh_xy, str_xy)
       do J=js-1,Jeq ; do I=is-1,Ieq
         if (visc_limit_q_flag(I,J,k) > 0) then
           Kh_BS(I,J) = 0.
@@ -1966,13 +1862,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do J=js-1,Jeq ; do I=is-1,Ieq
         str_xy(I,J) = str_xy(I,J) + str_xy_BS(I,J)
       enddo ; enddo
-      !$omp target update to(str_xy)
     endif ! Backscatter
 
     if (CS%use_GME) then
-      !$omp target update from(str_xx, str_xy)
-      !$omp target update from(hq) if (CS%no_slip)
-
       ! The wider halo here is to permit one pass of smoothing without a halo update.
       do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
         GME_coeff = GME_effic_h(i,j) * 0.25 * &
@@ -2012,34 +1904,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
-      !$omp target update to(str_xx, str_xy)
+
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do concurrent (j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo
+      enddo ; enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+        do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
-        enddo
+        enddo ; enddo
       else
-        do concurrent (J=js-1:Jeq, I=is-1:Ieq)
+        do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo
+        enddo ; enddo
       endif
     endif ! use_GME
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
-    do concurrent (j=js:je, I=Isq:Ieq)
+    do j=js,je ; do I=Isq,Ieq
       diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1)) - (CS%dx2q(I,J)*str_xy(I,J))) + &
                        G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j)) - (CS%dy2h(i+1,j)*str_xx(i+1,j)))) * &
-                     G%IareaCu(I,j)) / (h_u(I,j) + h_neglect)
-    enddo
+                     G%IareaCu(I,j)) / (h_u(I,j,1) + h_neglect)
+    enddo ; enddo
 
     if (apply_OBC) then
-      !$omp target update from(diffu)
       ! This is not the right boundary condition. If all the masking of tendencies are done
       ! correctly later then eliminating this block should not change answers.
       do n=1,OBC%number_of_segments
@@ -2050,18 +1941,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
         endif
       enddo
-      !$omp target update to(diffu)
     endif
 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
-    do concurrent (J=Jsq:Jeq, i=is:ie)
+    do J=Jsq,Jeq ; do i=is,ie
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j)) - (CS%dx2h(i,j+1)*str_xx(i,j+1)))) * &
                      G%IareaCv(i,J)) / (h_v(i,J) + h_neglect)
-    enddo
+    enddo ; enddo
 
     if (apply_OBC) then
-      !$omp target update from(diffv)
       ! This is not the right boundary condition. If all the masking of tendencies are done
       ! correctly later then eliminating this block should not change answers.
       do n=1,OBC%number_of_segments
@@ -2072,15 +1961,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
         endif
       enddo
-      !$omp target update to(diffv)
     endif
 
-    !$omp target update from(h_u, h_v) &
-    !$omp   if ((find_Frictwork .or. find_FrictWork_bh) .and. .not. CS%FrictWork_bug)
-
     if (find_FrictWork) then
-      !$omp target update from(str_xx, str_xy)
-
       if (CS%FrictWork_bug) then
         ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion
@@ -2105,29 +1988,29 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do j=js,je ; do i=is,ie
           FrictWork(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((str_xx(i,j)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) ) ) &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
            - (str_xx(i,j)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
           + (0.25*(((str_xy(I,J)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect))))            &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
                 +(str_xy(I-1,J-1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1)+h_neglect))))    &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
                +((str_xy(I-1,J)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect))))      &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
                 +(str_xy(I,J-1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1)+h_neglect))))          &
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
 
@@ -2141,8 +2024,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
     endif
 
-    if (find_FrictWork_bh) then
-      !$omp target update from(bhstr_xx, bhstr_xy)
+    if (CS%id_FrictWork_bh>0 .or. CS%id_FrictWorkIntz_bh > 0 .or. allocated(MEKE%mom_src_bh)) then
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc
@@ -2168,29 +2050,29 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
           FrictWork_bh(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((bhstr_xx(i,j)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) ) ) &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
            - (bhstr_xx(i,j)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
           + (0.25*(((bhstr_xy(I,J)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect))))            &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
                 +(bhstr_xy(I-1,J-1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1)+h_neglect))))    &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
                +((bhstr_xy(I-1,J)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect))))      &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
                 +(bhstr_xy(I,J-1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1)+h_neglect))))          &
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
         enddo ; enddo
@@ -2226,29 +2108,29 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       else ; do j=js,je ; do i=is,ie
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((str_xx_GME(i,j)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) ) ) &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
            - (str_xx_GME(i,j)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
        + (0.25*(((str_xy_GME(I,J)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect))))            &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
                 +(str_xy_GME(I-1,J-1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1)+h_neglect))))    &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
                +((str_xy_GME(I-1,J)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect))))      &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
                 +(str_xy_GME(I,J-1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1)+h_neglect))))          &
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
       enddo ; enddo ; endif
@@ -2282,7 +2164,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
       endif
       if (MEKE%backscatter_Ro_c /= 0.) then
-        !$omp target update from(sh_xx, sh_xy)
         do j=js,je ; do i=is,ie
           FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
                         (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
@@ -2333,21 +2214,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! find_FrictWork and associated(mom_src)
   enddo ! end of k loop
 
-  !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
-  !$omp target exit data map(delete: h_u, h_v, hq)
-  !$omp target exit data map(delete: str_xx, str_xy)
-  !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
-  !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)
-  !$omp target exit data map(delete: Shear_mag) if (use_Smag)
-  !$omp target exit data map(delete: Kh) if (CS%Laplacian)
-  !$omp target exit data map(delete: Ah) if (CS%biharmonic)
-  !$omp target exit data map(delete: bhstr_xx, bhstr_xy) if (CS%biharmonic)
-
-  !$omp target exit data map(delete: hrat_min) &
-  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
-  !$omp target exit data map(delete: visc_bound_rem) &
-  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
-
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)
   if (CS%id_shearstress > 0) call post_data(CS%id_shearstress, ShSt, CS%diag)
@@ -2395,9 +2261,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       call Bchksum(Ah_q, "Ah_q", G%HI, haloshift=0, symmetric=.true., unscale=US%L_to_m**4*US%s_to_T)
     endif
   endif
-
-  !$omp target exit data map(delete: sh_xy_q) &
-  !$omp   if (CS%id_sh_xy_q > 0)
 
   if (CS%id_FrictWorkIntz > 0) then
     do j=js,je
@@ -2860,9 +2723,6 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       "LAPLACIAN or BIHARMONIC viscosity.")
     return ! We are not using either Laplacian or Bi-harmonic lateral viscosity
   endif
-
-  !$omp target update to(CS)
-
   deg2rad = atan(1.0) / 45.
   ALLOC_(CS%dx2h(isd:ied,jsd:jed))        ; CS%dx2h(:,:)    = 0.0
   ALLOC_(CS%dy2h(isd:ied,jsd:jed))        ; CS%dy2h(:,:)    = 0.0
@@ -2872,9 +2732,6 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   ALLOC_(CS%dy_dxT(isd:ied,jsd:jed))      ; CS%dy_dxT(:,:)  = 0.0
   ALLOC_(CS%dx_dyBu(IsdB:IedB,JsdB:JedB)) ; CS%dx_dyBu(:,:) = 0.0
   ALLOC_(CS%dy_dxBu(IsdB:IedB,JsdB:JedB)) ; CS%dy_dxBu(:,:) = 0.0
-  !$omp target enter data map(alloc: CS%dx2h, CS%dy2h, CS%dx2q, CS%dy2q)
-  !$omp target enter data map(alloc: CS%dx_dyT, CS%dy_dxT, CS%dx_dyBu, CS%dy_dxBu)
-
   if (CS%Laplacian) then
     ALLOC_(CS%grid_sp_h2(isd:ied,jsd:jed))   ; CS%grid_sp_h2(:,:) = 0.0
     ALLOC_(CS%Kh_bg_xx(isd:ied,jsd:jed))     ; CS%Kh_bg_xx(:,:) = 0.0
@@ -2966,37 +2823,31 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       allocate(CS%Re_Ah_const_xy(IsdB:IedB,JsdB:JedB), source=0.0)
     endif
   endif
-
-  do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
+  do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
     CS%dx2q(I,J) = G%dxBu(I,J)*G%dxBu(I,J) ; CS%dy2q(I,J) = G%dyBu(I,J)*G%dyBu(I,J)
-  enddo
+  enddo ; enddo
 
   if (((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) .and. &
       ((G%isc-G%isd < 3) .or. (G%isc-G%isd < 3))) call MOM_error(FATAL, &
           "The minimum halo size is 3 when a Leith viscosity is being used.")
   if (CS%use_Leithy) then
-    do concurrent (J=js-3:Jeq+2, I=is-3:Ieq+2)
+    do J=js-3,Jeq+2 ; do I=is-3,Ieq+2
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo
+    enddo ; enddo
   elseif ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
-    do concurrent (J=Jsq-2:Jeq+2, I=Isq-2:Ieq+2)
+    do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo
+    enddo ; enddo
   else
-    do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
+    do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo
+    enddo ; enddo
   endif
 
-  do concurrent (j=js-2:Jeq+2, i=is-2:Ieq+2)
+  do j=js-2,Jeq+2 ; do i=is-2,Ieq+2
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)
     CS%DX_dyT(i,j) = G%dxT(i,j)*G%IdyT(i,j) ; CS%DY_dxT(i,j) = G%dyT(i,j)*G%IdxT(i,j)
-  enddo
-
-  ! TODO: Remove this after every instance has been moved to GPU
-  !$omp target update from(CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)
-  !$omp target update from(CS%dx2h, CS%dy2h, CS%dx_dyT, CS%dy_dxT)
-
+  enddo ; enddo
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     CS%reduction_xx(i,j) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &
@@ -3012,7 +2863,6 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
         (G%dx_Cv(i,J-1) < G%dxCv(i,J-1) * CS%reduction_xx(i,j))) &
       CS%reduction_xx(i,j) = G%dx_Cv(i,J-1) / (G%dxCv(i,J-1))
   enddo ; enddo
-
   do J=js-1,Jeq ; do I=is-1,Ieq
     CS%reduction_xy(I,J) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &
@@ -3423,30 +3273,6 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       'Depth integrated work done by the biharmonic lateral friction', &
       'W m-2', conversion=US%RZ3_T3_to_W_m2*US%L_to_Z**2)
 
-
-  ! TODO: Position these after their respective loops (and run loops on device)
-  !$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-
-  !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Kh_max_xy) &
-  !$omp   if (CS%Laplacian .and. CS%bound_Kh)
-  !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
-  !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
-
-  !$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy)
-  !$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
-  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
-  !$omp target enter data map(to: CS%Biharm_const_xy) &
-  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
-  !$omp target enter data map(to: CS%Biharm_const2_xy) &
-  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
-  !$omp target enter data map(to: CS%Ah_max_xx) if (CS%bound_Ah)
-  !$omp target enter data map(to: CS%Ah_max_xy) if (CS%bound_Ah)
-
 end subroutine hor_visc_init
 
 !> hor_visc_vel_stencil returns the horizontal viscosity input velocity stencil size
@@ -3662,34 +3488,6 @@ end subroutine smooth_x9_uv
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
   type(hor_visc_CS), intent(inout) :: CS !< Horizontal viscosity control structure
-
-  !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
-  !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
-
-  !$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%dx2q, CS%dy2q)
-  !$omp target exit data map(delete: CS%dx2h, CS%dy2h)
-
-  !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Kh_max_xy) &
-  !$omp   if (CS%Laplacian .and. CS%bound_Kh)
-  !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
-  !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
-
-  !$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
-  !$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy)
-  !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
-  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
-  !$omp target exit data map(delete: CS%Biharm_const_xy) &
-  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
-  !$omp target exit data map(delete: CS%Biharm_const2_xy) &
-  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
-  !$omp target exit data map(delete: CS%Ah_max_xx) if (CS%bound_Ah)
-  !$omp target exit data map(delete: CS%Ah_max_xy) if (CS%bound_Ah)
-
   if (CS%Laplacian .or. CS%biharmonic) then
     DEALLOC_(CS%dx2h) ; DEALLOC_(CS%dx2q) ; DEALLOC_(CS%dy2h) ; DEALLOC_(CS%dy2q)
     DEALLOC_(CS%dx_dyT) ; DEALLOC_(CS%dy_dxT) ; DEALLOC_(CS%dx_dyBu) ; DEALLOC_(CS%dy_dxBu)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -563,12 +563,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                              dudx_bt, dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, &
                              GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME, &
                              GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
-    ! sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME are computed on the host above
-    ! and are only ever read (not written) on the device; dudx_bt, dvdy_bt, dvdx_bt, dudy_bt are only
-    ! used on the host (post_data diagnostics), so they are not mapped at all.
+    ! NOTE: sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, KH_u_GME and KH_v_GME
+    !   are computed on the host above and are only read (never written) on the
+    !   device.  dudx_bt, dvdy_bt, dvdx_bt and dudy_bt are only used on the
+    !   host (post_data diagnostics), so they are not mapped at all.
     !$omp target enter data map(to: sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME)
-    ! GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME are written and read entirely on the device
-    ! (aside from the smooth_GME host round-trip below), so a bare alloc is enough on entry.
+    ! NOTE: GME_coeff_h, GME_coeff_q, str_xx_GME and str_xy_GME are written and
+    !   read entirely on the device (aside from the smooth_GME host round-trip
+    !   below), so a bare alloc is enough on entry.
     !$omp target enter data map(alloc: GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
   endif
 
@@ -3205,6 +3207,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       "LAPLACIAN or BIHARMONIC viscosity.")
     return ! We are not using either Laplacian or Bi-harmonic lateral viscosity
   endif
+
+  !$omp target update to(CS)
+
   deg2rad = atan(1.0) / 45.
   ALLOC_(CS%dx2h(isd:ied,jsd:jed))        ; CS%dx2h(:,:)    = 0.0
   ALLOC_(CS%dy2h(isd:ied,jsd:jed))        ; CS%dy2h(:,:)    = 0.0
@@ -3214,6 +3219,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   ALLOC_(CS%dy_dxT(isd:ied,jsd:jed))      ; CS%dy_dxT(:,:)  = 0.0
   ALLOC_(CS%dx_dyBu(IsdB:IedB,JsdB:JedB)) ; CS%dx_dyBu(:,:) = 0.0
   ALLOC_(CS%dy_dxBu(IsdB:IedB,JsdB:JedB)) ; CS%dy_dxBu(:,:) = 0.0
+  !$omp target enter data map(alloc: CS%dx2h, CS%dy2h, CS%dx2q, CS%dy2q)
+  !$omp target enter data map(alloc: CS%dx_dyT, CS%dy_dxT, CS%dx_dyBu, CS%dy_dxBu)
+
   if (CS%Laplacian) then
     ALLOC_(CS%grid_sp_h2(isd:ied,jsd:jed))   ; CS%grid_sp_h2(:,:) = 0.0
     ALLOC_(CS%Kh_bg_xx(isd:ied,jsd:jed))     ; CS%Kh_bg_xx(:,:) = 0.0
@@ -3305,31 +3313,37 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       allocate(CS%Re_Ah_const_xy(IsdB:IedB,JsdB:JedB), source=0.0)
     endif
   endif
-  do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+
+  do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
     CS%dx2q(I,J) = G%dxBu(I,J)*G%dxBu(I,J) ; CS%dy2q(I,J) = G%dyBu(I,J)*G%dyBu(I,J)
-  enddo ; enddo
+  enddo
 
   if (((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) .and. &
       ((G%isc-G%isd < 3) .or. (G%isc-G%isd < 3))) call MOM_error(FATAL, &
           "The minimum halo size is 3 when a Leith viscosity is being used.")
   if (CS%use_Leithy) then
-    do J=js-3,Jeq+2 ; do I=is-3,Ieq+2
+    do concurrent (J=js-3:Jeq+2, I=is-3:Ieq+2)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo ; enddo
+    enddo
   elseif ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
-    do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+    do concurrent (J=Jsq-2:Jeq+2, I=Isq-2:Ieq+2)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo ; enddo
+    enddo
   else
-    do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+    do concurrent (J=js-2:Jeq+1, I=is-2:Ieq+1)
       CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
-    enddo ; enddo
+    enddo
   endif
 
-  do j=js-2,Jeq+2 ; do i=is-2,Ieq+2
+  do concurrent (j=js-2:Jeq+2, i=is-2:Ieq+2)
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)
     CS%DX_dyT(i,j) = G%dxT(i,j)*G%IdyT(i,j) ; CS%DY_dxT(i,j) = G%dyT(i,j)*G%IdxT(i,j)
-  enddo ; enddo
+  enddo
+
+  ! TODO: Remove this after every instance has been moved to GPU
+  !$omp target update from(CS%dx2q, CS%dy2q, CS%dx_dyBu, CS%dy_dxBu)
+  !$omp target update from(CS%dx2h, CS%dy2h, CS%dx_dyT, CS%dy_dxT)
+
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     CS%reduction_xx(i,j) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &
@@ -3345,6 +3359,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
         (G%dx_Cv(i,J-1) < G%dxCv(i,J-1) * CS%reduction_xx(i,j))) &
       CS%reduction_xx(i,j) = G%dx_Cv(i,J-1) / (G%dxCv(i,J-1))
   enddo ; enddo
+
   do J=js-1,Jeq ; do I=is-1,Ieq
     CS%reduction_xy(I,J) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &
@@ -3755,6 +3770,30 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       'Depth integrated work done by the biharmonic lateral friction', &
       'W m-2', conversion=US%RZ3_T3_to_W_m2*US%L_to_Z**2)
 
+
+  ! TODO: Position these after their respective loops (and run loops on device)
+  !$omp target enter data map(to: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+
+  !$omp target enter data map(to: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Kh_max_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Kh_max_xy) &
+  !$omp   if (CS%Laplacian .and. CS%bound_Kh)
+  !$omp target enter data map(to: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !$omp target enter data map(to: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
+
+  !$omp target enter data map(to: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
+  !$omp target enter data map(to: CS%reduction_xx, CS%reduction_xy)
+  !$omp target enter data map(to: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !$omp target enter data map(to: CS%Biharm_const_xy) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
+  !$omp target enter data map(to: CS%Biharm_const2_xy) &
+  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
+  !$omp target enter data map(to: CS%Ah_max_xx) if (CS%bound_Ah)
+  !$omp target enter data map(to: CS%Ah_max_xy) if (CS%bound_Ah)
+
 end subroutine hor_visc_init
 
 !> hor_visc_vel_stencil returns the horizontal viscosity input velocity stencil size
@@ -3970,6 +4009,34 @@ end subroutine smooth_x9_uv
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
   type(hor_visc_CS), intent(inout) :: CS !< Horizontal viscosity control structure
+
+  !$omp target exit data map(delete: CS%DX_dyT, CS%DY_dxT)
+  !$omp target exit data map(delete: CS%Dx_dyBu, CS%DY_dxBu)
+
+  !$omp target exit data map(delete: CS%Idxdy2u, CS%Idxdy2v) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%Idx2dyCu, CS%Idx2dyCv) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%dx2q, CS%dy2q)
+  !$omp target exit data map(delete: CS%dx2h, CS%dy2h)
+
+  !$omp target exit data map(delete: CS%Kh_bg_xx, CS%Kh_bg_xy) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Kh_Max_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Kh_max_xy) &
+  !$omp   if (CS%Laplacian .and. CS%bound_Kh)
+  !$omp target exit data map(delete: CS%Laplac2_const_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Laplac3_const_xx) if (CS%Laplacian)
+  !$omp target exit data map(delete: CS%Laplac2_const_xy) if (CS%Smagorinsky_Kh)
+
+  !$omp target exit data map(delete: CS%Ah_bg_xx, CS%Ah_bg_xy) if (CS%biharmonic)
+  !$omp target exit data map(delete: CS%reduction_xx, CS%reduction_xy)
+  !$omp target exit data map(delete: CS%Biharm_const_xx, CS%Biharm_const2_xx) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah .or. CS%use_Leithy)
+  !$omp target exit data map(delete: CS%Biharm_const_xy) &
+  !$omp   if (CS%Smagorinsky_Ah .or. CS%Leith_Ah)
+  !$omp target exit data map(delete: CS%Biharm_const2_xy) &
+  !$omp   if (CS%bound_Coriolis .and. (CS%Smagorinsky_Ah .or. CS%Leith_Ah))
+  !$omp target exit data map(delete: CS%Ah_max_xx) if (CS%bound_Ah)
+  !$omp target exit data map(delete: CS%Ah_max_xy) if (CS%bound_Ah)
+
   if (CS%Laplacian .or. CS%biharmonic) then
     DEALLOC_(CS%dx2h) ; DEALLOC_(CS%dx2q) ; DEALLOC_(CS%dy2h) ; DEALLOC_(CS%dy2q)
     DEALLOC_(CS%dx_dyT) ; DEALLOC_(CS%dy_dxT) ; DEALLOC_(CS%dx_dyBu) ; DEALLOC_(CS%dy_dxBu)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2,6 +2,8 @@
 ! See the LICENSE file for licensing information.
 ! SPDX-License-Identifier: Apache-2.0
 
+#include "do_concurrent_compat.h"
+
 !> Calculates horizontal viscosity and viscous stresses
 module MOM_hor_visc
 
@@ -680,7 +682,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! TODO: Explore methods for retaining both the syntax and speedup.
 
     ! Calculate horizontal tension
-    do concurrent (kk=1:kmax, j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
+    do concurrent (kk=1:kmax, j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2) DO_LOCALITY(local(k))
       k = kstart + kk - 1
       dudx(i,j,kk) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                     (G%IdyCu(I-1,j) * u(I-1,j,k)))
@@ -690,7 +692,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     enddo
 
     ! Components for the shearing strain
-    do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort)
+    do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort) DO_LOCALITY(local(k))
       k = kstart + kk - 1
       dvdx(I,J,kk) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J,kk) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
@@ -698,7 +700,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k, dudx_smooth, dvdy_smooth))
         k = kstart + kk - 1
         dudx_smooth = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
                                            (G%IdyCu(I-1,j) * u_smooth(I-1,j,k)))
@@ -708,7 +710,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       ! Components for the shearing strain from smoothed velocity
-      do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh)
+      do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         dvdx_smooth(I,J,kk) = CS%DY_dxBu(I,J) * &
                          ((v_smooth(i+1,J,k)*G%IdyCv(i+1,J)) - (v_smooth(i,J,k)*G%IdyCv(i,J)))
@@ -718,7 +720,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! use Leith+E
 
     if (CS%id_normstress > 0) then
-      do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+      do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         NoSt(i,j,k) = sh_xx(i,j,kk)
       enddo
@@ -730,29 +732,29 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
     if (use_cont_huv) then
-      do concurrent (kk=1:kmax, j=js-2:je+2, I=Isq-1:Ieq+1)
+      do concurrent (kk=1:kmax, j=js-2:je+2, I=Isq-1:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         h_u(I,j,kk) = hu_cont(I,j,k)
       enddo
-      do concurrent (kk=1:kmax, J=Jsq-1:Jeq+1, i=is-2:ie+2)
+      do concurrent (kk=1:kmax, J=Jsq-1:Jeq+1, i=is-2:ie+2) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         h_v(i,J,kk) = hv_cont(i,J,k)
       enddo
     elseif (CS%use_land_mask) then
-      do concurrent (kk=1:kmax, j=js-2:je+2, I=is-2:Ieq+1)
+      do concurrent (kk=1:kmax, j=js-2:je+2, I=is-2:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         h_u(I,j,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
       enddo
-      do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-2:ie+2)
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-2:ie+2) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         h_v(i,J,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
       enddo
     else
-      do concurrent (kk=1:kmax, j=js-2:je+2, I=is-2:Ieq+1)
+      do concurrent (kk=1:kmax, j=js-2:je+2, I=is-2:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         h_u(I,j,kk) = 0.5 * (h(i,j,k) + h(i+1,j,k))
       enddo
-      do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-2:ie+2)
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-2:ie+2) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         h_v(i,J,kk) = 0.5 * (h(i,j,k) + h(i,j+1,k))
       enddo
@@ -764,7 +766,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (apply_OBC_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
-          do concurrent (kk=1:kmax, I=max(OBC%segment(n)%HI%IsdB,Is_vort):min(OBC%segment(n)%HI%IedB,Ie_vort))
+          do concurrent (kk=1:kmax, &
+                         I=max(OBC%segment(n)%HI%IsdB,Is_vort):min(OBC%segment(n)%HI%IedB,Ie_vort)) &
+                         DO_LOCALITY(local(k))
             k = kstart + kk - 1
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
@@ -792,7 +796,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             endif
           enddo
         elseif (OBC%segment(n)%is_E_or_W .and. (I >= is_vort) .and. (I <= ie_vort)) then
-          do concurrent (kk=1:kmax, J=max(OBC%segment(n)%HI%JsdB,js_vort):min(OBC%segment(n)%HI%JedB,je_vort))
+          do concurrent (kk=1:kmax, &
+                         J=max(OBC%segment(n)%HI%JsdB,js_vort):min(OBC%segment(n)%HI%JedB,je_vort)) &
+                         DO_LOCALITY(local(k))
             k = kstart + kk - 1
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
@@ -828,28 +834,36 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! are always zeroed out at OBC points, in which case the i-loop below
         ! becomes do i=is-1,ie+1. -RWH
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do concurrent (kk=1:kmax, i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied))
+          do concurrent (kk=1:kmax, &
+                         i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied)) &
+                         DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_v(i,J,kk) = h(i,j,k)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do concurrent (kk=1:kmax, i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied))
+          do concurrent (kk=1:kmax, &
+                         i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied)) &
+                         DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_v(i,J,kk) = h(i,j+1,k)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do concurrent (kk=1:kmax, j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed))
+          do concurrent (kk=1:kmax, &
+                         j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed)) &
+                         DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_u(I,j,kk) = h(i,j,k)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do concurrent (kk=1:kmax, j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed))
+          do concurrent (kk=1:kmax, &
+                         j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed)) &
+                         DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_u(I,j,kk) = h(i+1,j,k)
           enddo
@@ -889,13 +903,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
-      do concurrent (kk=1:kmax, J=js-2:Jeq+1, I=is-2:Ieq+1)
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, I=is-2:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         sh_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
       enddo
     else
-      do concurrent (kk=1:kmax, J=js-2:Jeq+1, I=is-2:Ieq+1)
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, I=is-2:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         sh_xy(I,J,kk) = G%mask2dBu(I,J) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
@@ -950,7 +964,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo
       else
         if (CS%use_circulation) then
-          do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort)
+          do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort) DO_LOCALITY(local(k))
             k = kstart + kk - 1
             vort_xy(I,J,kk) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
               ((v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J)))  &
@@ -981,25 +995,25 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
 
       ! Vorticity gradient
-      do concurrent (kk=1:kmax, J=js-2:je_Kh, i=is_Kh-1:ie_Kh+1)
+      do concurrent (kk=1:kmax, J=js-2:je_Kh, i=is_Kh-1:ie_Kh+1) DO_LOCALITY(local(DY_dxBu))
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         vort_xy_dx(i,J,kk) = DY_dxBu * ((vort_xy(I,J,kk) * G%IdyCu(I,j)) - (vort_xy(I-1,J,kk) * G%IdyCu(I-1,j)))
       enddo
 
-      do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, I=is-2:ie_Kh)
+      do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, I=is-2:ie_Kh) DO_LOCALITY(local(DX_dyBu))
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
         vort_xy_dy(I,j,kk) = DX_dyBu * ((vort_xy(I,J,kk) * G%IdxCv(i,J)) - (vort_xy(I,J-1,kk) * G%IdxCv(i,J-1)))
       enddo
 
       if (CS%use_Leithy) then
         ! Gradient of smoothed vorticity
-        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is_Kh:ie_Kh)
+        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(DY_dxBu))
           DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
           vort_xy_dx_smooth(i,J,kk) = DY_dxBu * &
                       ((vort_xy_smooth(I,J,kk) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,kk) * G%IdyCu(I-1,j)))
         enddo
 
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, I=is_Kh-1:ie_Kh)
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, I=is_Kh-1:ie_Kh) DO_LOCALITY(local(DX_dyBu))
           DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
           vort_xy_dy_smooth(I,j,kk) = DX_dyBu * &
                       ((vort_xy_smooth(I,J,kk) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,kk) * G%IdxCv(i,J-1)))
@@ -1008,7 +1022,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! Laplacian of vorticity
       ! if (CS%Leith_Ah .or. CS%use_Leithy) then
-      do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh)
+      do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh) DO_LOCALITY(local(DY_dxBu, DX_dyBu))
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
 
@@ -1111,7 +1125,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(sh_xx_sq, sh_xy_sq))
         sh_xx_sq = sh_xx(i,j,kk)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1,kk)**2) + (sh_xy(I,J,kk)**2)) &
                           + ((sh_xy(I-1,J,kk)**2) + (sh_xy(I,J-1,kk)**2)) )
@@ -1120,7 +1134,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k, h_min))
         k = kstart + kk - 1
         h_min = min(h_u(I,j,kk), h_u(I-1,j,kk), h_v(i,J,kk), h_v(i,J-1,kk))
         hrat_min(i,j,kk) = min(1.0, h_min / (h(i,j,k) + h_neglect))
@@ -1134,7 +1148,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%use_QG_Leith_visc) then
-          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(grad_vort, grad_vort_qg))
             grad_vort = grad_vort_mag_h(i,j,kk) + grad_div_mag_h(i,j,kk)
             grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j,kk)
             vert_vort_mag(i,j,kk) = min(grad_vort, grad_vort_qg)
@@ -1184,12 +1198,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
               k = kstart + kk - 1
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
             enddo
           else
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
               k = kstart + kk - 1
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
             enddo
@@ -1216,7 +1230,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! Newer method of bounding for stability
       if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Kh_max_here))
           visc_bound_rem(i,j,kk) = 1.0
           Kh_max_here = hrat_min(i,j,kk) * CS%Kh_Max_xx(i,j)
           if (Kh(i,j,kk) >= Kh_max_here) then
@@ -1241,14 +1255,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_Kh_h>0 .or. CS%debug) then
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           Kh_h(i,j,k) = Kh(i,j,kk)
         enddo
       endif
 
       if (CS%id_grid_Re_Kh>0) then
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k, KE, grid_Kh))
           k = kstart + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           grid_Kh = max(Kh(i,j,kk), CS%min_grid_Kh)
@@ -1257,14 +1271,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_div_xx_h>0) then
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           div_xx_h(i,j,k) = dudx(i,j,kk) + dvdy(i,j,kk)
         enddo
       endif
 
       if (CS%id_sh_xx_h>0) then
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           sh_xx_h(i,j,k) = sh_xx(i,j,kk)
         enddo
@@ -1299,13 +1313,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(AhSm))
               AhSm = Shear_mag(i,j,kk) * (CS%Biharm_const_xx(i,j) &
                   + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j,kk))
               Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
             enddo
           else
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(AhSm))
               AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j,kk)
               Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
             enddo
@@ -1313,7 +1327,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
 
         if (CS%Leith_Ah) then
-          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Del2vort_h, AhLth))
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
                                  (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
@@ -1328,7 +1342,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
               m_leithy(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
             enddo
           endif
-          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Del2vort_h, AhLth))
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
                                  (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
@@ -1353,7 +1367,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             enddo
           endif
           ! Get Ah
-          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(Del2vort_h, AhLthy))
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
                                  (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
@@ -1374,13 +1388,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
               call smooth_x9_h(G, Ah_sq(:,:,kk), zero_land=.false.)
               call pass_var(Ah_sq(:,:,kk), G%Domain)
             enddo
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
               k = kstart + kk - 1
               Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,kk))))
               Ah(i,j,kk)    = Ah_h(i,j,k)
             enddo
           else
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
               k = kstart + kk - 1
               Ah_h(i,j,k) = Ah(i,j,kk)
             enddo
@@ -1397,7 +1411,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k, KE))
           k = kstart + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           Ah(i,j,kk) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
@@ -1417,7 +1431,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%EY24_EBT_BS) then
-          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k, tmp))
             k = kstart + kk - 1
             tmp = CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xx_KS(i,j)
             visc_limit_h(i,j,k) = tmp
@@ -1429,7 +1443,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           Ah_h(i,j,k) = Ah(i,j,kk)
         enddo
@@ -1438,7 +1452,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%use_Leithy) then
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           Kh(i,j,kk) = -m_leithy(i,j,kk) * Ah(i,j,kk)
           Kh_h(i,j,k) = Kh(i,j,kk)
@@ -1446,7 +1460,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%id_grid_Re_Ah > 0) then
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k, KE, grid_Ah))
           k = kstart + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I-1,j,k))**2) + ((v(i,J,k) + v(i,J-1,k))**2))
           grid_Ah = max(Ah(i,j,kk), CS%min_grid_Ah)
@@ -1454,7 +1468,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo
       endif
 
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k, d_del2u, d_del2v, d_str))
         k = kstart + kk - 1
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j,kk)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,kk))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J,kk)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,kk))
@@ -1471,7 +1485,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         if (visc_limit_h_flag(i,j,k) > 0) then
           Kh_BS(i,j,kk) = 0.
@@ -1489,7 +1503,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       if (CS%id_BS_coeff_h>0) then
-        do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+        do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           BS_coeff_h(i,j,k) = Kh_BS(i,j,kk)
         enddo
@@ -1533,7 +1547,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(sh_xy_sq, sh_xx_sq))
         sh_xy_sq = sh_xy(I,J,kk)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j,kk)**2) + (sh_xx(i+1,j+1,kk)**2)) &
                           + ((sh_xx(i,j+1,kk)**2) + (sh_xx(i+1,j,kk)**2)) )
@@ -1541,7 +1555,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
     endif
 
-    do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+    do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(h2uq, h2vq))
       h2uq = 4.0 * (h_u(I,j,kk) * h_u(I,j+1,kk))
       h2vq = 4.0 * (h_v(i,J,kk) * h_v(i+1,J,kk))
       hq(I,J,kk) = (2.0 * (h2uq * h2vq)) &
@@ -1549,7 +1563,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     enddo
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(h_min))
         h_min = min(h_u(I,j,kk), h_u(I,j+1,kk), h_v(i,J,kk), h_v(i+1,J,kk))
         hrat_min(I,J,kk) = min(1.0, h_min / (hq(I,J,kk) + h_neglect))
       enddo
@@ -1557,7 +1571,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     if (CS%no_slip) then
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(hu, hv))
         if (CS%no_slip .and. (G%mask2dBu(I,J) < 0.5)) then
           if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) + &
               (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) > 0.0) then
@@ -1596,7 +1610,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
-          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(grad_vort, grad_vort_qg))
             grad_vort = grad_vort_mag_q(I,J,kk) + grad_div_mag_q(I,J,kk)
             grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J,kk)
             vert_vort_mag(I,J,kk) = min(grad_vort, grad_vort_qg)
@@ -1651,7 +1665,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         if (use_kh_struct) then
-          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k, meke_res_fn))
             k = kstart + kk - 1
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
@@ -1662,7 +1676,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                        (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
           enddo
         else
-          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(meke_res_fn))
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
@@ -1681,7 +1695,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo
       endif
 
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(Kh_max_here))
         ! Newer method of bounding for stability
         if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
           visc_bound_rem(I,J,kk) = 1.0
@@ -1699,28 +1713,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (CS%use_Leithy) then
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           Kh(I,J,kk) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
         enddo
       endif
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           Kh_q(I,J,k) = Kh(I,J,kk)
         enddo
       endif
 
       if (CS%id_vort_xy_q > 0) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           vort_xy_q(I,J,k) = vort_xy(I,J,kk)
         enddo
       endif
 
       if (CS%id_sh_xy_q > 0) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           sh_xy_q(I,J,k) = sh_xy(I,J,kk)
         enddo
@@ -1742,7 +1756,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(local_strain))
         ! Horizontal-tension averaged to q-points
         local_strain = 0.25 * ( (sh_xx(i,j,kk) + sh_xx(i+1,j+1,kk)) + (sh_xx(i+1,j,kk) + sh_xx(i,j+1,kk)) )
         ! *Add* the tension contribution to the xy-component of stress
@@ -1761,13 +1775,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+            do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(AhSm))
               AhSm = Shear_mag(I,J,kk) * (CS%Biharm_const_xy(I,J) &
                   + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J,kk))
               Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
             enddo
           else
-            do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+            do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(AhSm))
               AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J,kk)
               Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
             enddo
@@ -1775,7 +1789,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         endif
 
         if (CS%Leith_Ah) then
-          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(AhLth))
             AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J,kk)) * inv_PI6
             Ah(I,J,kk) = max(Ah(I,J,kk), AhLth)
           enddo
@@ -1791,7 +1805,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k, KE))
           k = kstart + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I,j+1,k))**2) + ((v(i,J,k) + v(i+1,J,k))**2))
           Ah(I,J,kk) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
@@ -1811,7 +1825,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%EY24_EBT_BS) then
-          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k, tmp))
             k = kstart + kk - 1
             tmp = CS%KS_coef *hrat_min(I,J,kk) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
@@ -1824,21 +1838,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! Leith+E doesn't recompute Ah at q points, it just interpolates it from h to q points
       if (CS%use_Leithy) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           Ah(I,J,kk) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
         enddo
       endif
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           Ah_q(I,J,k) = Ah(I,J,kk)
         enddo
       endif
 
       ! Again, need to initialize str_xy as if its biharmonic
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(d_str))
         d_str = Ah(I,J,kk) * (dDel2vdx(I,J,kk) + dDel2udy(I,J,kk))
 
         str_xy(I,J,kk) = str_xy(I,J,kk) + d_str
@@ -1850,7 +1864,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         if (visc_limit_q_flag(I,J,k) > 0) then
           Kh_BS(I,J,kk) = 0.
@@ -1872,7 +1886,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       if (CS%id_BS_coeff_q>0) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           BS_coeff_q(I,J,k) = Kh_BS(I,J,kk)
         enddo
@@ -1885,7 +1899,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if (CS%use_GME) then
       ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do concurrent (kk=1:kmax, j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
+      do concurrent (kk=1:kmax, j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2) DO_LOCALITY(local(k, GME_coeff))
         k = kstart + kk - 1
         GME_coeff = GME_effic_h(i,j) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
@@ -1896,7 +1910,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do concurrent (kk=1:kmax, J=js-2:je+1, I=is-2:ie+1)
+      do concurrent (kk=1:kmax, J=js-2:je+1, I=is-2:ie+1) DO_LOCALITY(local(k, GME_coeff))
         k = kstart + kk - 1
         GME_coeff = GME_effic_q(I,J) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
@@ -1917,7 +1931,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       !$omp target update to(str_xx_GME, str_xy_GME)
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         str_xx(i,j,kk) = (str_xx(i,j,kk) + str_xx_GME(i,j,kk)) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo
@@ -1935,7 +1949,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         str_xx(i,j,kk) = str_xx(i,j,kk) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo
@@ -1953,7 +1967,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! use_GME
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
-    do concurrent (kk=1:kmax, j=js:je, I=Isq:Ieq)
+    do concurrent (kk=1:kmax, j=js:je, I=Isq:Ieq) DO_LOCALITY(local(k))
       k = kstart + kk - 1
       diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1,kk)) - (CS%dx2q(I,J)*str_xy(I,J,kk))) + &
                        G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j,kk)) - (CS%dy2h(i+1,j)*str_xx(i+1,j,kk)))) * &
@@ -1966,7 +1980,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_E_or_W) then
           I = OBC%segment(n)%HI%IsdB
-          do concurrent (kk=1:kmax, j=OBC%segment(n)%HI%jsd:OBC%segment(n)%HI%jed)
+          do concurrent (kk=1:kmax, j=OBC%segment(n)%HI%jsd:OBC%segment(n)%HI%jed) DO_LOCALITY(local(k))
             k = kstart + kk - 1
             diffu(I,j,k) = 0.
           enddo
@@ -1975,7 +1989,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
-    do concurrent (kk=1:kmax, J=Jsq:Jeq, i=is:ie)
+    do concurrent (kk=1:kmax, J=Jsq:Jeq, i=is:ie) DO_LOCALITY(local(k))
       k = kstart + kk - 1
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J,kk)) - (CS%dy2q(I,J)*str_xy(I,J,kk))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j,kk)) - (CS%dx2h(i,j+1)*str_xx(i,j+1,kk)))) * &
@@ -1988,7 +2002,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_N_or_S) then
           J = OBC%segment(n)%HI%JsdB
-          do concurrent (kk=1:kmax, i=OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied)
+          do concurrent (kk=1:kmax, i=OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied) DO_LOCALITY(local(k))
             k = kstart + kk - 1
             diffv(i,J,k) = 0.
           enddo
@@ -2000,7 +2014,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * ( &
                   ((str_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
@@ -2019,7 +2033,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo
       else
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((str_xx(i,j,kk)*CS%dy2h(i,j) * ( &
@@ -2053,7 +2067,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%EY24_EBT_BS) then
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           FrictWork(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork(i,j,k)
         enddo
@@ -2064,7 +2078,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           FrictWork_bh(i,j,k) = GV%H_to_RZ * ( &
                   ((bhstr_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
@@ -2083,7 +2097,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                       + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo
       else
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
           FrictWork_bh(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
@@ -2117,7 +2131,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       if (CS%EY24_EBT_BS) then
-        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
           k = kstart + kk - 1
           FrictWork_bh(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork_bh(i,j,k)
         enddo
@@ -2125,7 +2139,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     if (CS%use_GME) then
-      if (CS%FrictWork_bug) then ; do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+      if (CS%FrictWork_bug) then ; do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
         k = kstart + kk - 1
       ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
       ! This is the old formulation that includes energy diffusion
@@ -2145,7 +2159,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo
-      else ; do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+      else ; do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
         k = kstart + kk - 1
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((str_xx_GME(i,j,kk)*CS%dy2h(i,j) * ( &
@@ -2178,7 +2192,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (allocated(MEKE%GME_snk)) then
         do concurrent (j=js:je)
           do kk=1,kmax
-            do concurrent (i=is:ie)
+            do concurrent (i=is:ie) DO_LOCALITY(local(k))
               k = kstart+kk-1
               MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
             enddo
@@ -2187,7 +2201,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
     endif
 
-    if (skeb_use_frict) then ; do concurrent (kk=1:kmax, j=js:je, i=is:ie)
+    if (skeb_use_frict) then ; do concurrent (kk=1:kmax, j=js:je, i=is:ie) DO_LOCALITY(local(k))
       k = kstart + kk - 1
       ! Note that the sign convention is FrictWork < 0 means energy dissipation.
       STOCH%skeb_diss(i,j,k) = STOCH%skeb_diss(i,j,k) - STOCH%skeb_frict_coef * &
@@ -2201,7 +2215,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (MEKE%backscatter_Ro_c /= 0.) then
         do concurrent (j=js:je)
           do kk=1,kmax
-            do concurrent (i=is:ie)
+            do concurrent (i=is:ie) DO_LOCALITY(local(k, FatH, Shear_mag_bc, RoScl, Sh_F_pow))
               k = kstart + kk - 1
               FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
                             (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
@@ -2237,7 +2251,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       else
         do concurrent (j=js:je)
           do kk=1,kmax
-            do concurrent (i=is:ie)
+            do concurrent (i=is:ie) DO_LOCALITY(local(k))
               k = kstart + kk - 1
               MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
             enddo
@@ -2247,7 +2261,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         if (allocated(MEKE%mom_src_bh)) then
           do concurrent (j=js:je)
             do kk=1,kmax
-              do concurrent (i=is:ie)
+              do concurrent (i=is:ie) DO_LOCALITY(local(k))
                 k = kstart + kk - 1
                 MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
               enddo

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -458,6 +458,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   logical :: skeb_use_frict
   logical :: use_cont_huv
   logical :: use_kh_struct
+  logical :: use_Smag     ! True if a Smagorinsky viscosity is enabled
   integer :: is_vort, ie_vort, js_vort, je_vort  ! Loop ranges for vorticity terms
   integer :: is_Kh, ie_Kh, js_Kh, je_Kh  ! Loop ranges for thickness point viscosities
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
@@ -573,6 +574,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                              dudx_bt, dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, &
                              GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME, &
                              GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
+    ! sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME are computed on the host above
+    ! and are only ever read (not written) on the device; dudx_bt, dvdy_bt, dvdx_bt, dudy_bt are only
+    ! used on the host (post_data diagnostics), so they are not mapped at all.
+    !$omp target enter data map(to: sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME)
+    ! GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME are written and read entirely on the device
+    ! (aside from the smooth_GME host round-trip below), so a bare alloc is enough on entry.
+    !$omp target enter data map(alloc: GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
   endif
 
   if (CS%use_Leithy) then
@@ -614,44 +622,48 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
   endif
 
-  !$OMP parallel do default(none) if (.not. CS%smooth_AH) &
-  !$OMP shared( &
-  !$OMP   CS, G, GV, US, OBC, VarMix, MEKE, u, v, h, uh, vh, &
-  !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
-  !$OMP   is_vort, ie_vort, js_vort, je_vort, &
-  !$OMP   is_Kh, ie_Kh, js_Kh, je_Kh, &
-  !$OMP   apply_OBC, apply_OBC_strain, rescale_Kh, find_FrictWork, use_kh_struct, skeb_use_frict, &
-  !$OMP   use_MEKE_Ku, use_MEKE_Au, u_smooth, v_smooth, use_cont_huv, slope_x, slope_y, dz, &
-  !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
-  !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
-  !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_bh, FrictWork_GME, &
-  !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
-  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont, STOCH &
-  !$OMP ) &
-  !$OMP private( &
-  !$OMP   i, j, k, n, tmp, &
-  !$OMP   dudx, dudy, dvdx, dvdy, sh_xx, sh_xy, h_u, h_v, &
-  !$OMP   Del2u, Del2v, DY_dxBu, DX_dyBu, sh_xx_bt, sh_xy_bt, &
-  !$OMP   str_xx, str_xy, bhstr_xx, bhstr_xy, str_xx_GME, str_xy_GME, &
-  !$OMP   vort_xy, vort_xy_dx, vort_xy_dy, div_xx, div_xx_dx, div_xx_dy, &
-  !$OMP   grad_div_mag_h, grad_div_mag_q, grad_vort_mag_h, grad_vort_mag_q, &
-  !$OMP   grad_vort, grad_vort_qg, grad_vort_mag_h_2d, grad_vort_mag_q_2d, &
-  !$OMP   sh_xx_sq, sh_xy_sq, meke_res_fn, Shear_mag, Shear_mag_bc, vert_vort_mag, &
-  !$OMP   h_min, hrat_min, visc_bound_rem, Kh_max_here, &
-  !$OMP   grid_Ah, grid_Kh, d_Del2u, d_Del2v, d_str, &
-  !$OMP   Kh, Ah, AhSm, AhLth, local_strain, Sh_F_pow, &
-  !$OMP   dDel2vdx, dDel2udy, Del2vort_q, Del2vort_h, KE, &
-  !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff, &
-  !$OMP   dudx_smooth, dudy_smooth, dvdx_smooth, dvdy_smooth, &
-  !$OMP   vort_xy_smooth, vort_xy_dx_smooth, vort_xy_dy_smooth, &
-  !$OMP   sh_xx_smooth, sh_xy_smooth, &
-  !$OMP   vert_vort_mag_smooth, m_leithy, Ah_sq, AhLthy, &
-  !$OMP   Kh_BS, str_xx_bs, str_xy_bs, bs_coeff_h, bs_coeff_q &
-  !$OMP ) &
-  !$OMP firstprivate( &
-  !$OMP   visc_limit_h, visc_limit_h_frac, visc_limit_h_flag, &
-  !$OMP   visc_limit_q, visc_limit_q_frac, visc_limit_q_flag &
-  !$OMP )
+  use_Smag = CS%Smagorinsky_Kh .or. CS%Smagorinsky_Ah
+
+  !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
+  !$omp target enter data map(alloc: h_u, h_v, hq)
+  !$omp target enter data map(alloc: str_xx, str_xy)
+  !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
+  !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
+  !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
+  !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
+  ! TODO: Only needed if FrictWork_bh is true, and currently only used on CPU,
+  !   but I do not yet see any benefit to breaking up the calculation.
+  !$omp target enter data map(alloc: bhstr_xx, bhstr_xy) if (CS%biharmonic)
+
+  !$omp target enter data map(alloc: hrat_min) &
+  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
+  !$omp target enter data map(alloc: visc_bound_rem) &
+  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
+  !$omp target enter data map(alloc: sh_xy_q) &
+  !$omp   if (CS%id_sh_xy_q > 0)
+
+  !$omp target enter data map(alloc: Kh_BS, str_xx_BS, str_xy_BS, BS_coeff_h, BS_coeff_q) &
+  !$omp   if (CS%EY24_EBT_BS)
+  !$omp target enter data map(alloc: vert_vort_mag, vert_vort_mag_smooth) &
+  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
+  !$omp target enter data map(alloc: m_leithy, Ah_sq) if (CS%use_Leithy)
+  !$omp target enter data map(alloc: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
+  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
+  !$omp target enter data map(alloc: vort_xy, vort_xy_smooth) &
+  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
+  !$omp target enter data map(alloc: vort_xy_dx, vort_xy_dy, vort_xy_dx_smooth, vort_xy_dy_smooth, &
+  !$omp                              div_xx_dx, div_xx_dy) if (CS%use_QG_Leith_visc)
+  !$omp target enter data map(alloc: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
+  !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
+  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
+  !$omp target enter data map(alloc: div_xx) if (CS%Laplacian .or. CS%biharmonic)
+  !$omp target enter data map(alloc: slope_x, slope_y) &
+  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
+  !$omp target enter data map(alloc: dz) &
+  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
+  !$omp target enter data map(alloc: u_smooth, v_smooth) if (CS%use_Leithy)
+
   do kstart=1,nz,nkblock
     kend = min(kstart+nkblock-1,nz)
     kmax = kend-kstart+1
@@ -1895,10 +1907,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
+      ! smooth_GME is an impure host routine, so str_xx_GME/str_xy_GME must be brought back
+      ! from the device before this loop and pushed back afterward.
+      !$omp target update from(str_xx_GME, str_xy_GME)
       do kk=1,kmax
         call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,kk))
         call smooth_GME(CS, G, GME_flux_q=str_xy_GME(:,:,kk))
       enddo
+      !$omp target update to(str_xx_GME, str_xy_GME)
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
@@ -2243,6 +2259,48 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! find_FrictWork and associated(mom_src)
   enddo ! end of k loop
 
+  !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
+  !$omp target exit data map(delete: h_u, h_v, hq)
+  !$omp target exit data map(delete: str_xx, str_xy)
+  !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
+  !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)
+  !$omp target exit data map(delete: Shear_mag) if (use_Smag)
+  !$omp target exit data map(delete: Kh) if (CS%Laplacian)
+  !$omp target exit data map(delete: Ah) if (CS%biharmonic)
+  !$omp target exit data map(delete: bhstr_xx, bhstr_xy) if (CS%biharmonic)
+
+  !$omp target exit data map(delete: hrat_min) &
+  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
+  !$omp target exit data map(delete: visc_bound_rem) &
+  !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
+
+  !$omp target exit data map(delete: Kh_BS, str_xx_BS, str_xy_BS, BS_coeff_h, BS_coeff_q) &
+  !$omp   if (CS%EY24_EBT_BS)
+  !$omp target exit data map(delete: vert_vort_mag, vert_vort_mag_smooth) &
+  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
+  !$omp target exit data map(delete: m_leithy, Ah_sq) if (CS%use_Leithy)
+  !$omp target exit data map(delete: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
+  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
+  !$omp target exit data map(delete: vort_xy, vort_xy_smooth) &
+  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
+  !$omp target exit data map(delete: vort_xy_dx, vort_xy_dy, vort_xy_dx_smooth, vort_xy_dy_smooth, &
+  !$omp                              div_xx_dx, div_xx_dy) if (CS%use_QG_Leith_visc)
+  !$omp target exit data map(delete: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
+  !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
+  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
+  !$omp target exit data map(delete: div_xx) if (CS%Laplacian .or. CS%biharmonic)
+  !$omp target exit data map(delete: slope_x, slope_y) &
+  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
+  !$omp target exit data map(delete: dz) &
+  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
+  !$omp target exit data map(delete: u_smooth, v_smooth) if (CS%use_Leithy)
+
+  !$omp target exit data map(delete: sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME) &
+  !$omp   if (CS%use_GME)
+  !$omp target exit data map(delete: str_xx_GME, str_xy_GME) if (CS%use_GME)
+  ! GME_coeff_h/q are only diagnostic outputs beyond this point, so bring them back to the host.
+  !$omp target exit data map(from: GME_coeff_h, GME_coeff_q) if (CS%use_GME)
+
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)
   if (CS%id_shearstress > 0) call post_data(CS%id_shearstress, ShSt, CS%diag)
@@ -2290,6 +2348,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       call Bchksum(Ah_q, "Ah_q", G%HI, haloshift=0, symmetric=.true., unscale=US%L_to_m**4*US%s_to_T)
     endif
   endif
+
+  !$omp target exit data map(delete: sh_xy_q) &
+  !$omp   if (CS%id_sh_xy_q > 0)
 
   if (CS%id_FrictWorkIntz > 0) then
     do j=js,je

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1898,43 +1898,47 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        k = kstart + kk - 1
         if (visc_limit_q_flag(I,J,k) > 0) then
-          Kh_BS(I,J,1) = 0.
+          Kh_BS(I,J,kk) = 0.
         else
           if (use_kh_struct) then
-            Kh_BS(I,J,1) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+            Kh_BS(I,J,kk) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
                                  (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
                                 ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
                                  (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
           else
-            Kh_BS(I,J,1) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
+            Kh_BS(I,J,kk) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
                                 (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
           endif
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy_BS(I,J,1) = -Kh_BS(I,J,1) * (sh_xy(I,J,1))
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        str_xy_BS(I,J,kk) = -Kh_BS(I,J,kk) * (sh_xy(I,J,kk))
+      enddo ; enddo ; enddo
 
       if (CS%id_BS_coeff_q>0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          BS_coeff_q(I,J,k) = Kh_BS(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
+          BS_coeff_q(I,J,k) = Kh_BS(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J,1) = str_xy(I,J,1) + str_xy_BS(I,J,1)
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        str_xy(I,J,kk) = str_xy(I,J,kk) + str_xy_BS(I,J,kk)
+      enddo ; enddo ; enddo
     endif ! Backscatter
 
     if (CS%use_GME) then
-      ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-        GME_coeff = GME_effic_h(i,j,1) * 0.25 * &
-            ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
-        GME_coeff = MIN(GME_coeff, CS%GME_limiter)
+      do kk=1,kmax
+        k = kstart + kk - 1
+        ! The wider halo here is to permit one pass of smoothing without a halo update.
+        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+          GME_coeff = GME_effic_h(i,j,1) * 0.25 * &
+              ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
+          GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
         str_xx_GME(i,j,1) = GME_coeff * sh_xx_bt(i,j)
@@ -1969,22 +1973,24 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
+      enddo ! kk-loop
 
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = str_xx(i,j,1) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = kstart + kk - 1
+        str_xx(i,j,kk) = str_xx(i,j,kk) * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo ; enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = str_xy(I,J,1) * (hq(I,J,1) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = str_xy(I,J,kk) * (hq(I,J,kk) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       else
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = str_xy(I,J,1) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = str_xy(I,J,kk) * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       endif
     endif ! use_GME
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -314,8 +314,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
     vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
     div_xx_dx     ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),nkblock) :: &
     Del2v, &      ! The v-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
     h_v, &        ! Thickness interpolated to v points [H ~> m or kg m-2].
@@ -323,7 +321,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
     div_xx_dy     ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
   real, dimension(SZI_(G),SZJB_(G)) :: &
-    vbtav, &      ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
     dudx_bt, dvdy_bt ! components in the barotropic horizontal tension [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
     div_xx, &     ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
@@ -341,15 +338,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     grad_vort_mag_h, & ! Magnitude of vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
     grad_vort_mag_h_2d, & ! Magnitude of 2d vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
     grad_div_mag_h, &     ! Magnitude of divergence gradient at h-points [L-1 T-1 ~> m-1 s-1]
-    dudx, dvdy, &    ! components in the horizontal tension [T-1 ~> s-1]
-    GME_effic_h, &  ! The filtered efficiency of the GME terms at h points [nondim]
+    dudx, dvdy      ! components in the horizontal tension [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    GME_effic_h   ! The filtered efficiency of the GME terms at h points [nondim]
+  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
     m_leithy, &   ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
     Ah_sq, &      ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
-    htot, &       ! The total thickness of all layers [H ~> m or kg m-2]
     str_xx_BS      ! The diagonal term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
   real :: Del2vort_h ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
-  real :: grad_vel_mag_bt_h ! Magnitude of the barotropic velocity gradient tensor squared at h-points [T-2 ~> s-2]
-  real :: boundary_mask_h ! A mask that zeroes out cells with at least one land edge [nondim]
 
   real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     dvdx, dudy, & ! components in the shearing strain [T-1 ~> s-1]
@@ -373,12 +369,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     grad_vort_mag_q_2d, & ! Magnitude of 2d vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
     Del2vort_q, & ! Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]
     grad_div_mag_q, &  ! Magnitude of divergence gradient at q-points [L-1 T-1 ~> m-1 s-1]
-    hq, &          ! harmonic mean of the harmonic means of the u- & v point thicknesses [H ~> m or kg m-2]
+    hq             ! harmonic mean of the harmonic means of the u- & v point thicknesses [H ~> m or kg m-2]
                    ! This form guarantees that hq/hu < 4.
-    GME_effic_q, & ! The filtered efficiency of the GME terms at q points [nondim]
+  real, dimension(SZIB_(G),SZJB_(G)) :: &
+    GME_effic_q   ! The filtered efficiency of the GME terms at q points [nondim]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     str_xy_BS      ! The cross term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
-  real :: grad_vel_mag_bt_q ! Magnitude of the barotropic velocity gradient tensor squared at q-points [T-2 ~> s-2]
-  real :: boundary_mask_q ! A mask that zeroes out cells with at least one land edge [nondim]
 
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)) :: &
     Ah_q, &      ! biharmonic viscosity at corner points [L4 T-1 ~> m4 s-1]
@@ -429,8 +425,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real :: hu, hv     ! Thicknesses interpolated by arithmetic means to corner
                      ! points; these are first interpolated to u or v velocity
                      ! points where masks are applied [H ~> m or kg m-2].
-  real :: h_arith_q  ! The arithmetic mean total thickness at q points [H ~> m or kg m-2]
-  real :: I_GME_h0   ! The inverse of GME tapering scale [H-1 ~> m-1 or m2 kg-1]
   real :: h_neglect  ! thickness so small it can be lost in roundoff and so neglected [H ~> m or kg m-2]
   real :: h_neglect3 ! h_neglect^3 [H3 ~> m3 or kg3 m-6]
   real :: h_min      ! Minimum h at the 4 neighboring velocity points [H ~> m]
@@ -575,93 +569,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   endif
 
   if (CS%use_GME) then
-
-    ! Initialize diagnostic arrays with zeros
-    GME_coeff_h(:,:,:) = 0.0
-    GME_coeff_q(:,:,:) = 0.0
-    str_xx_GME(:,:,:) = 0.0
-    str_xy_GME(:,:,:) = 0.0
-
-    ! Get barotropic velocities and their gradients
-    call barotropic_get_tav(BT, ubtav, vbtav, G, US)
-
-    call pass_vector(ubtav, vbtav, G%Domain)
-    call pass_var(h, G%domain, halo=2)
-
-    ! Calculate the barotropic horizontal tension
-    do j=js-2,je+2 ; do i=is-2,ie+2
-      dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j)) - &
-                                     (G%IdyCu(I-1,j) * ubtav(I-1,j)))
-      dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J)) - &
-                                     (G%IdxCv(i,J-1) * vbtav(i,J-1)))
-    enddo ; enddo
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
-    enddo ; enddo
-
-    ! Components for the barotropic shearing strain
-    do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
-      dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J)*G%IdyCv(i+1,J)) &
-                                    - (vbtav(i,J)*G%IdyCv(i,J)))
-      dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1)*G%IdxCu(I,j+1)) &
-                                    - (ubtav(I,j)*G%IdxCu(I,j)))
-    enddo ; enddo
-
-    if (CS%no_slip) then
-      do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
-      enddo ; enddo
-    else
-      do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J) = G%mask2dBu(I,J) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
-      enddo ; enddo
-    endif
-
-    do j=js-2,je+2 ; do i=is-2,ie+2
-      htot(i,j,1) = 0.0
-    enddo ; enddo
-    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-      htot(i,j,1) = htot(i,j,1) + h(i,j,k)
-    enddo ; enddo ; enddo
-
-    I_GME_h0 = 1.0 / CS%GME_h0
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      boundary_mask_h = (G%mask2dCu(I,j) * G%mask2dCu(I-1,j)) * (G%mask2dCv(i,J) * G%mask2dCv(i,J-1))
-      grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j)**2 + dvdy_bt(i,j)**2 + &
-            (0.25*((dvdx_bt(I,J)+dvdx_bt(I-1,J-1)) + (dvdx_bt(I,J-1)+dvdx_bt(I-1,J))))**2 + &
-            (0.25*((dudy_bt(I,J)+dudy_bt(I-1,J-1)) + (dudy_bt(I,J-1)+dudy_bt(I-1,J))))**2)
-      ! Probably the following test could be simplified to
-      ! if (boundary_mask_h * G%mask2dT(I,J) > 0.0) then
-      if (grad_vel_mag_bt_h > 0.0) then
-        GME_effic_h(i,j,1) = CS%GME_efficiency * G%mask2dT(I,J) * (MIN(htot(i,j,1) * I_GME_h0, 1.0)**2)
-      else
-        GME_effic_h(i,j,1) = 0.0
-      endif
-    enddo ; enddo
-
-    do J=js-2,je+1 ; do I=is-2,ie+1
-      boundary_mask_q = (G%mask2dCv(i,J) * G%mask2dCv(i+1,J)) * (G%mask2dCu(I,j) * G%mask2dCu(I,j+1))
-      grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
-            (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1)) + (dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
-            (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1)) + (dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
-      ! Probably the following test could be simplified to
-      ! if (boundary_mask_q * G%mask2dBu(I,J) > 0.0) then
-      if (grad_vel_mag_bt_q > 0.0) then
-        h_arith_q = 0.25 * ((htot(i,j,1) + htot(i+1,j+1,1)) + (htot(i+1,j,1) + htot(i,j+1,1)))
-        GME_effic_q(I,J,1) = CS%GME_efficiency * G%mask2dBu(I,J) * (MIN(h_arith_q * I_GME_h0, 1.0)**2)
-      else
-        GME_effic_q(I,J,1) = 0.0
-      endif
-    enddo ; enddo
-
-    call thickness_diffuse_get_KH(TD, KH_u_GME, KH_v_GME, G, GV)
-
-    call pass_vector(KH_u_GME, KH_v_GME, G%domain, To_All+Scalar_Pair)
-
-    if (CS%debug) &
-      call uvchksum("GME KH[u,v]_GME", KH_u_GME, KH_v_GME, G%HI, haloshift=2, unscale=US%L_to_m**2*US%s_to_T)
-
-  endif ! use_GME
+    call hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, &
+                             dudx_bt, dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, &
+                             GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME, &
+                             GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
+  endif
 
   if (CS%use_Leithy) then
     ! Smooth the velocity. Right now it happens twice. In the future
@@ -1953,7 +1865,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
       do concurrent (kk=1:kmax, j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
         k = kstart + kk - 1
-        GME_coeff = GME_effic_h(i,j,1) * 0.25 * &
+        GME_coeff = GME_effic_h(i,j) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
@@ -1964,7 +1876,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
       do concurrent (kk=1:kmax, J=js-2:je+1, I=is-2:ie+1)
         k = kstart + kk - 1
-        GME_coeff = GME_effic_q(I,J,1) * 0.25 * &
+        GME_coeff = GME_effic_q(I,J) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
@@ -2419,6 +2331,168 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   endif
 
 end subroutine horizontal_viscosity
+
+!> Calculates the barotropic tension and shearing strain fields and the GME
+!! efficiency and isopycnal height diffusivity fields that are used within
+!! horizontal_viscosity when GME (CS%use_GME) is active. The caller must
+!! only invoke this routine when CS%use_GME is true.
+subroutine hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, &
+                               dudx_bt, dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, &
+                               GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME, &
+                               GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
+  type(ocean_grid_type),         intent(in)    :: G      !< The ocean's grid structure.
+  type(verticalGrid_type),       intent(in)    :: GV     !< The ocean's vertical grid structure.
+  type(unit_scale_type),         intent(in)    :: US     !< A dimensional unit scaling type
+  type(hor_visc_CS),             intent(inout) :: CS     !< Horizontal viscosity control structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                  intent(inout) :: h      !< Layer thicknesses [H ~> m or kg m-2].
+  type(barotropic_CS),           optional, intent(in) :: BT !< Barotropic control structure
+  type(thickness_diffuse_CS),    optional, intent(in) :: TD !< Thickness diffusion control structure
+  real, dimension(SZI_(G),SZJB_(G)), &
+                                  intent(out)   :: dudx_bt !< x-component in the barotropic
+                                                       !! horizontal tension [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJB_(G)), &
+                                  intent(out)   :: dvdy_bt !< y-component in the barotropic
+                                                       !! horizontal tension [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: dvdx_bt !< x-component in the barotropic
+                                                       !! shearing strain [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: dudy_bt !< y-component in the barotropic
+                                                       !! shearing strain [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                                  intent(out)   :: sh_xx_bt !< Barotropic horizontal tension
+                                                       !! (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: sh_xy_bt !< Barotropic horizontal shearing strain
+                                                       !! (du/dy + dv/dx) including metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                                  intent(out)   :: GME_effic_h !< The filtered efficiency of the
+                                                       !! GME terms at h points [nondim]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: GME_effic_q !< The filtered efficiency of the
+                                                       !! GME terms at q points [nondim]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), &
+                                  intent(out)   :: KH_u_GME !< Isopycnal height diffusivities in
+                                                       !! u-columns [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), &
+                                  intent(out)   :: KH_v_GME !< Isopycnal height diffusivities in
+                                                       !! v-columns [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                  intent(out)   :: GME_coeff_h !< GME coefficient at h-points
+                                                       !! [L2 T-1 ~> m2 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
+                                  intent(out)   :: GME_coeff_q !< GME coeff. at q-points [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                                  intent(out)   :: str_xx_GME !< Smoothed diagonal term in the
+                                                       !! stress tensor from GME [L2 T-2 ~> m2 s-2]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(out)   :: str_xy_GME !< Smoothed cross term in the
+                                                       !! stress tensor from GME [L2 T-2 ~> m2 s-2]
+  ! Local variables
+  real, dimension(SZIB_(G),SZJ_(G)) :: &
+    ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G)) :: &
+    vbtav         ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    htot          ! The total thickness of all layers [H ~> m or kg m-2]
+  real :: grad_vel_mag_bt_h ! Magnitude of the barotropic velocity gradient tensor squared at h-points [T-2 ~> s-2]
+  real :: boundary_mask_h ! A mask that zeroes out cells with at least one land edge [nondim]
+  real :: grad_vel_mag_bt_q ! Magnitude of the barotropic velocity gradient tensor squared at q-points [T-2 ~> s-2]
+  real :: boundary_mask_q ! A mask that zeroes out cells with at least one land edge [nondim]
+  real :: h_arith_q  ! The arithmetic mean total thickness at q points [H ~> m or kg m-2]
+  real :: I_GME_h0   ! The inverse of GME tapering scale [H-1 ~> m-1 or m2 kg-1]
+  integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+
+  is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
+  Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+
+  ! Initialize diagnostic arrays with zeros
+  GME_coeff_h(:,:,:) = 0.0
+  GME_coeff_q(:,:,:) = 0.0
+  str_xx_GME(:,:,:) = 0.0
+  str_xy_GME(:,:,:) = 0.0
+
+  ! Get barotropic velocities and their gradients
+  call barotropic_get_tav(BT, ubtav, vbtav, G, US)
+
+  call pass_vector(ubtav, vbtav, G%Domain)
+  call pass_var(h, G%domain, halo=2)
+
+  ! Calculate the barotropic horizontal tension
+  do j=js-2,je+2 ; do i=is-2,ie+2
+    dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j)) - &
+                                   (G%IdyCu(I-1,j) * ubtav(I-1,j)))
+    dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J)) - &
+                                   (G%IdxCv(i,J-1) * vbtav(i,J-1)))
+  enddo ; enddo
+  do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
+  enddo ; enddo
+
+  ! Components for the barotropic shearing strain
+  do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+    dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J)*G%IdyCv(i+1,J)) &
+                                  - (vbtav(i,J)*G%IdyCv(i,J)))
+    dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1)*G%IdxCu(I,j+1)) &
+                                  - (ubtav(I,j)*G%IdxCu(I,j)))
+  enddo ; enddo
+
+  if (CS%no_slip) then
+    do J=js-2,je+1 ; do I=is-2,ie+1
+      sh_xy_bt(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+    enddo ; enddo
+  else
+    do J=js-2,je+1 ; do I=is-2,ie+1
+      sh_xy_bt(I,J) = G%mask2dBu(I,J) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+    enddo ; enddo
+  endif
+
+  do j=js-2,je+2 ; do i=is-2,ie+2
+    htot(i,j) = 0.0
+  enddo ; enddo
+  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+    htot(i,j) = htot(i,j) + h(i,j,k)
+  enddo ; enddo ; enddo
+
+  I_GME_h0 = 1.0 / CS%GME_h0
+  do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    boundary_mask_h = (G%mask2dCu(I,j) * G%mask2dCu(I-1,j)) * (G%mask2dCv(i,J) * G%mask2dCv(i,J-1))
+    grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j)**2 + dvdy_bt(i,j)**2 + &
+          (0.25*((dvdx_bt(I,J)+dvdx_bt(I-1,J-1)) + (dvdx_bt(I,J-1)+dvdx_bt(I-1,J))))**2 + &
+          (0.25*((dudy_bt(I,J)+dudy_bt(I-1,J-1)) + (dudy_bt(I,J-1)+dudy_bt(I-1,J))))**2)
+    ! Probably the following test could be simplified to
+    ! if (boundary_mask_h * G%mask2dT(I,J) > 0.0) then
+    if (grad_vel_mag_bt_h > 0.0) then
+      GME_effic_h(i,j) = CS%GME_efficiency * G%mask2dT(I,J) * (MIN(htot(i,j) * I_GME_h0, 1.0)**2)
+    else
+      GME_effic_h(i,j) = 0.0
+    endif
+  enddo ; enddo
+
+  do J=js-2,je+1 ; do I=is-2,ie+1
+    boundary_mask_q = (G%mask2dCv(i,J) * G%mask2dCv(i+1,J)) * (G%mask2dCu(I,j) * G%mask2dCu(I,j+1))
+    grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
+          (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1)) + (dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
+          (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1)) + (dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
+    ! Probably the following test could be simplified to
+    ! if (boundary_mask_q * G%mask2dBu(I,J) > 0.0) then
+    if (grad_vel_mag_bt_q > 0.0) then
+      h_arith_q = 0.25 * ((htot(i,j) + htot(i+1,j+1)) + (htot(i+1,j) + htot(i,j+1)))
+      GME_effic_q(I,J) = CS%GME_efficiency * G%mask2dBu(I,J) * (MIN(h_arith_q * I_GME_h0, 1.0)**2)
+    else
+      GME_effic_q(I,J) = 0.0
+    endif
+  enddo ; enddo
+
+  call thickness_diffuse_get_KH(TD, KH_u_GME, KH_v_GME, G, GV)
+
+  call pass_vector(KH_u_GME, KH_v_GME, G%domain, To_All+Scalar_Pair)
+
+  if (CS%debug) &
+    call uvchksum("GME KH[u,v]_GME", KH_u_GME, KH_v_GME, G%HI, haloshift=2, unscale=US%L_to_m**2*US%s_to_T)
+
+end subroutine hor_visc_GME_setup
 
 !> Allocates space for and calculates static variables used by horizontal_viscosity.
 !! hor_visc_init calculates and stores the values of a number of metric functions that

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -37,7 +37,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public horizontal_viscosity, hor_visc_init, hor_visc_end, hor_visc_vel_stencil
+public horizontal_viscosity, hor_visc_nkblock, hor_visc_init, hor_visc_end, hor_visc_vel_stencil
 
 !> Control structure for horizontal viscosity
 type, public :: hor_visc_CS ; private
@@ -120,6 +120,7 @@ type, public :: hor_visc_CS ; private
   logical :: res_scale_MEKE  !< If true, the viscosity contribution from MEKE is scaled by
                              !! the resolution function.
   logical :: use_GME         !< If true, use GME backscatter scheme.
+  integer :: nkblock         !< The k block size used in horizontal viscosity calculations [nondim].
   integer :: answer_date     !< The vintage of the order of arithmetic and expressions in the
                              !! horizontal viscosity calculations.  Values below 20190101 recover
                              !! the answers from the end of 2018, while higher values use updated
@@ -253,8 +254,6 @@ type, public :: hor_visc_CS ; private
 
 end type hor_visc_CS
 
-  integer, parameter :: nkblock = 1
-
 contains
 
 !> Calculates the acceleration due to the horizontal viscosity.
@@ -270,7 +269,7 @@ contains
 !!   v(is-2:ie+2,js-2:je+2)
 !!   h(is-1:ie+1,js-1:je+1) or up to h(is-2:ie+2,js-2:je+2) with some Leith options.
 subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, GV, US, &
-                                CS, tv, dt, OBC, BT, TD, ADp, hu_cont, hv_cont, STOCH)
+                                CS, nkblock, tv, dt, OBC, BT, TD, ADp, hu_cont, hv_cont, STOCH)
   type(ocean_grid_type),         intent(in)  :: G      !< The ocean's grid structure.
   type(verticalGrid_type),       intent(in)  :: GV     !< The ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
@@ -294,6 +293,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   type(VarMix_CS),               intent(inout) :: VarMix !< Variable mixing control structure
   type(unit_scale_type),         intent(in)    :: US   !< A dimensional unit scaling type
   type(hor_visc_CS),             intent(inout) :: CS   !< Horizontal viscosity control structure
+  integer,                       intent(in)    :: nkblock !< The effective k-block size [nondim]
   type(thermo_var_ptrs),         intent(in)    :: tv   !< A structure pointing to various
                                                        !! thermodynamic variables
   real,                          intent(in)    :: dt   !< Time increment [T ~> s]
@@ -503,7 +503,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   skeb_use_frict = .false.
   if (present(STOCH)) skeb_use_frict = STOCH%skeb_use_frict
 
-  m_leithy(:,:,1) = 0.0 ! Initialize
+  if (CS%use_Leithy) m_leithy(:,:,:) = 0.0 ! Initialize
 
   if (present(OBC)) then ; if (associated(OBC)) then ; if (OBC%OBC_pe) then
     apply_OBC = OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally
@@ -1311,7 +1311,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         if (CS%use_Leithy) then
           ! Get m_leithy
-          if (CS%smooth_Ah) m_leithy(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
+          if (CS%smooth_Ah) then
+            do kk=1,kmax
+              m_leithy(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
+            enddo
+          endif
           do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
                                  (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
@@ -1329,10 +1333,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
 
           if (CS%smooth_Ah) then
-            ! Smooth m_leithy.  A single call smoothes twice.
-            call pass_var(m_leithy(:,:,1), G%Domain, halo=2)
-            call smooth_x9_h(G, m_leithy(:,:,1), zero_land=.true.)
-            call pass_var(m_leithy(:,:,1), G%Domain)
+            do kk=1,kmax
+              ! Smooth m_leithy.  A single call smoothes twice.
+              call pass_var(m_leithy(:,:,kk), G%Domain, halo=2)
+              call smooth_x9_h(G, m_leithy(:,:,kk), zero_land=.true.)
+              call pass_var(m_leithy(:,:,kk), G%Domain)
+            enddo
           endif
           ! Get Ah
           do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
@@ -1344,14 +1350,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
           if (CS%smooth_Ah) then
             ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
-            Ah_sq(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
+            do kk=1,kmax
+              Ah_sq(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
+            enddo
             do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               Ah_sq(i,j,kk) = Ah(i,j,kk)**2
             enddo
-            call pass_var(Ah_sq(:,:,1), G%Domain, halo=2)
-            ! A single call smoothes twice.
-            call smooth_x9_h(G, Ah_sq(:,:,1), zero_land=.false.)
-            call pass_var(Ah_sq(:,:,1), G%Domain)
+            do kk=1,kmax
+              call pass_var(Ah_sq(:,:,kk), G%Domain, halo=2)
+              ! A single call smoothes twice.
+              call smooth_x9_h(G, Ah_sq(:,:,kk), zero_land=.false.)
+              call pass_var(Ah_sq(:,:,kk), G%Domain)
+            enddo
             do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               k = kstart + kk - 1
               Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,kk))))
@@ -2332,6 +2342,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
 end subroutine horizontal_viscosity
 
+!> Returns the effective k-block size for horizontal_viscosity calls.
+integer function hor_visc_nkblock(CS, GV)
+  type(hor_visc_CS),       intent(in) :: CS !< Horizontal viscosity control structure
+  type(verticalGrid_type), intent(in) :: GV !< The ocean's vertical grid structure.
+  hor_visc_nkblock = merge(GV%ke, CS%nkblock, CS%nkblock==0)
+end function hor_visc_nkblock
+
 !> Calculates the barotropic tension and shearing strain fields and the GME
 !! efficiency and isopycnal height diffusivity fields that are used within
 !! horizontal_viscosity when GME (CS%use_GME) is active. The caller must
@@ -2383,10 +2400,10 @@ subroutine hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, &
                                                        !! [L2 T-1 ~> m2 s-1]
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
                                   intent(out)   :: GME_coeff_q !< GME coeff. at q-points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+  real, dimension(SZI_(G),SZJ_(G),merge(GV%ke,CS%nkblock,CS%nkblock==0)), &
                                   intent(out)   :: str_xx_GME !< Smoothed diagonal term in the
                                                        !! stress tensor from GME [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+  real, dimension(SZIB_(G),SZJB_(G),merge(GV%ke,CS%nkblock,CS%nkblock==0)), &
                                   intent(out)   :: str_xy_GME !< Smoothed cross term in the
                                                        !! stress tensor from GME [L2 T-2 ~> m2 s-2]
   ! Local variables
@@ -2560,6 +2577,11 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   integer :: i, j
+#ifdef __NVCOMPILER_OPENMP_GPU
+  integer, parameter :: default_nkblock = 0
+#else
+  integer, parameter :: default_nkblock = 1
+#endif
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_hor_visc"  ! module name
@@ -2576,6 +2598,12 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   CS%diag => diag
   ! Read parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
+
+  call get_param(param_file, mdl, "HORVISC_NKBLOCK", CS%nkblock, &
+                 "The k-direction block size used in horizontal viscosity calculations. "//&
+                 "The default 0 setting dynamically uses the full vertical column.", &
+                 default=default_nkblock, layoutParam=.true.)
+  if (CS%nkblock < 0) call MOM_error(FATAL, "HORVISC_NKBLOCK must be >= 0.")
 
   call get_param(param_file, mdl, "USE_CIRCULATION_IN_HORVISC", CS%use_circulation, &
                  "Use circulation theorem to compute vorticity in horvisc module (for ZB20 or Leith)", &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -348,7 +348,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real :: grad_vel_mag_bt_h ! Magnitude of the barotropic velocity gradient tensor squared at h-points [T-2 ~> s-2]
   real :: boundary_mask_h ! A mask that zeroes out cells with at least one land edge [nondim]
 
-  real, dimension(SZIB_(G),SZJB_(G)) :: &
+  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     dvdx, dudy, & ! components in the shearing strain [T-1 ~> s-1]
     dvdx_smooth, dudy_smooth, & ! components in the shearing strain from smoothed velocity [T-1 ~> s-1]
     dDel2vdx, dDel2udy, & ! Components in the biharmonic equivalent of the shearing strain [L-2 T-1 ~> m-2 s-1]
@@ -572,7 +572,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     GME_coeff_h(:,:,:) = 0.0
     GME_coeff_q(:,:,:) = 0.0
     str_xx_GME(:,:,1) = 0.0
-    str_xy_GME(:,:) = 0.0
+    str_xy_GME(:,:,1) = 0.0
 
     ! Get barotropic velocities and their gradients
     call barotropic_get_tav(BT, ubtav(:,:,1), vbtav(:,:,1), G, US)
@@ -593,19 +593,19 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Components for the barotropic shearing strain
     do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
-      dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J,1)*G%IdyCv(i+1,J)) &
+      dvdx_bt(I,J,1) = CS%DY_dxBu(I,J)*((vbtav(i+1,J,1)*G%IdyCv(i+1,J)) &
                                     - (vbtav(i,J,1)*G%IdyCv(i,J)))
-      dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1,1)*G%IdxCu(I,j+1)) &
+      dudy_bt(I,J,1) = CS%DX_dyBu(I,J)*((ubtav(I,j+1,1)*G%IdxCu(I,j+1)) &
                                     - (ubtav(I,j,1)*G%IdxCu(I,j)))
     enddo ; enddo
 
     if (CS%no_slip) then
       do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+        sh_xy_bt(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J,1) + dudy_bt(I,J,1) )
       enddo ; enddo
     else
       do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J) = G%mask2dBu(I,J) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+        sh_xy_bt(I,J,1) = G%mask2dBu(I,J) * ( dvdx_bt(I,J,1) + dudy_bt(I,J,1) )
       enddo ; enddo
     endif
 
@@ -620,8 +620,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       boundary_mask_h = (G%mask2dCu(I,j) * G%mask2dCu(I-1,j)) * (G%mask2dCv(i,J) * G%mask2dCv(i,J-1))
       grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j,1)**2 + dvdy_bt(i,j,1)**2 + &
-            (0.25*((dvdx_bt(I,J)+dvdx_bt(I-1,J-1)) + (dvdx_bt(I,J-1)+dvdx_bt(I-1,J))))**2 + &
-            (0.25*((dudy_bt(I,J)+dudy_bt(I-1,J-1)) + (dudy_bt(I,J-1)+dudy_bt(I-1,J))))**2)
+            (0.25*((dvdx_bt(I,J,1)+dvdx_bt(I-1,J-1,1)) + (dvdx_bt(I,J-1,1)+dvdx_bt(I-1,J,1))))**2 + &
+            (0.25*((dudy_bt(I,J,1)+dudy_bt(I-1,J-1,1)) + (dudy_bt(I,J-1,1)+dudy_bt(I-1,J,1))))**2)
       ! Probably the following test could be simplified to
       ! if (boundary_mask_h * G%mask2dT(I,J) > 0.0) then
       if (grad_vel_mag_bt_h > 0.0) then
@@ -633,16 +633,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     do J=js-2,je+1 ; do I=is-2,ie+1
       boundary_mask_q = (G%mask2dCv(i,J) * G%mask2dCv(i+1,J)) * (G%mask2dCu(I,j) * G%mask2dCu(I,j+1))
-      grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
+      grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J,1)**2 + dudy_bt(I,J,1)**2 + &
             (0.25*((dudx_bt(i,j,1)+dudx_bt(i+1,j+1,1)) + (dudx_bt(i,j+1,1)+dudx_bt(i+1,j,1))))**2 + &
             (0.25*((dvdy_bt(i,j,1)+dvdy_bt(i+1,j+1,1)) + (dvdy_bt(i,j+1,1)+dvdy_bt(i+1,j,1))))**2)
       ! Probably the following test could be simplified to
       ! if (boundary_mask_q * G%mask2dBu(I,J) > 0.0) then
       if (grad_vel_mag_bt_q > 0.0) then
         h_arith_q = 0.25 * ((htot(i,j,1) + htot(i+1,j+1,1)) + (htot(i+1,j,1) + htot(i,j+1,1)))
-        GME_effic_q(I,J) = CS%GME_efficiency * G%mask2dBu(I,J) * (MIN(h_arith_q * I_GME_h0, 1.0)**2)
+        GME_effic_q(I,J,1) = CS%GME_efficiency * G%mask2dBu(I,J) * (MIN(h_arith_q * I_GME_h0, 1.0)**2)
       else
-        GME_effic_q(I,J) = 0.0
+        GME_effic_q(I,J,1) = 0.0
       endif
     enddo ; enddo
 
@@ -737,8 +737,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Components for the shearing strain
     do J=js_vort,je_vort ; do I=is_vort,ie_vort
-      dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
-      dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
+      dvdx(I,J,1) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
+      dudy(I,J,1) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
     enddo ; enddo
 
     if (CS%use_Leithy) then
@@ -753,9 +753,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! Components for the shearing strain from smoothed velocity
       do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-        dvdx_smooth(I,J) = CS%DY_dxBu(I,J) * &
+        dvdx_smooth(I,J,1) = CS%DY_dxBu(I,J) * &
                          ((v_smooth(i+1,J,k)*G%IdyCv(i+1,J)) - (v_smooth(i,J,k)*G%IdyCv(i,J)))
-        dudy_smooth(I,J) = CS%DX_dyBu(I,J) * &
+        dudy_smooth(I,J,1) = CS%DX_dyBu(I,J) * &
                          ((u_smooth(I,j+1,k)*G%IdxCu(I,j+1)) - (u_smooth(I,j,k)*G%IdxCu(I,j)))
       enddo ; enddo
     endif ! use Leith+E
@@ -803,54 +803,54 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           do I = max(OBC%segment(n)%HI%IsdB,Is_vort), min(OBC%segment(n)%HI%IedB,Ie_vort)
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
-                dvdx(I,J) = 0. ; dudy(I,J) = 0.
+                dvdx(I,J,1) = 0. ; dudy(I,J,1) = 0.
               case (OBC_STRAIN_FREESLIP)
-                dudy(I,J) = 0.
+                dudy(I,J,1) = 0.
               case (OBC_STRAIN_COMPUTED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                  dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
+                  dudy(I,J,1) = 2.0*CS%DX_dyBu(I,J)* &
                               (OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%IdxCu(I,j)
                 else
-                  dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
+                  dudy(I,J,1) = 2.0*CS%DX_dyBu(I,J)* &
                               (u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdxCu(I,j+1)
                 endif
               case (OBC_STRAIN_SPECIFIED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                  dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
+                  dudy(I,J,1) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
                 else
-                  dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
+                  dudy(I,J,1) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
                 endif
             end select
             if (CS%use_Leithy) then
-              dvdx_smooth(I,J) = dvdx(I,J)
-              dudy_smooth(I,J) = dudy(I,J)
+              dvdx_smooth(I,J,1) = dvdx(I,J,1)
+              dudy_smooth(I,J,1) = dudy(I,J,1)
             endif
           enddo
         elseif (OBC%segment(n)%is_E_or_W .and. (I >= is_vort) .and. (I <= ie_vort)) then
           do J = max(OBC%segment(n)%HI%JsdB,js_vort), min(OBC%segment(n)%HI%JedB,je_vort)
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
-                dvdx(I,J) = 0. ; dudy(I,J) = 0.
+                dvdx(I,J,1) = 0. ; dudy(I,J,1) = 0.
               case (OBC_STRAIN_FREESLIP)
-                dvdx(I,J) = 0.
+                dvdx(I,J,1) = 0.
               case (OBC_STRAIN_COMPUTED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                  dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
+                  dvdx(I,J,1) = 2.0*CS%DY_dxBu(I,J)* &
                               (OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%IdyCv(i,J)
                 else
-                  dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
+                  dvdx(I,J,1) = 2.0*CS%DY_dxBu(I,J)* &
                               (v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdyCv(i+1,J)
                 endif
               case (OBC_STRAIN_SPECIFIED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                  dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
+                  dvdx(I,J,1) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
                 else
-                  dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
+                  dvdx(I,J,1) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
                 endif
             end select
             if (CS%use_Leithy) then
-              dvdx_smooth(I,J) = dvdx(I,J)
-              dudy_smooth(I,J) = dudy(I,J)
+              dvdx_smooth(I,J,1) = dvdx(I,J,1)
+              dudy_smooth(I,J,1) = dudy(I,J,1)
             endif
           enddo
         endif
@@ -920,13 +920,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
       do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-        sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
+        sh_xy(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,1) + dudy(I,J,1) )
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,1)
       enddo ; enddo
     else
       do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-        sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
+        sh_xy(I,J,1) = G%mask2dBu(I,J) * ( dvdx(I,J,1) + dudy(I,J,1) )
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,1)
       enddo ; enddo
     endif
 
@@ -935,11 +935,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! dudy_smooth and dvdx_smooth do not (yet) include modifications at OBCs from above.
       if (CS%no_slip) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_smooth(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J) + dudy_smooth(I,J) )
+          sh_xy_smooth(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,1) + dudy_smooth(I,J,1) )
         enddo ; enddo
       else
         do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_smooth(I,J) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J) + dudy_smooth(I,J) )
+          sh_xy_smooth(I,J,1) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,1) + dudy_smooth(I,J,1) )
         enddo ; enddo
       endif
     endif ! use Leith+E
@@ -947,11 +947,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
       do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
-        Del2u(I,j,1) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
+        Del2u(I,j,1) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J,1)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1,1))) + &
                      CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j,1)) - (CS%dy2h(i,j)*sh_xx(i,j,1)))
       enddo ; enddo
       do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
-        Del2v(i,J,1) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
+        Del2v(i,J,1) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J,1)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J,1))) - &
                      CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1,1)) - (CS%dx2h(i,j)*sh_xx(i,j,1)))
       enddo ; enddo
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
@@ -974,19 +974,19 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
       if (CS%no_slip) then
         do J=js_vort,je_vort ; do I=is_vort,ie_vort
-          vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
+          vort_xy(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,1) - dudy(I,J,1) )
         enddo ; enddo
       else
         if (CS%use_circulation) then
           do J=js_vort,je_vort ; do I=is_vort,ie_vort
-            vort_xy(I,J) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
+            vort_xy(I,J,1) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
               ((v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J)))  &
             - ((u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j)))  &
              )
           enddo ; enddo
         else
           do J=js_vort,je_vort ; do I=is_vort,ie_vort
-            vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
+            vort_xy(I,J,1) = G%mask2dBu(I,J) * ( dvdx(I,J,1) - dudy(I,J,1) )
           enddo ; enddo
         endif
       endif
@@ -995,11 +995,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%use_Leithy) then
       if (CS%no_slip) then
         do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-          vort_xy_smooth(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J) - dudy_smooth(I,J) )
+          vort_xy_smooth(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,1) - dudy_smooth(I,J,1) )
         enddo ; enddo
       else
         do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-          vort_xy_smooth(I,J) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J) - dudy_smooth(I,J) )
+          vort_xy_smooth(I,J,1) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,1) - dudy_smooth(I,J,1) )
         enddo ; enddo
       endif
     endif
@@ -1010,12 +1010,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Vorticity gradient
       do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-        vort_xy_dx(i,J,1) = DY_dxBu * ((vort_xy(I,J) * G%IdyCu(I,j)) - (vort_xy(I-1,J) * G%IdyCu(I-1,j)))
+        vort_xy_dx(i,J,1) = DY_dxBu * ((vort_xy(I,J,1) * G%IdyCu(I,j)) - (vort_xy(I-1,J,1) * G%IdyCu(I-1,j)))
       enddo ; enddo
 
       do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-        vort_xy_dy(I,j,1) = DX_dyBu * ((vort_xy(I,J) * G%IdxCv(i,J)) - (vort_xy(I,J-1) * G%IdxCv(i,J-1)))
+        vort_xy_dy(I,j,1) = DX_dyBu * ((vort_xy(I,J,1) * G%IdxCv(i,J)) - (vort_xy(I,J-1,1) * G%IdxCv(i,J-1)))
       enddo ; enddo
 
       if (CS%use_Leithy) then
@@ -1023,13 +1023,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do J=js_Kh-1,je_Kh ; do i=is_Kh,ie_Kh
           DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
           vort_xy_dx_smooth(i,J,1) = DY_dxBu * &
-                      ((vort_xy_smooth(I,J) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J) * G%IdyCu(I-1,j)))
+                      ((vort_xy_smooth(I,J,1) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,1) * G%IdyCu(I-1,j)))
         enddo ; enddo
 
         do j=js_Kh,je_Kh ; do I=is_Kh-1,ie_Kh
           DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
           vort_xy_dy_smooth(I,j,1) = DX_dyBu * &
-                      ((vort_xy_smooth(I,J) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1) * G%IdxCv(i,J-1)))
+                      ((vort_xy_smooth(I,J,1) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,1) * G%IdxCv(i,J-1)))
         enddo ; enddo
       endif ! If Leithy
 
@@ -1039,7 +1039,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
 
-        Del2vort_q(I,J) = DY_dxBu * ((vort_xy_dx(i+1,J,1) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J,1) * G%IdyCv(i,J))) + &
+        Del2vort_q(I,J,1) = DY_dxBu * ((vort_xy_dx(i+1,J,1) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J,1) * G%IdyCv(i,J))) + &
                           DX_dyBu * ((vort_xy_dy(I,j+1,1) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,1) * G%IdyCu(I,j)))
       enddo ; enddo
       ! endif
@@ -1065,7 +1065,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                      ((0.5*(div_xx_dy(i,J,1) + div_xx_dy(i,J-1,1)))**2))
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_div_mag_q(I,J) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I,j+1,1)))**2) + &
+          grad_div_mag_q(I,J,1) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I,j+1,1)))**2) + &
                                      ((0.5*(div_xx_dy(i,J,1) + div_xx_dy(i+1,J,1)))**2))
         enddo ; enddo
 
@@ -1081,7 +1081,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           grad_div_mag_h(i,j,1) = 0.0
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_div_mag_q(I,J) = 0.0
+          grad_div_mag_q(I,J,1) = 0.0
         enddo ; enddo
 
       endif ! CS%modified_Leith
@@ -1103,7 +1103,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                          ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_vort_mag_q_2d(I,J) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
+          grad_vort_mag_q_2d(I,J,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
                                          ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
         enddo ; enddo
 
@@ -1118,7 +1118,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                     ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
       enddo ; enddo
       do J=js-1,Jeq ; do I=is-1,Ieq
-        grad_vort_mag_q(I,J) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
+        grad_vort_mag_q(I,J,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
                                     ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
       enddo ; enddo
 
@@ -1136,8 +1136,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         sh_xx_sq = sh_xx(i,j,1)**2
-        sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1)**2) + (sh_xy(I,J)**2)) &
-                          + ((sh_xy(I-1,J)**2) + (sh_xy(I,J-1)**2)) )
+        sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1,1)**2) + (sh_xy(I,J,1)**2)) &
+                          + ((sh_xy(I-1,J,1)**2) + (sh_xy(I,J-1,1)**2)) )
         Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
       enddo ; enddo
     endif
@@ -1298,7 +1298,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%anisotropic) then
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         ! Shearing-strain averaged to h-points
-        local_strain = 0.25 * ( (sh_xy(I,J) + sh_xy(I-1,J-1)) + (sh_xy(I-1,J) + sh_xy(I,J-1)) )
+        local_strain = 0.25 * ( (sh_xy(I,J,1) + sh_xy(I-1,J-1,1)) + (sh_xy(I-1,J,1) + sh_xy(I,J-1,1)) )
         ! *Add* the shear-strain contribution to the xx-component of stress
         str_xx(i,j,1) = str_xx(i,j,1) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
       enddo ; enddo
@@ -1330,8 +1330,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         if (CS%Leith_Ah) then
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
-                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
+                                 (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
             Ah(i,j) = max(Ah(i,j), AhLth)
           enddo ; enddo
@@ -1341,14 +1341,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           ! Get m_leithy
           if (CS%smooth_Ah) m_leithy(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
-                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
+                                 (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
             AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
             if (AhLth <= CS%Ah_bg_xx(i,j)) then
               m_leithy(i,j,1) = 0.0
             else
-              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j)) < abs(vort_xy_smooth(i,j))) then
-                m_leithy(i,j,1) = CS%c_K * (vert_vort_mag(i,j) / vort_xy_smooth(i,j))**2
+              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j)) < abs(vort_xy_smooth(i,j,1))) then
+                m_leithy(i,j,1) = CS%c_K * (vert_vort_mag(i,j) / vort_xy_smooth(i,j,1))**2
               else
                 m_leithy(i,j,1) = CS%m_leithy_max(i,j)
               endif
@@ -1364,8 +1364,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
           ! Get Ah
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
-                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
+                                 (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
             AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
                     sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,1)*vert_vort_mag_smooth(i,j)**2))
             Ah(i,j) = max(CS%Ah_bg_xx(i,j), AhLthy)
@@ -1499,8 +1499,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
       do J=js-1,Jeq ; do I=is-1,Ieq
-        dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J,1)*G%IdyCv(i+1,J)) - (Del2v(i,J,1)*G%IdyCv(i,J)))
-        dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,1)*G%IdxCu(I,j+1)) - (Del2u(I,j,1)*G%IdxCu(I,j)))
+        dDel2vdx(I,J,1) = CS%DY_dxBu(I,J)*((Del2v(i+1,J,1)*G%IdyCv(i+1,J)) - (Del2v(i,J,1)*G%IdyCv(i,J)))
+        dDel2udy(I,J,1) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,1)*G%IdxCu(I,j+1)) - (Del2u(I,j,1)*G%IdxCu(I,j)))
       enddo ; enddo
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if ((OBC%strain_config == OBC_STRAIN_ZERO) .or. &
@@ -1510,17 +1510,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
             do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
-                dDel2vdx(I,J) = 0. ; dDel2udy(I,J) = 0.
+                dDel2vdx(I,J,1) = 0. ; dDel2udy(I,J,1) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
-                dDel2udy(I,J) = 0.
+                dDel2udy(I,J,1) = 0.
               endif
             enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= Ieq)) then
             do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
-                dDel2vdx(I,J) = 0. ; dDel2udy(I,J) = 0.
+                dDel2vdx(I,J,1) = 0. ; dDel2udy(I,J,1) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
-                dDel2vdx(I,J) = 0.
+                dDel2vdx(I,J,1) = 0.
               endif
             enddo
           endif
@@ -1530,7 +1530,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
       do J=js-1,Jeq ; do I=is-1,Ieq
-        sh_xy_sq = sh_xy(I,J)**2
+        sh_xy_sq = sh_xy(I,J,1)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j,1)**2) + (sh_xx(i+1,j+1,1)**2)) &
                           + ((sh_xx(i,j+1,1)**2) + (sh_xx(i+1,j,1)**2)) )
         Shear_mag(I,J) = sqrt(sh_xy_sq + sh_xx_sq)
@@ -1540,14 +1540,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     do J=js-1,Jeq ; do I=is-1,Ieq
       h2uq = 4.0 * (h_u(I,j,1) * h_u(I,j+1,1))
       h2vq = 4.0 * (h_v(i,J,1) * h_v(i+1,J,1))
-      hq(I,J) = (2.0 * (h2uq * h2vq)) &
+      hq(I,J,1) = (2.0 * (h2uq * h2vq)) &
           / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,1) + h_u(I,j+1,1)) + (h_v(i,J,1) + h_v(i+1,J,1))))
     enddo ; enddo
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
       do J=js-1,Jeq ; do I=is-1,Ieq
         h_min = min(h_u(I,j,1), h_u(I,j+1,1), h_v(i,J,1), h_v(i+1,J,1))
-        hrat_min(I,J) = min(1.0, h_min / (hq(I,J) + h_neglect))
+        hrat_min(I,J) = min(1.0, h_min / (hq(I,J,1) + h_neglect))
       enddo ; enddo
 
     endif
@@ -1564,12 +1564,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) * &
                 (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
               ! Only one of hu and hv is nonzero, so just add them.
-              hq(I,J) = hu + hv
+              hq(I,J,1) = hu + hv
               hrat_min(I,J) = 1.0
             else
               ! Both hu and hv are nonzero, so take the harmonic mean.
-              hq(I,J) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
-              hrat_min(I,J) = min(1.0, min(hu, hv) / (hq(I,J) + h_neglect) )
+              hq(I,J,1) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
+              hrat_min(I,J) = min(1.0, min(hu, hv) / (hq(I,J,1) + h_neglect) )
             endif
           endif
         endif
@@ -1578,7 +1578,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then
-      call ZB2020_copy_gradient_and_thickness(sh_xx(:,:,1), sh_xy, vort_xy, hq, G, GV, CS%ZB2020, k)
+      call ZB2020_copy_gradient_and_thickness(sh_xx(:,:,1), sh_xy(:,:,1), vort_xy(:,:,1), hq(:,:,1), &
+                                              G, GV, CS%ZB2020, k)
     endif
 
     if (CS%Laplacian) then
@@ -1589,13 +1590,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
           do J=js-1,Jeq ; do I=is-1,Ieq
-            grad_vort = grad_vort_mag_q(I,J) + grad_div_mag_q(I,J)
-            grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J)
+            grad_vort = grad_vort_mag_q(I,J,1) + grad_div_mag_q(I,J,1)
+            grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J,1)
             vert_vort_mag(I,J) = min(grad_vort, grad_vort_qg)
           enddo ; enddo
         else
           do J=js-1,Jeq ; do I=is-1,Ieq
-            vert_vort_mag(I,J) = grad_vort_mag_q(I,J) + grad_div_mag_q(I,J)
+            vert_vort_mag(I,J) = grad_vort_mag_q(I,J,1) + grad_div_mag_q(I,J,1)
           enddo ; enddo
         endif
       endif
@@ -1703,28 +1704,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (CS%id_vort_xy_q > 0) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          vort_xy_q(I,J,k) = vort_xy(I,J)
+          vort_xy_q(I,J,k) = vort_xy(I,J,1)
         enddo ; enddo
       endif
 
       if (CS%id_sh_xy_q > 0) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_q(I,J,k) = sh_xy(I,J)
+          sh_xy_q(I,J,k) = sh_xy(I,J,1)
         enddo ; enddo
       endif
 
       if (.not. CS%use_Leithy) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
+          str_xy(I,J,1) = -Kh(I,J) * sh_xy(I,J,1)
         enddo ; enddo
       else
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = -Kh(I,J) * sh_xy_smooth(I,J)
+          str_xy(I,J,1) = -Kh(I,J) * sh_xy_smooth(I,J,1)
         enddo ; enddo
       endif
     else
       do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J) = 0.
+        str_xy(I,J,1) = 0.
       enddo ; enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
@@ -1733,7 +1734,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Horizontal-tension averaged to q-points
         local_strain = 0.25 * ( (sh_xx(i,j,1) + sh_xx(i+1,j+1,1)) + (sh_xx(i+1,j,1) + sh_xx(i,j+1,1)) )
         ! *Add* the tension contribution to the xy-component of stress
-        str_xy(I,J) = str_xy(I,J) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
+        str_xy(I,J,1) = str_xy(I,J,1) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
       enddo ; enddo
     endif
 
@@ -1763,7 +1764,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         if (CS%Leith_Ah) then
           do J=js-1,Jeq ; do I=is-1,Ieq
-            AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J)) * inv_PI6
+            AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J,1)) * inv_PI6
             Ah(I,J) = max(Ah(I,J), AhLth)
           enddo ; enddo
         endif
@@ -1822,12 +1823,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! Again, need to initialize str_xy as if its biharmonic
       do J=js-1,Jeq ; do I=is-1,Ieq
-        d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
+        d_str = Ah(I,J) * (dDel2vdx(I,J,1) + dDel2udy(I,J,1))
 
-        str_xy(I,J) = str_xy(I,J) + d_str
+        str_xy(I,J,1) = str_xy(I,J,1) + d_str
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+        bhstr_xy(I,J,1) = d_str * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
       enddo ; enddo
     endif ! Get Ah at q points and biharmonic part of str_xy
 
@@ -1850,7 +1851,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
 
       do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy_BS(I,J) = -Kh_BS(I,J) * (sh_xy(I,J))
+        str_xy_BS(I,J,1) = -Kh_BS(I,J) * (sh_xy(I,J,1))
       enddo ; enddo
 
       if (CS%id_BS_coeff_q>0) then
@@ -1860,7 +1861,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J) = str_xy(I,J) + str_xy_BS(I,J)
+        str_xy(I,J,1) = str_xy(I,J,1) + str_xy_BS(I,J,1)
       enddo ; enddo
     endif ! Backscatter
 
@@ -1877,17 +1878,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
       do J=js-2,je+1 ; do I=is-2,ie+1
-        GME_coeff = GME_effic_q(I,J) * 0.25 * &
+        GME_coeff = GME_effic_q(I,J,1) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if (CS%id_GME_coeff_q>0) GME_coeff_q(I,J,k) = GME_coeff
-        str_xy_GME(I,J) = GME_coeff * sh_xy_bt(I,J)
+        str_xy_GME(I,J,1) = GME_coeff * sh_xy_bt(I,J,1)
       enddo ; enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
       call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,1))
-      call smooth_GME(CS, G, GME_flux_q=str_xy_GME)
+      call smooth_GME(CS, G, GME_flux_q=str_xy_GME(:,:,1))
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -1897,11 +1898,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * CS%reduction_xy(I,J))
         enddo ; enddo
       else
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
 
@@ -1914,18 +1915,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = str_xy(I,J,1) * (hq(I,J,1) * CS%reduction_xy(I,J))
         enddo ; enddo
       else
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = str_xy(I,J) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = str_xy(I,J,1) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
     endif ! use_GME
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
     do j=js,je ; do I=Isq,Ieq
-      diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1)) - (CS%dx2q(I,J)*str_xy(I,J))) + &
+      diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1,1)) - (CS%dx2q(I,J)*str_xy(I,J,1))) + &
                        G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j,1)) - (CS%dy2h(i+1,j)*str_xx(i+1,j,1)))) * &
                      G%IareaCu(I,j)) / (h_u(I,j,1) + h_neglect)
     enddo ; enddo
@@ -1945,7 +1946,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
     do J=Jsq,Jeq ; do i=is,ie
-      diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
+      diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J,1)) - (CS%dy2q(I,J)*str_xy(I,J,1))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j,1)) - (CS%dx2h(i,j+1)*str_xx(i,j+1,1)))) * &
                      G%IareaCv(i,J)) / (h_v(i,J,1) + h_neglect)
     enddo ; enddo
@@ -1971,16 +1972,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           FrictWork(i,j,k) = GV%H_to_RZ * ( &
                   ((str_xx(i,j,1) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
                  - (str_xx(i,j,1) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy(I,J) *                                  &
+              + 0.25*(( (str_xy(I,J,1) *                                  &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy(I-1,J-1) *                              &
+                      + (str_xy(I-1,J-1,1) *                              &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy(I-1,J) *                                &
+                    + ( (str_xy(I-1,J,1) *                                &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy(I,J-1) *                                &
+                      + (str_xy(I,J-1,1) *                                &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo ; enddo
@@ -1993,22 +1994,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
            - (str_xx(i,j,1)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
-          + (0.25*(((str_xy(I,J)*(                                     &
+          + (0.25*(((str_xy(I,J,1)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
-                +(str_xy(I-1,J-1)*(                                 &
+                +(str_xy(I-1,J-1,1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
-               +((str_xy(I-1,J)*(                                   &
+               +((str_xy(I-1,J,1)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
-                +(str_xy(I,J-1)*(                                   &
+                +(str_xy(I,J-1,1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
@@ -2032,16 +2033,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           FrictWork_bh(i,j,k) = GV%H_to_RZ * ( &
                   ((bhstr_xx(i,j,1) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
                  - (bhstr_xx(i,j,1) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))) &
-              + 0.25*(( (bhstr_xy(I,J) *                              &
+              + 0.25*(( (bhstr_xy(I,J,1) *                              &
                        (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                       + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                    + (bhstr_xy(I-1,J-1) *                            &
+                    + (bhstr_xy(I-1,J-1,1) *                            &
                        (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                       + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                  + ( (bhstr_xy(I-1,J) *                              &
+                  + ( (bhstr_xy(I-1,J,1) *                              &
                        (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                       + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                    + (bhstr_xy(I,J-1) *                              &
+                    + (bhstr_xy(I,J-1,1) *                              &
                        (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                       + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo ; enddo
@@ -2055,22 +2056,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
            - (bhstr_xx(i,j,1)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
-          + (0.25*(((bhstr_xy(I,J)*(                                     &
+          + (0.25*(((bhstr_xy(I,J,1)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
-                +(bhstr_xy(I-1,J-1)*(                                 &
+                +(bhstr_xy(I-1,J-1,1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
-               +((bhstr_xy(I-1,J)*(                                   &
+               +((bhstr_xy(I-1,J,1)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
-                +(bhstr_xy(I,J-1)*(                                   &
+                +(bhstr_xy(I,J-1,1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
@@ -2092,16 +2093,16 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         FrictWork_GME(i,j,k) = GV%H_to_RZ * ( &
                 ((str_xx_GME(i,j,1)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
                - (str_xx_GME(i,j,1)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy_GME(I,J) *                              &
+              + 0.25*(( (str_xy_GME(I,J,1) *                              &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy_GME(I-1,J-1) *                          &
+                      + (str_xy_GME(I-1,J-1,1) *                          &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy_GME(I-1,J) *                            &
+                    + ( (str_xy_GME(I-1,J,1) *                            &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy_GME(I,J-1) *                            &
+                      + (str_xy_GME(I,J-1,1) *                            &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo ; enddo
@@ -2113,22 +2114,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
            - (str_xx_GME(i,j,1)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
-       + (0.25*(((str_xy_GME(I,J)*(                                     &
+       + (0.25*(((str_xy_GME(I,J,1)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
-                +(str_xy_GME(I-1,J-1)*(                                 &
+                +(str_xy_GME(I-1,J-1,1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
-               +((str_xy_GME(I-1,J)*(                                   &
+               +((str_xy_GME(I-1,J,1)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
-                +(str_xy_GME(I,J-1)*(                                   &
+                +(str_xy_GME(I,J-1,1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
@@ -2168,8 +2169,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
                         (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
           Shear_mag_bc = sqrt(sh_xx(i,j,1) * sh_xx(i,j,1) + &
-            0.25*(((sh_xy(I-1,J-1)*sh_xy(I-1,J-1)) + (sh_xy(I,J)*sh_xy(I,J))) + &
-                  ((sh_xy(I-1,J)*sh_xy(I-1,J)) + (sh_xy(I,J-1)*sh_xy(I,J-1)))))
+            0.25*(((sh_xy(I-1,J-1,1)*sh_xy(I-1,J-1,1)) + (sh_xy(I,J,1)*sh_xy(I,J,1))) + &
+                  ((sh_xy(I-1,J,1)*sh_xy(I-1,J,1)) + (sh_xy(I,J-1,1)*sh_xy(I,J-1,1)))))
           if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
             FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
             ! Note the hard-coded dimensional constant in the following line that can not
@@ -2237,8 +2238,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%id_FrictWork_GME>0) call post_data(CS%id_FrictWork_GME, FrictWork_GME, CS%diag)
     if (CS%id_dudx_bt > 0) call post_data(CS%id_dudx_bt, dudx_bt(:,:,1), CS%diag)
     if (CS%id_dvdy_bt > 0) call post_data(CS%id_dvdy_bt, dvdy_bt(:,:,1), CS%diag)
-    if (CS%id_dudy_bt > 0) call post_data(CS%id_dudy_bt, dudy_bt, CS%diag)
-    if (CS%id_dvdx_bt > 0) call post_data(CS%id_dvdx_bt, dvdx_bt, CS%diag)
+    if (CS%id_dudy_bt > 0) call post_data(CS%id_dudy_bt, dudy_bt(:,:,1), CS%diag)
+    if (CS%id_dvdx_bt > 0) call post_data(CS%id_dvdx_bt, dvdx_bt(:,:,1), CS%diag)
   endif
   if (CS%EY24_EBT_BS) then
     if (CS%id_visc_limit_h>0) call post_data(CS%id_visc_limit_h, visc_limit_h, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1589,49 +1589,52 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo ; enddo
     endif
 
-    do J=js-1,Jeq ; do I=is-1,Ieq
-      h2uq = 4.0 * (h_u(I,j,1) * h_u(I,j+1,1))
-      h2vq = 4.0 * (h_v(i,J,1) * h_v(i+1,J,1))
-      hq(I,J,1) = (2.0 * (h2uq * h2vq)) &
-          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,1) + h_u(I,j+1,1)) + (h_v(i,J,1) + h_v(i+1,J,1))))
-    enddo ; enddo
+    do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      h2uq = 4.0 * (h_u(I,j,kk) * h_u(I,j+1,kk))
+      h2vq = 4.0 * (h_v(i,J,kk) * h_v(i+1,J,kk))
+      hq(I,J,kk) = (2.0 * (h2uq * h2vq)) &
+          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,kk) + h_u(I,j+1,kk)) + (h_v(i,J,kk) + h_v(i+1,J,kk))))
+    enddo ; enddo ; enddo
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        h_min = min(h_u(I,j,1), h_u(I,j+1,1), h_v(i,J,1), h_v(i+1,J,1))
-        hrat_min(I,J,1) = min(1.0, h_min / (hq(I,J,1) + h_neglect))
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        h_min = min(h_u(I,j,kk), h_u(I,j+1,kk), h_v(i,J,kk), h_v(i+1,J,kk))
+        hrat_min(I,J,kk) = min(1.0, h_min / (hq(I,J,kk) + h_neglect))
+      enddo ; enddo ; enddo
 
     endif
 
     if (CS%no_slip) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
         if (CS%no_slip .and. (G%mask2dBu(I,J) < 0.5)) then
           if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) + &
               (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) > 0.0) then
             ! This is a coastal vorticity point, so modify hq and hrat_min.
 
-            hu = G%mask2dCu(I,j) * h_u(I,j,1) + G%mask2dCu(I,j+1) * h_u(I,j+1,1)
-            hv = G%mask2dCv(i,J) * h_v(i,J,1) + G%mask2dCv(i+1,J) * h_v(i+1,J,1)
+            hu = G%mask2dCu(I,j) * h_u(I,j,kk) + G%mask2dCu(I,j+1) * h_u(I,j+1,kk)
+            hv = G%mask2dCv(i,J) * h_v(i,J,kk) + G%mask2dCv(i+1,J) * h_v(i+1,J,kk)
             if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) * &
                 (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
               ! Only one of hu and hv is nonzero, so just add them.
-              hq(I,J,1) = hu + hv
-              hrat_min(I,J,1) = 1.0
+              hq(I,J,kk) = hu + hv
+              hrat_min(I,J,kk) = 1.0
             else
               ! Both hu and hv are nonzero, so take the harmonic mean.
-              hq(I,J,1) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
-              hrat_min(I,J,1) = min(1.0, min(hu, hv) / (hq(I,J,1) + h_neglect) )
+              hq(I,J,kk) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
+              hrat_min(I,J,kk) = min(1.0, min(hu, hv) / (hq(I,J,kk) + h_neglect) )
             endif
           endif
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then
-      call ZB2020_copy_gradient_and_thickness(sh_xx(:,:,1), sh_xy(:,:,1), vort_xy(:,:,1), hq(:,:,1), &
-                                              G, GV, CS%ZB2020, k)
+      do kk=1,kmax
+        k = kstart + kk - 1
+        call ZB2020_copy_gradient_and_thickness(sh_xx(:,:,kk), sh_xy(:,:,kk), vort_xy(:,:,kk), hq(:,:,kk), &
+                                                 G, GV, CS%ZB2020, k)
+      enddo
     endif
 
     if (CS%Laplacian) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1003,34 +1003,35 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Vorticity
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
       if (CS%no_slip) then
-        do J=js_vort,je_vort ; do I=is_vort,ie_vort
-          vort_xy(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,1) - dudy(I,J,1) )
-        enddo ; enddo
+        do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+          vort_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) - dudy(I,J,kk) )
+        enddo ; enddo ; enddo
       else
         if (CS%use_circulation) then
-          do J=js_vort,je_vort ; do I=is_vort,ie_vort
-            vort_xy(I,J,1) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
+          do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+            k = kstart + kk - 1
+            vort_xy(I,J,kk) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
               ((v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J)))  &
             - ((u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j)))  &
              )
-          enddo ; enddo
+          enddo ; enddo ; enddo
         else
-          do J=js_vort,je_vort ; do I=is_vort,ie_vort
-            vort_xy(I,J,1) = G%mask2dBu(I,J) * ( dvdx(I,J,1) - dudy(I,J,1) )
-          enddo ; enddo
+          do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+            vort_xy(I,J,kk) = G%mask2dBu(I,J) * ( dvdx(I,J,kk) - dudy(I,J,kk) )
+          enddo ; enddo ; enddo
         endif
       endif
     endif
 
     if (CS%use_Leithy) then
       if (CS%no_slip) then
-        do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-          vort_xy_smooth(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,1) - dudy_smooth(I,J,1) )
-        enddo ; enddo
+        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+          vort_xy_smooth(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,kk) - dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       else
-        do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-          vort_xy_smooth(I,J,1) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,1) - dudy_smooth(I,J,1) )
-        enddo ; enddo
+        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+          vort_xy_smooth(I,J,kk) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,kk) - dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       endif
     endif
 
@@ -1038,127 +1039,131 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
 
       ! Vorticity gradient
-      do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
+      do kk=1,kmax ; do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-        vort_xy_dx(i,J,1) = DY_dxBu * ((vort_xy(I,J,1) * G%IdyCu(I,j)) - (vort_xy(I-1,J,1) * G%IdyCu(I-1,j)))
-      enddo ; enddo
+        vort_xy_dx(i,J,kk) = DY_dxBu * ((vort_xy(I,J,kk) * G%IdyCu(I,j)) - (vort_xy(I-1,J,kk) * G%IdyCu(I-1,j)))
+      enddo ; enddo ; enddo
 
-      do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
+      do kk=1,kmax ; do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-        vort_xy_dy(I,j,1) = DX_dyBu * ((vort_xy(I,J,1) * G%IdxCv(i,J)) - (vort_xy(I,J-1,1) * G%IdxCv(i,J-1)))
-      enddo ; enddo
+        vort_xy_dy(I,j,kk) = DX_dyBu * ((vort_xy(I,J,kk) * G%IdxCv(i,J)) - (vort_xy(I,J-1,kk) * G%IdxCv(i,J-1)))
+      enddo ; enddo ; enddo
 
       if (CS%use_Leithy) then
         ! Gradient of smoothed vorticity
-        do J=js_Kh-1,je_Kh ; do i=is_Kh,ie_Kh
+        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do i=is_Kh,ie_Kh
           DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-          vort_xy_dx_smooth(i,J,1) = DY_dxBu * &
-                      ((vort_xy_smooth(I,J,1) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,1) * G%IdyCu(I-1,j)))
-        enddo ; enddo
+          vort_xy_dx_smooth(i,J,kk) = DY_dxBu * &
+                      ((vort_xy_smooth(I,J,kk) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,kk) * G%IdyCu(I-1,j)))
+        enddo ; enddo ; enddo
 
-        do j=js_Kh,je_Kh ; do I=is_Kh-1,ie_Kh
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do I=is_Kh-1,ie_Kh
           DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-          vort_xy_dy_smooth(I,j,1) = DX_dyBu * &
-                      ((vort_xy_smooth(I,J,1) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,1) * G%IdxCv(i,J-1)))
-        enddo ; enddo
+          vort_xy_dy_smooth(I,j,kk) = DX_dyBu * &
+                      ((vort_xy_smooth(I,J,kk) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,kk) * G%IdxCv(i,J-1)))
+        enddo ; enddo ; enddo
       endif ! If Leithy
 
       ! Laplacian of vorticity
       ! if (CS%Leith_Ah .or. CS%use_Leithy) then
-      do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+      do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
 
-        Del2vort_q(I,J,1) = DY_dxBu * ((vort_xy_dx(i+1,J,1) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J,1) * G%IdyCv(i,J))) + &
-                          DX_dyBu * ((vort_xy_dy(I,j+1,1) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,1) * G%IdyCu(I,j)))
-      enddo ; enddo
+        Del2vort_q(I,J,kk) = DY_dxBu * ((vort_xy_dx(i+1,J,kk) * G%IdyCv(i+1,J)) &
+                                        - (vort_xy_dx(i,J,kk) * G%IdyCv(i,J))) + &
+                          DX_dyBu * ((vort_xy_dy(I,j+1,kk) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,kk) * G%IdyCu(I,j)))
+      enddo ; enddo ; enddo
       ! endif
 
       if (CS%modified_Leith) then
 
         ! Divergence
-        do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
-          div_xx(i,j,1) = dudx(i,j,1) + dvdy(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
+          div_xx(i,j,kk) = dudx(i,j,kk) + dvdy(i,j,kk)
+        enddo ; enddo ; enddo
 
         ! Divergence gradient
-        do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
-          div_xx_dx(I,j,1) = G%IdxCu(I,j)*(div_xx(i+1,j,1) - div_xx(i,j,1))
-        enddo ; enddo
-        do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
-          div_xx_dy(i,J,1) = G%IdyCv(i,J)*(div_xx(i,j+1,1) - div_xx(i,j,1))
-        enddo ; enddo
+        do kk=1,kmax ; do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
+          div_xx_dx(I,j,kk) = G%IdxCu(I,j)*(div_xx(i+1,j,kk) - div_xx(i,j,kk))
+        enddo ; enddo ; enddo
+        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
+          div_xx_dy(i,J,kk) = G%IdyCv(i,J)*(div_xx(i,j+1,kk) - div_xx(i,j,kk))
+        enddo ; enddo ; enddo
 
         ! Magnitude of divergence gradient
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_div_mag_h(i,j,1) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I-1,j,1)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J,1) + div_xx_dy(i,J-1,1)))**2))
-        enddo ; enddo
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_div_mag_q(I,J,1) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I,j+1,1)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J,1) + div_xx_dy(i+1,J,1)))**2))
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          grad_div_mag_h(i,j,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I-1,j,kk)))**2) + &
+                                     ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i,J-1,kk)))**2))
+        enddo ; enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          grad_div_mag_q(I,J,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I,j+1,kk)))**2) + &
+                                     ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i+1,J,kk)))**2))
+        enddo ; enddo ; enddo
 
       else
 
-        do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
-          div_xx_dx(I,j,1) = 0.0
-        enddo ; enddo
-        do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
-          div_xx_dy(i,J,1) = 0.0
-        enddo ; enddo
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_div_mag_h(i,j,1) = 0.0
-        enddo ; enddo
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_div_mag_q(I,J,1) = 0.0
-        enddo ; enddo
+        do kk=1,kmax ; do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
+          div_xx_dx(I,j,kk) = 0.0
+        enddo ; enddo ; enddo
+        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
+          div_xx_dy(i,J,kk) = 0.0
+        enddo ; enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          grad_div_mag_h(i,j,kk) = 0.0
+        enddo ; enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          grad_div_mag_q(I,J,kk) = 0.0
+        enddo ; enddo ; enddo
 
       endif ! CS%modified_Leith
 
       ! Add in beta for the Leith viscosity
       if (CS%use_beta_in_Leith) then
-        do J=js-2,Jeq+1 ; do i=is-1,ie+1
-          vort_xy_dx(i,J,1) = vort_xy_dx(i,J,1) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
-        enddo ; enddo
-        do j=js-1,je+1 ; do I=is-2,Ieq+1
-          vort_xy_dy(I,j,1) = vort_xy_dy(I,j,1) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-2,Jeq+1 ; do i=is-1,ie+1
+          vort_xy_dx(i,J,kk) = vort_xy_dx(i,J,kk) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
+        enddo ; enddo ; enddo
+        do kk=1,kmax ; do j=js-1,je+1 ; do I=is-2,Ieq+1
+          vort_xy_dy(I,j,kk) = vort_xy_dy(I,j,kk) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
+        enddo ; enddo ; enddo
       endif ! CS%use_beta_in_Leith
 
       if (CS%use_QG_Leith_visc) then
 
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_vort_mag_h_2d(i,j,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
-        enddo ; enddo
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_vort_mag_q_2d(I,J,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          grad_vort_mag_h_2d(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
+                                         ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
+        enddo ; enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          grad_vort_mag_q_2d(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
+                                         ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
+        enddo ; enddo ; enddo
 
         ! This accumulates terms, some of which are in VarMix.
-        call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,1), div_xx_dy(:,:,1), &
-                                     slope_x, slope_y, vort_xy_dx(:,:,1), vort_xy_dy(:,:,1))
+        do kk=1,kmax
+          k = kstart + kk - 1
+          call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,kk), div_xx_dy(:,:,kk), &
+                                       slope_x, slope_y, vort_xy_dx(:,:,kk), vort_xy_dy(:,:,kk))
+        enddo
 
       endif
 
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        grad_vort_mag_h(i,j,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
-      enddo ; enddo
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        grad_vort_mag_q(I,J,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i+1,J,1)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I,j+1,1)))**2) )
-      enddo ; enddo
+      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        grad_vort_mag_h(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
+                                    ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
+      enddo ; enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        grad_vort_mag_q(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
+                                    ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
+      enddo ; enddo ; enddo
 
       if (CS%use_Leithy) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          vert_vort_mag_smooth(i,j,1) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,1) + &
-                                                  vort_xy_dx_smooth(i,J-1,1)))**2) + &
-                                           ((0.5*(vort_xy_dy_smooth(I,j,1) + &
-                                                  vort_xy_dy_smooth(I-1,j,1)))**2) )
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          vert_vort_mag_smooth(i,j,kk) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,kk) + &
+                                                  vort_xy_dx_smooth(i,J-1,kk)))**2) + &
+                                           ((0.5*(vort_xy_dy_smooth(I,j,kk) + &
+                                                  vort_xy_dy_smooth(I-1,j,kk)))**2) )
+        enddo ; enddo ; enddo
       endif ! Leithy
 
     endif ! CS%Leith_Kh

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1995,11 +1995,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! use_GME
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
-    do j=js,je ; do I=Isq,Ieq
-      diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1,1)) - (CS%dx2q(I,J)*str_xy(I,J,1))) + &
-                       G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j,1)) - (CS%dy2h(i+1,j)*str_xx(i+1,j,1)))) * &
-                     G%IareaCu(I,j)) / (h_u(I,j,1) + h_neglect)
-    enddo ; enddo
+    do kk=1,kmax ; do j=js,je ; do I=Isq,Ieq
+      k = kstart + kk - 1
+      diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1,kk)) - (CS%dx2q(I,J)*str_xy(I,J,kk))) + &
+                       G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j,kk)) - (CS%dy2h(i+1,j)*str_xx(i+1,j,kk)))) * &
+                     G%IareaCu(I,j)) / (h_u(I,j,kk) + h_neglect)
+    enddo ; enddo ; enddo
 
     if (apply_OBC) then
       ! This is not the right boundary condition. If all the masking of tendencies are done
@@ -2007,19 +2008,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_E_or_W) then
           I = OBC%segment(n)%HI%IsdB
-          do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+          do kk=1,kmax ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+            k = kstart + kk - 1
             diffu(I,j,k) = 0.
-          enddo
+          enddo ; enddo
         endif
       enddo
     endif
 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
-    do J=Jsq,Jeq ; do i=is,ie
-      diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J,1)) - (CS%dy2q(I,J)*str_xy(I,J,1))) - &
-                       G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j,1)) - (CS%dx2h(i,j+1)*str_xx(i,j+1,1)))) * &
-                     G%IareaCv(i,J)) / (h_v(i,J,1) + h_neglect)
-    enddo ; enddo
+    do kk=1,kmax ; do J=Jsq,Jeq ; do i=is,ie
+      k = kstart + kk - 1
+      diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J,kk)) - (CS%dy2q(I,J)*str_xy(I,J,kk))) - &
+                       G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j,kk)) - (CS%dx2h(i,j+1)*str_xx(i,j+1,kk)))) * &
+                     G%IareaCv(i,J)) / (h_v(i,J,kk) + h_neglect)
+    enddo ; enddo ; enddo
 
     if (apply_OBC) then
       ! This is not the right boundary condition. If all the masking of tendencies are done
@@ -2027,9 +2030,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_N_or_S) then
           J = OBC%segment(n)%HI%JsdB
-          do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+          do kk=1,kmax ; do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+            k = kstart + kk - 1
             diffv(i,J,k) = 0.
-          enddo
+          enddo ; enddo
         endif
       enddo
     endif

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -579,8 +579,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Initialize diagnostic arrays with zeros
     GME_coeff_h(:,:,:) = 0.0
     GME_coeff_q(:,:,:) = 0.0
-    str_xx_GME(:,:,1) = 0.0
-    str_xy_GME(:,:,1) = 0.0
+    str_xx_GME(:,:,:) = 0.0
+    str_xy_GME(:,:,:) = 0.0
 
     ! Get barotropic velocities and their gradients
     call barotropic_get_tav(BT, ubtav, vbtav, G, US)
@@ -1950,48 +1950,50 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! Backscatter
 
     if (CS%use_GME) then
-      do kk=1,kmax
+      ! The wider halo here is to permit one pass of smoothing without a halo update.
+      do kk=1,kmax ; do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
         k = kstart + kk - 1
-        ! The wider halo here is to permit one pass of smoothing without a halo update.
-        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-          GME_coeff = GME_effic_h(i,j,1) * 0.25 * &
-              ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
-          GME_coeff = MIN(GME_coeff, CS%GME_limiter)
+        GME_coeff = GME_effic_h(i,j,1) * 0.25 * &
+            ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
+        GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
-        str_xx_GME(i,j,1) = GME_coeff * sh_xx_bt(i,j)
-      enddo ; enddo
+        str_xx_GME(i,j,kk) = GME_coeff * sh_xx_bt(i,j)
+      enddo ; enddo ; enddo
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do J=js-2,je+1 ; do I=is-2,ie+1
+      do kk=1,kmax ; do J=js-2,je+1 ; do I=is-2,ie+1
+        k = kstart + kk - 1
         GME_coeff = GME_effic_q(I,J,1) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if (CS%id_GME_coeff_q>0) GME_coeff_q(I,J,k) = GME_coeff
-        str_xy_GME(I,J,1) = GME_coeff * sh_xy_bt(I,J)
-      enddo ; enddo
+        str_xy_GME(I,J,kk) = GME_coeff * sh_xy_bt(I,J)
+      enddo ; enddo ; enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
-      call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,1))
-      call smooth_GME(CS, G, GME_flux_q=str_xy_GME(:,:,1))
+      do kk=1,kmax
+        call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,kk))
+        call smooth_GME(CS, G, GME_flux_q=str_xy_GME(:,:,kk))
+      enddo
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = (str_xx(i,j,1) + str_xx_GME(i,j,1)) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = kstart + kk - 1
+        str_xx(i,j,kk) = (str_xx(i,j,kk) + str_xx_GME(i,j,kk)) * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo ; enddo
 
       ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = (str_xy(I,J,kk) + str_xy_GME(I,J,kk)) * (hq(I,J,kk) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       else
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = (str_xy(I,J,kk) + str_xy_GME(I,J,kk)) * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       endif
-      enddo ! kk-loop
 
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
@@ -2190,46 +2192,46 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
       ! This is the old formulation that includes energy diffusion
         FrictWork_GME(i,j,k) = GV%H_to_RZ * ( &
-                ((str_xx_GME(i,j,1)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-               - (str_xx_GME(i,j,1)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy_GME(I,J,1) *                              &
+                ((str_xx_GME(i,j,kk)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+               - (str_xx_GME(i,j,kk)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+              + 0.25*(( (str_xy_GME(I,J,kk) *                              &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy_GME(I-1,J-1,1) *                          &
+                      + (str_xy_GME(I-1,J-1,kk) *                          &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy_GME(I-1,J,1) *                            &
+                    + ( (str_xy_GME(I-1,J,kk) *                            &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy_GME(I,J-1,1) *                            &
+                      + (str_xy_GME(I,J-1,kk) *                            &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo ; enddo ; enddo
       else ; do kk=1,kmax ; do j=js,je ; do i=is,ie
         k = kstart + kk - 1
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx_GME(i,j,1)*CS%dy2h(i,j) * ( &
+            ((str_xx_GME(i,j,kk)*CS%dy2h(i,j) * ( &
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) ) ) &
-           - (str_xx_GME(i,j,1)*CS%dx2h(i,j) * ( &
+           - (str_xx_GME(i,j,kk)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) ) )) &
-       + (0.25*(((str_xy_GME(I,J,1)*(                                     &
+       + (0.25*(((str_xy_GME(I,J,kk)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,kk)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,kk)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)))) ))          &
-                +(str_xy_GME(I-1,J-1,1)*(                                 &
+                +(str_xy_GME(I-1,J-1,kk)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,kk)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,kk)+h_neglect)))) )) ) &
-               +((str_xy_GME(I-1,J,1)*(                                   &
+               +((str_xy_GME(I-1,J,kk)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,kk)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,kk)+h_neglect)))) ))        &
-                +(str_xy_GME(I,J-1,1)*(                                   &
+                +(str_xy_GME(I,J-1,kk)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -756,48 +756,48 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! TODO: Explore methods for retaining both the syntax and speedup.
 
     ! Calculate horizontal tension
-    do kk=1,kmax ; do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    do concurrent (kk=1:kmax, j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
       k = kstart + kk - 1
       dudx(i,j,kk) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                     (G%IdyCu(I-1,j) * u(I-1,j,k)))
       dvdy(i,j,kk) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
                                     (G%IdxCv(i,J-1) * v(i,J-1,k)))
       sh_xx(i,j,kk) = dudx(i,j,kk) - dvdy(i,j,kk)
-    enddo ; enddo ; enddo
+    enddo
 
     ! Components for the shearing strain
-    do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+    do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort)
       k = kstart + kk - 1
       dvdx(I,J,kk) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
       dudy(I,J,kk) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
-    enddo ; enddo ; enddo
+    enddo
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         k = kstart + kk - 1
         dudx_smooth = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
                                            (G%IdyCu(I-1,j) * u_smooth(I-1,j,k)))
         dvdy_smooth = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
                                            (G%IdxCv(i,J-1) * v_smooth(i,J-1,k)))
         sh_xx_smooth(i,j,kk) = dudx_smooth - dvdy_smooth
-      enddo ; enddo ; enddo
+      enddo
 
       ! Components for the shearing strain from smoothed velocity
-      do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+      do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh)
         k = kstart + kk - 1
         dvdx_smooth(I,J,kk) = CS%DY_dxBu(I,J) * &
                          ((v_smooth(i+1,J,k)*G%IdyCv(i+1,J)) - (v_smooth(i,J,k)*G%IdyCv(i,J)))
         dudy_smooth(I,J,kk) = CS%DX_dyBu(I,J) * &
                          ((u_smooth(I,j+1,k)*G%IdxCu(I,j+1)) - (u_smooth(I,j,k)*G%IdxCu(I,j)))
-      enddo ; enddo ; enddo
+      enddo
     endif ! use Leith+E
 
     if (CS%id_normstress > 0) then
-      do kk=1,kmax ; do j=js,je ; do i=is,ie
+      do concurrent (kk=1:kmax, j=js:je, i=is:ie)
         k = kstart + kk - 1
         NoSt(i,j,k) = sh_xx(i,j,kk)
-      enddo ; enddo ; enddo
+      enddo
     endif
 
     ! Interpolate the thicknesses to velocity points.
@@ -806,32 +806,32 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
     if (use_cont_huv) then
-      do kk=1,kmax ; do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+      do concurrent (kk=1:kmax, j=js-2:je+2, I=Isq-1:Ieq+1)
         k = kstart + kk - 1
         h_u(I,j,kk) = hu_cont(I,j,k)
-      enddo ; enddo ; enddo
-      do kk=1,kmax ; do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
+      enddo
+      do concurrent (kk=1:kmax, J=Jsq-1:Jeq+1, i=is-2:ie+2)
         k = kstart + kk - 1
         h_v(i,J,kk) = hv_cont(i,J,k)
-      enddo ; enddo ; enddo
+      enddo
     elseif (CS%use_land_mask) then
-      do kk=1,kmax ; do j=js-2,je+2 ; do I=is-2,Ieq+1
+      do concurrent (kk=1:kmax, j=js-2:je+2, I=is-2:Ieq+1)
         k = kstart + kk - 1
         h_u(I,j,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
-      enddo ; enddo ; enddo
-      do kk=1,kmax ; do J=js-2,Jeq+1 ; do i=is-2,ie+2
+      enddo
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-2:ie+2)
         k = kstart + kk - 1
         h_v(i,J,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
-      enddo ; enddo ; enddo
+      enddo
     else
-      do kk=1,kmax ; do j=js-2,je+2 ; do I=is-2,Ieq+1
+      do concurrent (kk=1:kmax, j=js-2:je+2, I=is-2:Ieq+1)
         k = kstart + kk - 1
         h_u(I,j,kk) = 0.5 * (h(i,j,k) + h(i+1,j,k))
-      enddo ; enddo ; enddo
-      do kk=1,kmax ; do J=js-2,Jeq+1 ; do i=is-2,ie+2
+      enddo
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-2:ie+2)
         k = kstart + kk - 1
         h_v(i,J,kk) = 0.5 * (h(i,j,k) + h(i,j+1,k))
-      enddo ; enddo ; enddo
+      enddo
     endif
 
     ! Adjust contributions to shearing strain and interpolated values of
@@ -840,7 +840,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (apply_OBC_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
-          do kk=1,kmax ; do I = max(OBC%segment(n)%HI%IsdB,Is_vort), min(OBC%segment(n)%HI%IedB,Ie_vort)
+          do concurrent (kk=1:kmax, I=max(OBC%segment(n)%HI%IsdB,Is_vort):min(OBC%segment(n)%HI%IedB,Ie_vort))
             k = kstart + kk - 1
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
@@ -866,9 +866,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
               dvdx_smooth(I,J,kk) = dvdx(I,J,kk)
               dudy_smooth(I,J,kk) = dudy(I,J,kk)
             endif
-          enddo ; enddo
+          enddo
         elseif (OBC%segment(n)%is_E_or_W .and. (I >= is_vort) .and. (I <= ie_vort)) then
-          do kk=1,kmax ; do J = max(OBC%segment(n)%HI%JsdB,js_vort), min(OBC%segment(n)%HI%JedB,je_vort)
+          do concurrent (kk=1:kmax, J=max(OBC%segment(n)%HI%JsdB,js_vort):min(OBC%segment(n)%HI%JedB,je_vort))
             k = kstart + kk - 1
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
@@ -894,7 +894,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
               dvdx_smooth(I,J,kk) = dvdx(I,J,kk)
               dudy_smooth(I,J,kk) = dudy(I,J,kk)
             endif
-          enddo ; enddo
+          enddo
         endif
       endif
 
@@ -904,31 +904,31 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! are always zeroed out at OBC points, in which case the i-loop below
         ! becomes do i=is-1,ie+1. -RWH
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do kk=1,kmax ; do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
+          do concurrent (kk=1:kmax, i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied))
             k = kstart + kk - 1
             h_v(i,J,kk) = h(i,j,k)
-          enddo ; enddo
+          enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do kk=1,kmax ; do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
+          do concurrent (kk=1:kmax, i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied))
             k = kstart + kk - 1
             h_v(i,J,kk) = h(i,j+1,k)
-          enddo ; enddo
+          enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do kk=1,kmax ; do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
+          do concurrent (kk=1:kmax, j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed))
             k = kstart + kk - 1
             h_u(I,j,kk) = h(i,j,k)
-          enddo ; enddo
+          enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do kk=1,kmax ; do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
+          do concurrent (kk=1:kmax, j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed))
             k = kstart + kk - 1
             h_u(I,j,kk) = h(i+1,j,k)
-          enddo ; enddo
+          enddo
         endif
       endif
     enddo ; endif
@@ -937,27 +937,27 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
         if ((J >= js-2) .and. (J <= je)) then
-          do kk=1,kmax ; do I = max(is-2,OBC%segment(n)%HI%IsdB), min(Ieq+1,OBC%segment(n)%HI%IedB)
+          do concurrent (kk=1:kmax, I=max(is-2,OBC%segment(n)%HI%IsdB):min(Ieq+1,OBC%segment(n)%HI%IedB))
             h_u(I,j+1,kk) = h_u(I,j,kk)
-          enddo ; enddo
+          enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-1) .and. (J <= je+1)) then
-          do kk=1,kmax ; do I = max(is-2,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
+          do concurrent (kk=1:kmax, I=max(is-2,OBC%segment(n)%HI%isd):min(Ieq+1,OBC%segment(n)%HI%ied))
             h_u(I,j,kk) = h_u(I,j+1,kk)
-          enddo ; enddo
+          enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= ie)) then
-          do kk=1,kmax ; do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
+          do concurrent (kk=1:kmax, J=max(js-2,OBC%segment(n)%HI%jsd):min(Jeq+1,OBC%segment(n)%HI%jed))
             h_v(i+1,J,kk) = h_v(i,J,kk)
-          enddo ; enddo
+          enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-1) .and. (I <= ie+1)) then
-          do kk=1,kmax ; do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
+          do concurrent (kk=1:kmax, J=max(js-2,OBC%segment(n)%HI%jsd):min(Jeq+1,OBC%segment(n)%HI%jed))
             h_v(i,J,kk) = h_v(i+1,J,kk)
-          enddo ; enddo
+          enddo
         endif
       endif
     enddo ; endif
@@ -965,54 +965,54 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
-      do kk=1,kmax ; do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, I=is-2:Ieq+1)
         k = kstart + kk - 1
         sh_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
-      enddo ; enddo ; enddo
+      enddo
     else
-      do kk=1,kmax ; do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+      do concurrent (kk=1:kmax, J=js-2:Jeq+1, I=is-2:Ieq+1)
         k = kstart + kk - 1
         sh_xy(I,J,kk) = G%mask2dBu(I,J) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
         if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
-      enddo ; enddo ; enddo
+      enddo
     endif
 
     if (CS%use_Leithy) then
       ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
       ! dudy_smooth and dvdx_smooth do not (yet) include modifications at OBCs from above.
       if (CS%no_slip) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           sh_xy_smooth(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,kk) + dudy_smooth(I,J,kk) )
-        enddo ; enddo ; enddo
+        enddo
       else
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           sh_xy_smooth(I,J,kk) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,kk) + dudy_smooth(I,J,kk) )
-        enddo ; enddo ; enddo
+        enddo
       endif
     endif ! use Leith+E
 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
-      do kk=1,kmax ; do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do concurrent (kk=1:kmax, j=js-1:Jeq+1, I=Isq-1:Ieq+1)
         Del2u(I,j,kk) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J,kk)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1,kk))) + &
                      CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j,kk)) - (CS%dy2h(i,j)*sh_xx(i,j,kk)))
-      enddo ; enddo ; enddo
-      do kk=1,kmax ; do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
+      enddo
+      do concurrent (kk=1:kmax, J=Jsq-1:Jeq+1, i=is-1:Ieq+1)
         Del2v(i,J,kk) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J,kk)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J,kk))) - &
                      CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1,kk)) - (CS%dx2h(i,j)*sh_xx(i,j,kk)))
-      enddo ; enddo ; enddo
+      enddo
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
         do n=1,OBC%number_of_segments
           I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
-            do kk=1,kmax ; do I=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+            do concurrent (kk=1:kmax, I=OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied)
               Del2v(i,J,kk) = 0.
-            enddo ; enddo
+            enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
-            do kk=1,kmax ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+            do concurrent (kk=1:kmax, j=OBC%segment(n)%HI%jsd:OBC%segment(n)%HI%jed)
               Del2u(I,j,kk) = 0.
-            enddo ; enddo
+            enddo
           endif
         enddo
       endif ; endif
@@ -1021,35 +1021,35 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Vorticity
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
       if (CS%no_slip) then
-        do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+        do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort)
           vort_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) - dudy(I,J,kk) )
-        enddo ; enddo ; enddo
+        enddo
       else
         if (CS%use_circulation) then
-          do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+          do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort)
             k = kstart + kk - 1
             vort_xy(I,J,kk) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
               ((v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J)))  &
             - ((u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j)))  &
              )
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+          do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort)
             vort_xy(I,J,kk) = G%mask2dBu(I,J) * ( dvdx(I,J,kk) - dudy(I,J,kk) )
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
     endif
 
     if (CS%use_Leithy) then
       if (CS%no_slip) then
-        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh)
           vort_xy_smooth(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,kk) - dudy_smooth(I,J,kk) )
-        enddo ; enddo ; enddo
+        enddo
       else
-        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh)
           vort_xy_smooth(I,J,kk) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,kk) - dudy_smooth(I,J,kk) )
-        enddo ; enddo ; enddo
+        enddo
       endif
     endif
 
@@ -1057,105 +1057,105 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
 
       ! Vorticity gradient
-      do kk=1,kmax ; do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
+      do concurrent (kk=1:kmax, J=js-2:je_Kh, i=is_Kh-1:ie_Kh+1)
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         vort_xy_dx(i,J,kk) = DY_dxBu * ((vort_xy(I,J,kk) * G%IdyCu(I,j)) - (vort_xy(I-1,J,kk) * G%IdyCu(I-1,j)))
-      enddo ; enddo ; enddo
+      enddo
 
-      do kk=1,kmax ; do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, I=is-2:ie_Kh)
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
         vort_xy_dy(I,j,kk) = DX_dyBu * ((vort_xy(I,J,kk) * G%IdxCv(i,J)) - (vort_xy(I,J-1,kk) * G%IdxCv(i,J-1)))
-      enddo ; enddo ; enddo
+      enddo
 
       if (CS%use_Leithy) then
         ! Gradient of smoothed vorticity
-        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is_Kh:ie_Kh)
           DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
           vort_xy_dx_smooth(i,J,kk) = DY_dxBu * &
                       ((vort_xy_smooth(I,J,kk) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,kk) * G%IdyCu(I-1,j)))
-        enddo ; enddo ; enddo
+        enddo
 
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do I=is_Kh-1,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, I=is_Kh-1:ie_Kh)
           DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
           vort_xy_dy_smooth(I,j,kk) = DX_dyBu * &
                       ((vort_xy_smooth(I,J,kk) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,kk) * G%IdxCv(i,J-1)))
-        enddo ; enddo ; enddo
+        enddo
       endif ! If Leithy
 
       ! Laplacian of vorticity
       ! if (CS%Leith_Ah .or. CS%use_Leithy) then
-      do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+      do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh)
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
 
         Del2vort_q(I,J,kk) = DY_dxBu * ((vort_xy_dx(i+1,J,kk) * G%IdyCv(i+1,J)) &
                                         - (vort_xy_dx(i,J,kk) * G%IdyCv(i,J))) + &
                           DX_dyBu * ((vort_xy_dy(I,j+1,kk) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,kk) * G%IdyCu(I,j)))
-      enddo ; enddo ; enddo
+      enddo
       ! endif
 
       if (CS%modified_Leith) then
 
         ! Divergence
-        do kk=1,kmax ; do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
+        do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, i=is_Kh-1:ie_Kh+1)
           div_xx(i,j,kk) = dudx(i,j,kk) + dvdy(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
 
         ! Divergence gradient
-        do kk=1,kmax ; do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
+        do concurrent (kk=1:kmax, j=js-1:je+1, I=is_Kh-1:ie_Kh)
           div_xx_dx(I,j,kk) = G%IdxCu(I,j)*(div_xx(i+1,j,kk) - div_xx(i,j,kk))
-        enddo ; enddo ; enddo
-        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
+        enddo
+        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is-1:ie+1)
           div_xx_dy(i,J,kk) = G%IdyCv(i,J)*(div_xx(i,j+1,kk) - div_xx(i,j,kk))
-        enddo ; enddo ; enddo
+        enddo
 
         ! Magnitude of divergence gradient
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           grad_div_mag_h(i,j,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I-1,j,kk)))**2) + &
                                      ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i,J-1,kk)))**2))
-        enddo ; enddo ; enddo
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        enddo
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           grad_div_mag_q(I,J,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I,j+1,kk)))**2) + &
                                      ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i+1,J,kk)))**2))
-        enddo ; enddo ; enddo
+        enddo
 
       else
 
-        do kk=1,kmax ; do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
+        do concurrent (kk=1:kmax, j=js-1:je+1, I=is_Kh-1:ie_Kh)
           div_xx_dx(I,j,kk) = 0.0
-        enddo ; enddo ; enddo
-        do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
+        enddo
+        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is-1:ie+1)
           div_xx_dy(i,J,kk) = 0.0
-        enddo ; enddo ; enddo
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        enddo
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           grad_div_mag_h(i,j,kk) = 0.0
-        enddo ; enddo ; enddo
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        enddo
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           grad_div_mag_q(I,J,kk) = 0.0
-        enddo ; enddo ; enddo
+        enddo
 
       endif ! CS%modified_Leith
 
       ! Add in beta for the Leith viscosity
       if (CS%use_beta_in_Leith) then
-        do kk=1,kmax ; do J=js-2,Jeq+1 ; do i=is-1,ie+1
+        do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-1:ie+1)
           vort_xy_dx(i,J,kk) = vort_xy_dx(i,J,kk) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
-        enddo ; enddo ; enddo
-        do kk=1,kmax ; do j=js-1,je+1 ; do I=is-2,Ieq+1
+        enddo
+        do concurrent (kk=1:kmax, j=js-1:je+1, I=is-2:Ieq+1)
           vort_xy_dy(I,j,kk) = vort_xy_dy(I,j,kk) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
-        enddo ; enddo ; enddo
+        enddo
       endif ! CS%use_beta_in_Leith
 
       if (CS%use_QG_Leith_visc) then
 
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           grad_vort_mag_h_2d(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
                                          ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
-        enddo ; enddo ; enddo
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        enddo
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           grad_vort_mag_q_2d(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
                                          ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
-        enddo ; enddo ; enddo
+        enddo
 
         ! This accumulates terms, some of which are in VarMix.
         do kk=1,kmax
@@ -1166,41 +1166,41 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       endif
 
-      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         grad_vort_mag_h(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
                                     ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
-      enddo ; enddo ; enddo
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      enddo
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         grad_vort_mag_q(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
                                     ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
-      enddo ; enddo ; enddo
+      enddo
 
       if (CS%use_Leithy) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           vert_vort_mag_smooth(i,j,kk) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,kk) + &
                                                   vort_xy_dx_smooth(i,J-1,kk)))**2) + &
                                            ((0.5*(vort_xy_dy_smooth(I,j,kk) + &
                                                   vort_xy_dy_smooth(I-1,j,kk)))**2) )
-        enddo ; enddo ; enddo
+        enddo
       endif ! Leithy
 
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         sh_xx_sq = sh_xx(i,j,kk)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1,kk)**2) + (sh_xy(I,J,kk)**2)) &
                           + ((sh_xy(I-1,J,kk)**2) + (sh_xy(I,J-1,kk)**2)) )
         Shear_mag(i,j,kk) = sqrt(sh_xx_sq + sh_xy_sq)
-      enddo ; enddo ; enddo
+      enddo
     endif
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         k = kstart + kk - 1
         h_min = min(h_u(I,j,kk), h_u(I-1,j,kk), h_v(i,J,kk), h_v(i,J-1,kk))
         hrat_min(i,j,kk) = min(1.0, h_min / (h(i,j,k) + h_neglect))
-      enddo ; enddo ; enddo
+      enddo
     endif
 
     if (CS%Laplacian) then
@@ -1210,26 +1210,26 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%use_QG_Leith_visc) then
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             grad_vort = grad_vort_mag_h(i,j,kk) + grad_div_mag_h(i,j,kk)
             grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j,kk)
             vert_vort_mag(i,j,kk) = min(grad_vort, grad_vort_qg)
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             vert_vort_mag(i,j,kk) = grad_vort_mag_h(i,j,kk) + grad_div_mag_h(i,j,kk)
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
-      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         Kh(i,j,kk) = CS%Kh_bg_xx(i,j)
-      enddo ; enddo ; enddo
+      enddo
 
       ! NOTE: The following do-block can be decomposed and vectorized after the
       !   stack size has been reduced.
-      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         if (CS%add_LES_viscosity) then
           if (CS%Smagorinsky_Kh) &
             Kh(i,j,kk) = Kh(i,j,kk) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,kk)
@@ -1241,58 +1241,58 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           if (CS%Leith_Kh) &
             Kh(i,j,kk) = max(Kh(i,j,kk), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,kk) * inv_PI3)
         endif
-      enddo ; enddo ; enddo
+      enddo
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           Kh(i,j,kk) = VarMix%Res_fn_h(i,j) * Kh(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       ! Place a floor on the viscosity, if desired.
-      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         Kh(i,j,kk) = max(Kh(i,j,kk), CS%Kh_bg_min)
-      enddo ; enddo ; enddo
+      enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               k = kstart + kk - 1
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
-            enddo ; enddo ; enddo
+            enddo
           else
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               k = kstart + kk - 1
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
-            enddo ; enddo ; enddo
+            enddo
           endif
         else
           if (CS%res_scale_MEKE) then
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
-            enddo ; enddo ; enddo
+            enddo
           else
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j)
-            enddo ; enddo ; enddo
+            enddo
           endif
         endif
       endif
 
       if (CS%anisotropic) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           ! *Add* the tension component of anisotropic viscosity
           Kh(i,j,kk) = Kh(i,j,kk) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       ! Newer method of bounding for stability
       if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           visc_bound_rem(i,j,kk) = 1.0
           Kh_max_here = hrat_min(i,j,kk) * CS%Kh_Max_xx(i,j)
           if (Kh(i,j,kk) >= Kh_max_here) then
@@ -1301,58 +1301,58 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           elseif ((Kh(i,j,kk) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
             visc_bound_rem(i,j,kk) = 1.0 - Kh(i,j,kk) / Kh_max_here
           endif
-        enddo ; enddo ; enddo
+        enddo
       elseif (CS%bound_Kh) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           Kh(i,j,kk) = min(Kh(i,j,kk), hrat_min(i,j,kk) * CS%Kh_Max_xx(i,j))
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
       ! The harmonic component of str_xx is added in the biharmonic loop.
       if (CS%use_Leithy) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           Kh(i,j,kk) = 0.
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_Kh_h>0 .or. CS%debug) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           k = kstart + kk - 1
           Kh_h(i,j,k) = Kh(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_grid_Re_Kh>0) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           grid_Kh = max(Kh(i,j,kk), CS%min_grid_Kh)
           grid_Re_Kh(i,j,k) = (sqrt(KE) * sqrt(CS%grid_sp_h2(i,j))) / grid_Kh
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_div_xx_h>0) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           div_xx_h(i,j,k) = dudx(i,j,kk) + dvdy(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_sh_xx_h>0) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           sh_xx_h(i,j,k) = sh_xx(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         str_xx(i,j,kk) = -Kh(i,j,kk) * sh_xx(i,j,kk)
-      enddo ; enddo ; enddo
+      enddo
     else
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         str_xx(i,j,kk) = 0.0
-      enddo ; enddo ; enddo
+      enddo
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then
@@ -1368,39 +1368,39 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Determine the biharmonic viscosity at h points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
-      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
         Ah(i,j,kk) = CS%Ah_bg_xx(i,j)
-      enddo ; enddo ; enddo
+      enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               AhSm = Shear_mag(i,j,kk) * (CS%Biharm_const_xx(i,j) &
                   + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j,kk))
               Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
-            enddo ; enddo ; enddo
+            enddo
           else
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j,kk)
               Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
-            enddo ; enddo ; enddo
+            enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
                                  (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
             Ah(i,j,kk) = max(Ah(i,j,kk), AhLth)
-          enddo ; enddo ; enddo
+          enddo
         endif
 
         if (CS%use_Leithy) then
           ! Get m_leithy
           if (CS%smooth_Ah) m_leithy(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
                                  (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
@@ -1414,7 +1414,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
               endif
               m_leithy(i,j,kk) = G%mask2dBu(i,j) * m_leithy(i,j,kk)
             endif
-          enddo ; enddo ; enddo
+          enddo
 
           if (CS%smooth_Ah) then
             ! Smooth m_leithy.  A single call smoothes twice.
@@ -1423,33 +1423,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             call pass_var(m_leithy(:,:,1), G%Domain)
           endif
           ! Get Ah
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
                                  (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
                     sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,kk)*vert_vort_mag_smooth(i,j,kk)**2))
             Ah(i,j,kk) = max(CS%Ah_bg_xx(i,j), AhLthy)
-          enddo ; enddo ; enddo
+          enddo
           if (CS%smooth_Ah) then
             ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
             Ah_sq(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               Ah_sq(i,j,kk) = Ah(i,j,kk)**2
-            enddo ; enddo ; enddo
+            enddo
             call pass_var(Ah_sq(:,:,1), G%Domain, halo=2)
             ! A single call smoothes twice.
             call smooth_x9_h(G, Ah_sq(:,:,1), zero_land=.false.)
             call pass_var(Ah_sq(:,:,1), G%Domain)
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               k = kstart + kk - 1
               Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,kk))))
               Ah(i,j,kk)    = Ah_h(i,j,k)
-            enddo ; enddo ; enddo
+            enddo
           else
-            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
               k = kstart + kk - 1
               Ah_h(i,j,k) = Ah(i,j,kk)
-            enddo ; enddo ; enddo
+            enddo
           endif
         endif
 
@@ -1457,33 +1457,33 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           Ah(i,j,kk) = Ah(i,j,kk) + MEKE%Au(i,j)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           k = kstart + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           Ah(i,j,kk) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Ah(i,j,kk) = min(Ah(i,j,kk), visc_bound_rem(i,j,kk) * hrat_min(i,j,kk) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             Ah(i,j,kk) = min(Ah(i,j,kk), hrat_min(i,j,kk) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
             k = kstart + kk - 1
             tmp = CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xx_KS(i,j)
             visc_limit_h(i,j,k) = tmp
@@ -1491,36 +1491,36 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             if (Ah(i,j,kk) >= tmp) then
               visc_limit_h_flag(i,j,k) = 1.
             endif
-          enddo ; enddo ; enddo
+          enddo
       endif
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           k = kstart + kk - 1
           Ah_h(i,j,k) = Ah(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%use_Leithy) then
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
-        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
           k = kstart + kk - 1
           Kh(i,j,kk) = -m_leithy(i,j,kk) * Ah(i,j,kk)
           Kh_h(i,j,k) = Kh(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_grid_Re_Ah > 0) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I-1,j,k))**2) + ((v(i,J,k) + v(i,J-1,k))**2))
           grid_Ah = max(Ah(i,j,kk), CS%min_grid_Ah)
           grid_Re_Ah(i,j,k) = (sqrt(KE) * CS%grid_sp_h3(i,j)) / grid_Ah
-        enddo ; enddo ; enddo
+        enddo
       endif
 
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         k = kstart + kk - 1
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j,kk)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,kk))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J,kk)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,kk))
@@ -1532,12 +1532,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xx(i,j,kk) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo ; enddo
+      enddo
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         k = kstart + kk - 1
         if (visc_limit_h_flag(i,j,k) > 0) then
           Kh_BS(i,j,kk) = 0.
@@ -1548,82 +1548,82 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Kh_BS(i,j,kk) = MEKE%Ku(i,j)
           endif
         endif
-      enddo ; enddo ; enddo
+      enddo
 
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         str_xx_BS(i,j,kk) = -Kh_BS(i,j,kk) * sh_xx(i,j,kk)
-      enddo ; enddo ; enddo
+      enddo
 
       if (CS%id_BS_coeff_h>0) then
-        do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
           k = kstart + kk - 1
           BS_coeff_h(i,j,k) = Kh_BS(i,j,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         str_xx(i,j,kk) = str_xx(i,j,kk) + str_xx_BS(i,j,kk)
-      enddo ; enddo ; enddo
+      enddo
     endif ! Backscatter
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         dDel2vdx(I,J,kk) = CS%DY_dxBu(I,J)*((Del2v(i+1,J,kk)*G%IdyCv(i+1,J)) - (Del2v(i,J,kk)*G%IdyCv(i,J)))
         dDel2udy(I,J,kk) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,kk)*G%IdxCu(I,j+1)) - (Del2u(I,j,kk)*G%IdxCu(I,j)))
-      enddo ; enddo ; enddo
+      enddo
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if ((OBC%strain_config == OBC_STRAIN_ZERO) .or. &
                                 (OBC%strain_config == OBC_STRAIN_FREESLIP)) then
         do n=1,OBC%number_of_segments
           J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
-            do kk=1,kmax ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+            do concurrent (kk=1:kmax, I=OBC%segment(n)%HI%IsdB:OBC%segment(n)%HI%IedB)
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
                 dDel2vdx(I,J,kk) = 0. ; dDel2udy(I,J,kk) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
                 dDel2udy(I,J,kk) = 0.
               endif
-            enddo ; enddo
+            enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= Ieq)) then
-            do kk=1,kmax ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+            do concurrent (kk=1:kmax, J=OBC%segment(n)%HI%JsdB:OBC%segment(n)%HI%JedB)
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
                 dDel2vdx(I,J,kk) = 0. ; dDel2udy(I,J,kk) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
                 dDel2vdx(I,J,kk) = 0.
               endif
-            enddo ; enddo
+            enddo
           endif
         enddo
       endif ; endif
     endif
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         sh_xy_sq = sh_xy(I,J,kk)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j,kk)**2) + (sh_xx(i+1,j+1,kk)**2)) &
                           + ((sh_xx(i,j+1,kk)**2) + (sh_xx(i+1,j,kk)**2)) )
         Shear_mag(I,J,kk) = sqrt(sh_xy_sq + sh_xx_sq)
-      enddo ; enddo ; enddo
+      enddo
     endif
 
-    do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+    do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
       h2uq = 4.0 * (h_u(I,j,kk) * h_u(I,j+1,kk))
       h2vq = 4.0 * (h_v(i,J,kk) * h_v(i+1,J,kk))
       hq(I,J,kk) = (2.0 * (h2uq * h2vq)) &
           / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,kk) + h_u(I,j+1,kk)) + (h_v(i,J,kk) + h_v(i+1,J,kk))))
-    enddo ; enddo ; enddo
+    enddo
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         h_min = min(h_u(I,j,kk), h_u(I,j+1,kk), h_v(i,J,kk), h_v(i+1,J,kk))
         hrat_min(I,J,kk) = min(1.0, h_min / (hq(I,J,kk) + h_neglect))
-      enddo ; enddo ; enddo
+      enddo
 
     endif
 
     if (CS%no_slip) then
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         if (CS%no_slip .and. (G%mask2dBu(I,J) < 0.5)) then
           if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) + &
               (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) > 0.0) then
@@ -1643,7 +1643,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             endif
           endif
         endif
-      enddo ; enddo ; enddo
+      enddo
     endif
 
     ! Pass the velocity gradients and thickness to ZB2020
@@ -1662,62 +1662,62 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             grad_vort = grad_vort_mag_q(I,J,kk) + grad_div_mag_q(I,J,kk)
             grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J,kk)
             vert_vort_mag(I,J,kk) = min(grad_vort, grad_vort_qg)
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             vert_vort_mag(I,J,kk) = grad_vort_mag_q(I,J,kk) + grad_div_mag_q(I,J,kk)
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         Kh(I,J,kk) = CS%Kh_bg_xy(I,J)
-      enddo ; enddo ; enddo
+      enddo
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             Kh(I,J,kk) = Kh(I,J,kk) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,kk)
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             Kh(I,J,kk) = max(Kh(I,J,kk), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,kk) )
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
       if (CS%Leith_Kh) then
         if (CS%add_LES_viscosity) then
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             Kh(I,J,kk) = Kh(I,J,kk) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,kk) * inv_PI3 ! Is this right? -AJA
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             Kh(I,J,kk) = max(Kh(I,J,kk), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,kk) * inv_PI3)
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           Kh(I,J,kk) = VarMix%Res_fn_q(I,J) * Kh(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         Kh(I,J,kk) = max(Kh(I,J,kk), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
-      enddo ; enddo ; enddo
+      enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         if (use_kh_struct) then
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             k = kstart + kk - 1
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
@@ -1726,9 +1726,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                        (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
                                        ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
                                        (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
@@ -1736,18 +1736,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                 (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
                                        (MEKE%Ku(i+1,j) + &
                                         MEKE%Ku(i,j+1)) ) * meke_res_fn
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
       if (CS%anisotropic) then
         ! *Add* the shear component of anisotropic viscosity
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             Kh(I,J,kk) = Kh(I,J,kk) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
-        enddo ; enddo ; enddo
+        enddo
       endif
 
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         ! Newer method of bounding for stability
         if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
           visc_bound_rem(I,J,kk) = 1.0
@@ -1761,123 +1761,123 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         elseif (CS%bound_Kh) then
           Kh(I,J,kk) = min(Kh(I,J,kk), hrat_min(I,J,kk) * CS%Kh_Max_xy(I,J))
         endif
-      enddo ; enddo ; enddo
+      enddo
 
       if (CS%use_Leithy) then
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           Kh(I,J,kk) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           Kh_q(I,J,k) = Kh(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_vort_xy_q > 0) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           vort_xy_q(I,J,k) = vort_xy(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_sh_xy_q > 0) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           sh_xy_q(I,J,k) = sh_xy(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (.not. CS%use_Leithy) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J,kk) = -Kh(I,J,kk) * sh_xy(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       else
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J,kk) = -Kh(I,J,kk) * sh_xy_smooth(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
     else
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         str_xy(I,J,kk) = 0.
-      enddo ; enddo ; enddo
+      enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         ! Horizontal-tension averaged to q-points
         local_strain = 0.25 * ( (sh_xx(i,j,kk) + sh_xx(i+1,j+1,kk)) + (sh_xx(i+1,j,kk) + sh_xx(i,j+1,kk)) )
         ! *Add* the tension contribution to the xy-component of stress
         str_xy(I,J,kk) = str_xy(I,J,kk) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
-      enddo ; enddo ; enddo
+      enddo
     endif
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         Ah(I,J,kk) = CS%Ah_bg_xy(I,J)
-      enddo ; enddo ; enddo
+      enddo
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
               AhSm = Shear_mag(I,J,kk) * (CS%Biharm_const_xy(I,J) &
                   + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J,kk))
               Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
-            enddo ; enddo ; enddo
+            enddo
           else
-            do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
               AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J,kk)
               Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
-            enddo ; enddo ; enddo
+            enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J,kk)) * inv_PI6
             Ah(I,J,kk) = max(Ah(I,J,kk), AhLth)
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif ! Smagorinsky_Ah or Leith_Ah
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           Ah(I,J,kk) = Ah(I,J,kk) + 0.25 * ( &
               (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) + (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I,j+1,k))**2) + ((v(i,J,k) + v(i+1,J,k))**2))
           Ah(I,J,kk) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             Ah(I,J,kk) = min(Ah(I,J,kk), visc_bound_rem(I,J,kk) * hrat_min(I,J,kk) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo ; enddo
+          enddo
         else
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             Ah(I,J,kk) = min(Ah(I,J,kk), hrat_min(I,J,kk) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
             k = kstart + kk - 1
             tmp = CS%KS_coef *hrat_min(I,J,kk) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
@@ -1885,38 +1885,38 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             if (Ah(I,J,kk) >= tmp) then
               visc_limit_q_flag(I,J,k) = 1.
             endif
-          enddo ; enddo ; enddo
+          enddo
       endif
 
       ! Leith+E doesn't recompute Ah at q points, it just interpolates it from h to q points
       if (CS%use_Leithy) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           Ah(I,J,kk) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           Ah_q(I,J,k) = Ah(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       ! Again, need to initialize str_xy as if its biharmonic
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         d_str = Ah(I,J,kk) * (dDel2vdx(I,J,kk) + dDel2udy(I,J,kk))
 
         str_xy(I,J,kk) = str_xy(I,J,kk) + d_str
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xy(I,J,kk) = d_str * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-      enddo ; enddo ; enddo
+      enddo
     endif ! Get Ah at q points and biharmonic part of str_xy
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         k = kstart + kk - 1
         if (visc_limit_q_flag(I,J,k) > 0) then
           Kh_BS(I,J,kk) = 0.
@@ -1931,27 +1931,27 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                 (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
           endif
         endif
-      enddo ; enddo ; enddo
+      enddo
 
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         str_xy_BS(I,J,kk) = -Kh_BS(I,J,kk) * (sh_xy(I,J,kk))
-      enddo ; enddo ; enddo
+      enddo
 
       if (CS%id_BS_coeff_q>0) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           k = kstart + kk - 1
           BS_coeff_q(I,J,k) = Kh_BS(I,J,kk)
-        enddo ; enddo ; enddo
+        enddo
       endif
 
-      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
         str_xy(I,J,kk) = str_xy(I,J,kk) + str_xy_BS(I,J,kk)
-      enddo ; enddo ; enddo
+      enddo
     endif ! Backscatter
 
     if (CS%use_GME) then
       ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do kk=1,kmax ; do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+      do concurrent (kk=1:kmax, j=Jsq-1:Jeq+2, i=Isq-1:Ieq+2)
         k = kstart + kk - 1
         GME_coeff = GME_effic_h(i,j,1) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
@@ -1959,10 +1959,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
         str_xx_GME(i,j,kk) = GME_coeff * sh_xx_bt(i,j)
-      enddo ; enddo ; enddo
+      enddo
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do kk=1,kmax ; do J=js-2,je+1 ; do I=is-2,ie+1
+      do concurrent (kk=1:kmax, J=js-2:je+1, I=is-2:ie+1)
         k = kstart + kk - 1
         GME_coeff = GME_effic_q(I,J,1) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
@@ -1970,7 +1970,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         if (CS%id_GME_coeff_q>0) GME_coeff_q(I,J,k) = GME_coeff
         str_xy_GME(I,J,kk) = GME_coeff * sh_xy_bt(I,J)
-      enddo ; enddo ; enddo
+      enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
       do kk=1,kmax
@@ -1979,48 +1979,48 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         k = kstart + kk - 1
         str_xx(i,j,kk) = (str_xx(i,j,kk) + str_xx_GME(i,j,kk)) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo ; enddo
+      enddo
 
       ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J,kk) = (str_xy(I,J,kk) + str_xy_GME(I,J,kk)) * (hq(I,J,kk) * CS%reduction_xy(I,J))
-        enddo ; enddo ; enddo
+        enddo
       else
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J,kk) = (str_xy(I,J,kk) + str_xy_GME(I,J,kk)) * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo ; enddo
+        enddo
       endif
 
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
         k = kstart + kk - 1
         str_xx(i,j,kk) = str_xx(i,j,kk) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo ; enddo
+      enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J,kk) = str_xy(I,J,kk) * (hq(I,J,kk) * CS%reduction_xy(I,J))
-        enddo ; enddo ; enddo
+        enddo
       else
-        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
           str_xy(I,J,kk) = str_xy(I,J,kk) * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo ; enddo
+        enddo
       endif
     endif ! use_GME
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
-    do kk=1,kmax ; do j=js,je ; do I=Isq,Ieq
+    do concurrent (kk=1:kmax, j=js:je, I=Isq:Ieq)
       k = kstart + kk - 1
       diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1,kk)) - (CS%dx2q(I,J)*str_xy(I,J,kk))) + &
                        G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j,kk)) - (CS%dy2h(i+1,j)*str_xx(i+1,j,kk)))) * &
                      G%IareaCu(I,j)) / (h_u(I,j,kk) + h_neglect)
-    enddo ; enddo ; enddo
+    enddo
 
     if (apply_OBC) then
       ! This is not the right boundary condition. If all the masking of tendencies are done
@@ -2028,21 +2028,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_E_or_W) then
           I = OBC%segment(n)%HI%IsdB
-          do kk=1,kmax ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+          do concurrent (kk=1:kmax, j=OBC%segment(n)%HI%jsd:OBC%segment(n)%HI%jed)
             k = kstart + kk - 1
             diffu(I,j,k) = 0.
-          enddo ; enddo
+          enddo
         endif
       enddo
     endif
 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
-    do kk=1,kmax ; do J=Jsq,Jeq ; do i=is,ie
+    do concurrent (kk=1:kmax, J=Jsq:Jeq, i=is:ie)
       k = kstart + kk - 1
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J,kk)) - (CS%dy2q(I,J)*str_xy(I,J,kk))) - &
                        G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j,kk)) - (CS%dx2h(i,j+1)*str_xx(i,j+1,kk)))) * &
                      G%IareaCv(i,J)) / (h_v(i,J,kk) + h_neglect)
-    enddo ; enddo ; enddo
+    enddo
 
     if (apply_OBC) then
       ! This is not the right boundary condition. If all the masking of tendencies are done
@@ -2050,10 +2050,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_N_or_S) then
           J = OBC%segment(n)%HI%JsdB
-          do kk=1,kmax ; do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+          do concurrent (kk=1:kmax, i=OBC%segment(n)%HI%isd:OBC%segment(n)%HI%ied)
             k = kstart + kk - 1
             diffv(i,J,k) = 0.
-          enddo ; enddo
+          enddo
         endif
       enddo
     endif
@@ -2062,7 +2062,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * ( &
                   ((str_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
@@ -2079,9 +2079,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                       + (str_xy(I,J-1,kk) *                                &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo ; enddo
+        enddo
       else
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((str_xx(i,j,kk)*CS%dy2h(i,j) * ( &
@@ -2111,14 +2111,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
 
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%EY24_EBT_BS) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           FrictWork(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork(i,j,k)
-        enddo ; enddo ; enddo
+        enddo
       endif
     endif
 
@@ -2126,7 +2126,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           FrictWork_bh(i,j,k) = GV%H_to_RZ * ( &
                   ((bhstr_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
@@ -2143,9 +2143,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                     + (bhstr_xy(I,J-1,kk) *                              &
                        (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                       + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo ; enddo
+        enddo
       else
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
           FrictWork_bh(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
@@ -2175,19 +2175,19 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
-        enddo ; enddo ; enddo
+        enddo
       endif
 
       if (CS%EY24_EBT_BS) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
+        do concurrent (kk=1:kmax, j=js:je, i=is:ie)
           k = kstart + kk - 1
           FrictWork_bh(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork_bh(i,j,k)
-        enddo ; enddo ; enddo
+        enddo
       endif
     endif
 
     if (CS%use_GME) then
-      if (CS%FrictWork_bug) then ; do kk=1,kmax ; do j=js,je ; do i=is,ie
+      if (CS%FrictWork_bug) then ; do concurrent (kk=1:kmax, j=js:je, i=is:ie)
         k = kstart + kk - 1
       ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
       ! This is the old formulation that includes energy diffusion
@@ -2206,8 +2206,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                       + (str_xy_GME(I,J-1,kk) *                            &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo ; enddo
-      else ; do kk=1,kmax ; do j=js,je ; do i=is,ie
+        enddo
+      else ; do concurrent (kk=1:kmax, j=js:je, i=is:ie)
         k = kstart + kk - 1
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((str_xx_GME(i,j,kk)*CS%dy2h(i,j) * ( &
@@ -2236,69 +2236,85 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
-      enddo ; enddo ; enddo ; endif
+      enddo ; endif
       if (allocated(MEKE%GME_snk)) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
-          k = kstart+kk-1
-          MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
-        enddo ; enddo ; enddo
+        do concurrent (j=js:je)
+          do kk=1,kmax
+            do concurrent (i=is:ie)
+              k = kstart+kk-1
+              MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
+            enddo
+          enddo
+        enddo
       endif
     endif
 
-    if (skeb_use_frict) then ; do kk=1,kmax ; do j=js,je ; do i=is,ie
+    if (skeb_use_frict) then ; do concurrent (kk=1:kmax, j=js:je, i=is:ie)
       k = kstart + kk - 1
       ! Note that the sign convention is FrictWork < 0 means energy dissipation.
       STOCH%skeb_diss(i,j,k) = STOCH%skeb_diss(i,j,k) - STOCH%skeb_frict_coef * &
                                FrictWork(i,j,k) / (GV%H_to_RZ * (h(i,j,k) + h_neglect))
-    enddo ; enddo ; enddo ; endif
+    enddo ; endif
 
     ! Make a similar calculation as for FrictWork above but accumulating into
     ! the vertically integrated MEKE source term, and adjusting for any
     ! energy loss seen as a reduction in the (biharmonic) frictional source term.
     if (find_FrictWork .and. allocated(MEKE%mom_src)) then
       if (MEKE%backscatter_Ro_c /= 0.) then
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
-          k = kstart + kk - 1
-          FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
-                        (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
-          Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
-            0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
-                  ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
-          if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
-            FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
-            ! Note the hard-coded dimensional constant in the following line that can not
-            ! be rescaled for dimensional consistency.
-            Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
-                        * MEKE%backscatter_Ro_c ! c * D^n
-            ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
-            ! RoScl = 1 - g(Ro)
-            RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
-          else
-            if (FatH <= backscat_subround*Shear_mag_bc) then
-              RoScl = 1.0
-            else
-              Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
-              RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
-            endif
-          endif
+        do concurrent (j=js:je)
+          do kk=1,kmax
+            do concurrent (i=is:ie)
+              k = kstart + kk - 1
+              FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
+                            (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
+              Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
+                0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
+                      ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
+              if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
+                FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
+                ! Note the hard-coded dimensional constant in the following line that can not
+                ! be rescaled for dimensional consistency.
+                Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
+                            * MEKE%backscatter_Ro_c ! c * D^n
+                ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
+                ! RoScl = 1 - g(Ro)
+                RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
+              else
+                if (FatH <= backscat_subround*Shear_mag_bc) then
+                  RoScl = 1.0
+                else
+                  Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
+                  RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
+                endif
+              endif
 
-          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
+              MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
 
-          if (allocated(MEKE%mom_src_bh)) &
-            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
-                + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
-        enddo ; enddo ; enddo
+              if (allocated(MEKE%mom_src_bh)) &
+                MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
+                    + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
+            enddo
+          enddo
+        enddo
       else
-        do kk=1,kmax ; do j=js,je ; do i=is,ie
-          k = kstart + kk - 1
-          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
-        enddo ; enddo ; enddo
+        do concurrent (j=js:je)
+          do kk=1,kmax
+            do concurrent (i=is:ie)
+              k = kstart + kk - 1
+              MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
+            enddo
+          enddo
+        enddo
 
         if (allocated(MEKE%mom_src_bh)) then
-          do kk=1,kmax ; do j=js,je ; do i=is,ie
-            k = kstart + kk - 1
-            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
-          enddo ; enddo ; enddo
+          do concurrent (j=js:je)
+            do kk=1,kmax
+              do concurrent (i=is:ie)
+                k = kstart + kk - 1
+                MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
+              enddo
+            enddo
+          enddo
         endif
       endif ! MEKE%backscatter_Ro_c
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2219,81 +2219,85 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo ; enddo ; endif
     endif
 
-    if (skeb_use_frict) then ; do j=js,je ; do i=is,ie
+    if (skeb_use_frict) then ; do kk=1,kmax ; do j=js,je ; do i=is,ie
+      k = kstart + kk - 1
       ! Note that the sign convention is FrictWork < 0 means energy dissipation.
       STOCH%skeb_diss(i,j,k) = STOCH%skeb_diss(i,j,k) - STOCH%skeb_frict_coef * &
                                FrictWork(i,j,k) / (GV%H_to_RZ * (h(i,j,k) + h_neglect))
-    enddo ; enddo ; endif
+    enddo ; enddo ; enddo ; endif
 
     ! Make a similar calculation as for FrictWork above but accumulating into
     ! the vertically integrated MEKE source term, and adjusting for any
     ! energy loss seen as a reduction in the (biharmonic) frictional source term.
     if (find_FrictWork .and. allocated(MEKE%mom_src)) then
-      if (k==1) then
-        do j=js,je ; do i=is,ie
-          MEKE%mom_src(i,j) = 0.
-        enddo ; enddo
-
-        if (allocated(MEKE%mom_src_bh)) then
+      do kk=1,kmax
+        k = kstart + kk - 1
+        if (k==1) then
           do j=js,je ; do i=is,ie
-            MEKE%mom_src_bh(i,j) = 0.
+            MEKE%mom_src(i,j) = 0.
           enddo ; enddo
-        endif
 
-        if (allocated(MEKE%GME_snk)) then
-          do j=js,je ; do i=is,ie
-            MEKE%GME_snk(i,j) = 0.
-          enddo ; enddo
-        endif
-      endif
-      if (MEKE%backscatter_Ro_c /= 0.) then
-        do j=js,je ; do i=is,ie
-          FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
-                        (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
-          Shear_mag_bc = sqrt(sh_xx(i,j,1) * sh_xx(i,j,1) + &
-            0.25*(((sh_xy(I-1,J-1,1)*sh_xy(I-1,J-1,1)) + (sh_xy(I,J,1)*sh_xy(I,J,1))) + &
-                  ((sh_xy(I-1,J,1)*sh_xy(I-1,J,1)) + (sh_xy(I,J-1,1)*sh_xy(I,J-1,1)))))
-          if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
-            FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
-            ! Note the hard-coded dimensional constant in the following line that can not
-            ! be rescaled for dimensional consistency.
-            Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
-                        * MEKE%backscatter_Ro_c ! c * D^n
-            ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
-            ! RoScl = 1 - g(Ro)
-            RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
-          else
-            if (FatH <= backscat_subround*Shear_mag_bc) then
-              RoScl = 1.0
-            else
-              Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
-              RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
-            endif
+          if (allocated(MEKE%mom_src_bh)) then
+            do j=js,je ; do i=is,ie
+              MEKE%mom_src_bh(i,j) = 0.
+            enddo ; enddo
           endif
 
-          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
-
-          if (allocated(MEKE%mom_src_bh)) &
-            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
-                + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
-        enddo ; enddo
-      else
-        do j=js,je ; do i=is,ie
-          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
-        enddo ; enddo
-
-        if (allocated(MEKE%mom_src_bh)) then
+          if (allocated(MEKE%GME_snk)) then
+            do j=js,je ; do i=is,ie
+              MEKE%GME_snk(i,j) = 0.
+            enddo ; enddo
+          endif
+        endif
+        if (MEKE%backscatter_Ro_c /= 0.) then
           do j=js,je ; do i=is,ie
-            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
+            FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
+                          (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
+            Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
+              0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
+                    ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
+            if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
+              FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
+              ! Note the hard-coded dimensional constant in the following line that can not
+              ! be rescaled for dimensional consistency.
+              Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
+                          * MEKE%backscatter_Ro_c ! c * D^n
+              ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
+              ! RoScl = 1 - g(Ro)
+              RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
+            else
+              if (FatH <= backscat_subround*Shear_mag_bc) then
+                RoScl = 1.0
+              else
+                Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
+                RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
+              endif
+            endif
+
+            MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
+
+            if (allocated(MEKE%mom_src_bh)) &
+              MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
+                  + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
+          enddo ; enddo
+        else
+          do j=js,je ; do i=is,ie
+            MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
+          enddo ; enddo
+
+          if (allocated(MEKE%mom_src_bh)) then
+            do j=js,je ; do i=is,ie
+              MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
+            enddo ; enddo
+          endif
+        endif ! MEKE%backscatter_Ro_c
+
+        if (CS%use_GME .and. allocated(MEKE%GME_snk)) then
+          do j=js,je ; do i=is,ie
+            MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
           enddo ; enddo
         endif
-      endif ! MEKE%backscatter_Ro_c
-
-      if (CS%use_GME .and. allocated(MEKE%GME_snk)) then
-        do j=js,je ; do i=is,ie
-          MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
-        enddo ; enddo
-      endif
+      enddo ! kk-loop
     endif ! find_FrictWork and associated(mom_src)
   enddo ! end of k loop
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1151,12 +1151,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(local_strain))
         ! Shearing-strain averaged to h-points
-        local_strain = 0.25 * ( (sh_xy(I,J,1) + sh_xy(I-1,J-1,1)) + (sh_xy(I-1,J,1) + sh_xy(I,J-1,1)) )
+        local_strain = 0.25 * ( (sh_xy(I,J,kk) + sh_xy(I-1,J-1,kk)) + (sh_xy(I-1,J,kk) + sh_xy(I,J-1,kk)) )
         ! *Add* the shear-strain contribution to the xx-component of stress
-        str_xx(i,j,1) = str_xx(i,j,1) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
-      enddo ; enddo
+        str_xx(i,j,kk) = str_xx(i,j,kk) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
+      enddo
     endif
 
     if (CS%biharmonic) then
@@ -2014,7 +2014,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif ! MEKE%backscatter_Ro_c
 
     endif ! find_FrictWork and associated(mom_src)
-  enddo ! end of k loop
+  enddo ! end of kstart block loop
 
   !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target exit data map(delete: h_u, h_v, hq)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1790,106 +1790,110 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
         ! Horizontal-tension averaged to q-points
-        local_strain = 0.25 * ( (sh_xx(i,j,1) + sh_xx(i+1,j+1,1)) + (sh_xx(i+1,j,1) + sh_xx(i,j+1,1)) )
+        local_strain = 0.25 * ( (sh_xx(i,j,kk) + sh_xx(i+1,j+1,kk)) + (sh_xx(i+1,j,kk) + sh_xx(i,j+1,kk)) )
         ! *Add* the tension contribution to the xy-component of stress
-        str_xy(I,J,1) = str_xy(I,J,1) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
-      enddo ; enddo
+        str_xy(I,J,kk) = str_xy(I,J,kk) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
+      enddo ; enddo ; enddo
     endif
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        Ah(I,J,1) = CS%Ah_bg_xy(I,J)
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        Ah(I,J,kk) = CS%Ah_bg_xy(I,J)
+      enddo ; enddo ; enddo
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do J=js-1,Jeq ; do I=is-1,Ieq
-              AhSm = Shear_mag(I,J,1) * (CS%Biharm_const_xy(I,J) &
-                  + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J,1))
-              Ah(I,J,1) = max(Ah(I,J,1), AhSm)
-            enddo ; enddo
+            do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+              AhSm = Shear_mag(I,J,kk) * (CS%Biharm_const_xy(I,J) &
+                  + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J,kk))
+              Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
+            enddo ; enddo ; enddo
           else
-            do J=js-1,Jeq ; do I=is-1,Ieq
-              AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J,1)
-              Ah(I,J,1) = max(Ah(I,J,1), AhSm)
-            enddo ; enddo
+            do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+              AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J,kk)
+              Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
+            enddo ; enddo ; enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J,1)) * inv_PI6
-            Ah(I,J,1) = max(Ah(I,J,1), AhLth)
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J,kk)) * inv_PI6
+            Ah(I,J,kk) = max(Ah(I,J,kk), AhLth)
+          enddo ; enddo ; enddo
         endif
       endif ! Smagorinsky_Ah or Leith_Ah
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah(I,J,1) = Ah(I,J,1) + 0.25 * ( &
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          Ah(I,J,kk) = Ah(I,J,kk) + 0.25 * ( &
               (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) + (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I,j+1,k))**2) + ((v(i,J,k) + v(i+1,J,k))**2))
-          Ah(I,J,1) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
-        enddo ; enddo
+          Ah(I,J,kk) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Ah(I,J,1) = min(Ah(I,J,1), visc_bound_rem(I,J,1) * hrat_min(I,J,1) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Ah(I,J,kk) = min(Ah(I,J,kk), visc_bound_rem(I,J,kk) * hrat_min(I,J,kk) * CS%Ah_Max_xy(I,J))
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Ah(I,J,1) = min(Ah(I,J,1), hrat_min(I,J,1) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Ah(I,J,kk) = min(Ah(I,J,kk), hrat_min(I,J,kk) * CS%Ah_Max_xy(I,J))
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            tmp = CS%KS_coef *hrat_min(I,J,1) * CS%Ah_Max_xy_KS(I,J)
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            k = kstart + kk - 1
+            tmp = CS%KS_coef *hrat_min(I,J,kk) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
-            visc_limit_q_frac(i,j,k) = Ah(i,j,1) / (CS%KS_coef * hrat_min(i,j,1) * CS%Ah_Max_xy_KS(i,j))
-            if (Ah(I,J,1) >= tmp) then
+            visc_limit_q_frac(i,j,k) = Ah(i,j,kk) / (CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xy_KS(i,j))
+            if (Ah(I,J,kk) >= tmp) then
               visc_limit_q_flag(I,J,k) = 1.
             endif
-          enddo ; enddo
+          enddo ; enddo ; enddo
       endif
 
       ! Leith+E doesn't recompute Ah at q points, it just interpolates it from h to q points
       if (CS%use_Leithy) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah(I,J,1) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
+          Ah(I,J,kk) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah_q(I,J,k) = Ah(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
+          Ah_q(I,J,k) = Ah(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
       ! Again, need to initialize str_xy as if its biharmonic
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        d_str = Ah(I,J,1) * (dDel2vdx(I,J,1) + dDel2udy(I,J,1))
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        d_str = Ah(I,J,kk) * (dDel2vdx(I,J,kk) + dDel2udy(I,J,kk))
 
-        str_xy(I,J,1) = str_xy(I,J,1) + d_str
+        str_xy(I,J,kk) = str_xy(I,J,kk) + d_str
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        bhstr_xy(I,J,1) = d_str * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-      enddo ; enddo
+        bhstr_xy(I,J,kk) = d_str * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+      enddo ; enddo ; enddo
     endif ! Get Ah at q points and biharmonic part of str_xy
 
     ! Backscatter using MEKE

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -819,8 +819,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! becomes do i=is-1,ie+1. -RWH
         if ((J >= js-2) .and. (J <= Jeq+1)) then
           do concurrent (kk=1:kmax, &
-                         i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied)) &
-                         DO_LOCALITY(local(k))
+                         i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied)) DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_v(i,J,kk) = h(i,j,k)
           enddo
@@ -828,8 +827,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-2) .and. (J <= Jeq+1)) then
           do concurrent (kk=1:kmax, &
-                         i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied)) &
-                         DO_LOCALITY(local(k))
+                         i=max(is-2,OBC%segment(n)%HI%isd):min(ie+2,OBC%segment(n)%HI%ied)) DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_v(i,J,kk) = h(i,j+1,k)
           enddo
@@ -837,8 +835,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
           do concurrent (kk=1:kmax, &
-                         j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed)) &
-                         DO_LOCALITY(local(k))
+                         j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed)) DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_u(I,j,kk) = h(i,j,k)
           enddo
@@ -846,8 +843,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
           do concurrent (kk=1:kmax, &
-                         j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed)) &
-                         DO_LOCALITY(local(k))
+                         j=max(js-2,OBC%segment(n)%HI%jsd):min(je+2,OBC%segment(n)%HI%jed)) DO_LOCALITY(local(k))
             k = kstart + kk - 1
             h_u(I,j,kk) = h(i+1,j,k)
           enddo
@@ -1936,7 +1932,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
       enddo ; endif
-      if (allocated(MEKE%GME_snk)) then
+      if (find_FrictWork .and. allocated(MEKE%mom_src) .and. allocated(MEKE%GME_snk)) then
         do concurrent (j=js:je)
           do kk=1,kmax
             do concurrent (i=is:ie) DO_LOCALITY(local(k))
@@ -2179,10 +2175,16 @@ subroutine hor_visc_Leith_grad(G, GV, US, CS, VarMix, nkblock, kstart, kmax, &
   integer,                       intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
   integer,                       intent(in)    :: kstart !< The first absolute k-layer of the current k-block
   integer,                       intent(in)    :: kmax   !< The number of active k-layers in the current k-block
-  integer,                       intent(in)    :: is, ie, js, je !< Loop ranges for the h-point viscosities
-  integer,                       intent(in)    :: is_Kh, ie_Kh, js_Kh, je_Kh !< Loop ranges for the
-                                                       !! thickness point viscosities
-  integer,                       intent(in)    :: Ieq, Jeq !< The last index in each direction at q-points
+  integer,                       intent(in)    :: is     !< Start i-loop index for the h-point viscosities
+  integer,                       intent(in)    :: ie     !< End i-loop index for the h-point viscosities
+  integer,                       intent(in)    :: js     !< Start j-loop index for the h-point viscosities
+  integer,                       intent(in)    :: je     !< End j-loop index for the h-point viscosities
+  integer,                       intent(in)    :: is_Kh  !< Start i-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: ie_Kh  !< End i-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: js_Kh  !< Start j-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: je_Kh  !< End j-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: Ieq    !< The last i-index at q-points
+  integer,                       intent(in)    :: Jeq    !< The last j-index at q-points
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                                   intent(in)    :: h      !< Layer thicknesses [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -2383,7 +2385,10 @@ subroutine hor_visc_backscatter_h(G, CS, MEKE, VarMix, use_kh_struct, nkblock, k
   integer,               intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
   integer,               intent(in)    :: kstart  !< The first absolute k-layer of the current k-block
   integer,               intent(in)    :: kmax    !< The number of active k-layers in the current k-block
-  integer,               intent(in)    :: Isq, Ieq, Jsq, Jeq !< Loop ranges for the stress tensor at h-points
+  integer,               intent(in)    :: Isq !< Start i-loop index for the stress tensor at h-points
+  integer,               intent(in)    :: Ieq !< End i-loop index for the stress tensor at h-points
+  integer,               intent(in)    :: Jsq !< Start j-loop index for the stress tensor at h-points
+  integer,               intent(in)    :: Jeq !< End j-loop index for the stress tensor at h-points
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                          intent(in)    :: visc_limit_h_flag !< determines whether backscatter is shut off [nondim]
   real, dimension(SZI_(G),SZJ_(G),nkblock), &
@@ -2446,8 +2451,10 @@ subroutine hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, nkbloc
   integer,                 intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
   integer,                 intent(in)    :: kstart  !< The first absolute k-layer of the current k-block
   integer,                 intent(in)    :: kmax    !< The number of active k-layers in the current k-block
-  integer,                 intent(in)    :: is, js  !< Loop start indices for the q-point stress tensor
-  integer,                 intent(in)    :: Ieq, Jeq !< Loop end indices for the q-point stress tensor
+  integer,                 intent(in)    :: is  !< Start i-loop index for the q-point stress tensor
+  integer,                 intent(in)    :: js  !< Start j-loop index for the q-point stress tensor
+  integer,                 intent(in)    :: Ieq !< End i-loop index for the q-point stress tensor
+  integer,                 intent(in)    :: Jeq !< End j-loop index for the q-point stress tensor
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
                            intent(in)    :: visc_limit_q_flag !< determines whether backscatter is shut off [nondim]
   real, dimension(SZIB_(G),SZJB_(G),nkblock), &
@@ -2512,8 +2519,10 @@ subroutine hor_visc_Leithy_Ah(G, GV, CS, nkblock, kstart, kmax, is_Kh, ie_Kh, js
   integer,                 intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
   integer,                 intent(in)    :: kstart  !< The first absolute k-layer of the current k-block
   integer,                 intent(in)    :: kmax    !< The number of active k-layers in the current k-block
-  integer,                 intent(in)    :: is_Kh, ie_Kh, js_Kh, je_Kh !< Loop ranges for the
-                                                 !! thickness point viscosities
+  integer,                 intent(in)    :: is_Kh !< Start i-loop index for the thickness point viscosities
+  integer,                 intent(in)    :: ie_Kh !< End i-loop index for the thickness point viscosities
+  integer,                 intent(in)    :: js_Kh !< Start j-loop index for the thickness point viscosities
+  integer,                 intent(in)    :: je_Kh !< End j-loop index for the thickness point viscosities
   real,                    intent(in)    :: inv_PI6 !< The inverse of pi to the sixth power [nondim]
   real, dimension(SZIB_(G),SZJB_(G),nkblock), &
                            intent(in)    :: Del2vort_q !< Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -617,7 +617,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target enter data map(alloc: h_u, h_v, hq)
-  !$omp target enter data map(alloc: str_xx, str_xy)
+  !$omp target enter data map(alloc: str_xx, str_xy, ShSt)
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
   !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
@@ -636,13 +636,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target enter data map(alloc: BS_coeff_h, BS_coeff_q) &
   !$omp   if (CS%EY24_EBT_BS)
-  !$omp target enter data map(alloc: vert_vort_mag, vert_vort_mag_smooth) &
-  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
-  !$omp target enter data map(alloc: m_leithy) if (CS%use_Leithy)
+  !$omp target enter data map(alloc: vert_vort_mag, vert_vort_mag_smooth)
+  !$omp target enter data map(alloc: m_leithy)
   !$omp target enter data map(alloc: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
-  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
-  !$omp target enter data map(alloc: vort_xy, vort_xy_smooth) &
-  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
+  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth)
+  !$omp target enter data map(alloc: vort_xy, vort_xy_smooth)
   !$omp target enter data map(alloc: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
   !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
@@ -2028,7 +2026,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target exit data map(delete: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
   !$omp target exit data map(delete: h_u, h_v, hq)
-  !$omp target exit data map(delete: str_xx, str_xy)
+  !$omp target exit data map(delete: str_xx, str_xy, ShSt)
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
   !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target exit data map(delete: Shear_mag) if (use_Smag)
@@ -2043,13 +2041,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   !$omp target exit data map(delete: BS_coeff_h, BS_coeff_q) &
   !$omp   if (CS%EY24_EBT_BS)
-  !$omp target exit data map(delete: vert_vort_mag, vert_vort_mag_smooth) &
-  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
-  !$omp target exit data map(delete: m_leithy) if (CS%use_Leithy)
+  !$omp target exit data map(delete: vert_vort_mag, vert_vort_mag_smooth)
+  !$omp target exit data map(delete: m_leithy)
   !$omp target exit data map(delete: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
-  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
-  !$omp target exit data map(delete: vort_xy, vort_xy_smooth) &
-  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
+  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth)
+  !$omp target exit data map(delete: vort_xy, vort_xy_smooth)
   !$omp target exit data map(delete: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
   !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
@@ -2067,6 +2063,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)
+  !$omp target update from(ShSt) if (CS%id_shearstress > 0)
   if (CS%id_shearstress > 0) call post_data(CS%id_shearstress, ShSt, CS%diag)
   if (CS%id_diffu>0)     call post_data(CS%id_diffu, diffu, CS%diag)
   if (CS%id_diffv>0)     call post_data(CS%id_diffv, diffv, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -561,7 +561,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   endif
 
   if (CS%use_GME) then
-    call hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, &
+    call hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, nkblock, &
                              dudx_bt, dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, &
                              GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME, &
                              GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
@@ -2600,7 +2600,7 @@ end function hor_visc_nkblock
 !! efficiency and isopycnal height diffusivity fields that are used within
 !! horizontal_viscosity when GME (CS%use_GME) is active. The caller must
 !! only invoke this routine when CS%use_GME is true.
-subroutine hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, &
+subroutine hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, nkblock, &
                                dudx_bt, dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, &
                                GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME, &
                                GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
@@ -2612,6 +2612,7 @@ subroutine hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, &
                                   intent(inout) :: h      !< Layer thicknesses [H ~> m or kg m-2].
   type(barotropic_CS),           optional, intent(in) :: BT !< Barotropic control structure
   type(thickness_diffuse_CS),    optional, intent(in) :: TD !< Thickness diffusion control structure
+  integer,                       intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
   real, dimension(SZI_(G),SZJB_(G)), &
                                   intent(out)   :: dudx_bt !< x-component in the barotropic
                                                        !! horizontal tension [T-1 ~> s-1]
@@ -2647,10 +2648,10 @@ subroutine hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, &
                                                        !! [L2 T-1 ~> m2 s-1]
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
                                   intent(out)   :: GME_coeff_q !< GME coeff. at q-points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJ_(G),merge(GV%ke,CS%nkblock,CS%nkblock==0)), &
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
                                   intent(out)   :: str_xx_GME !< Smoothed diagonal term in the
                                                        !! stress tensor from GME [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJB_(G),merge(GV%ke,CS%nkblock,CS%nkblock==0)), &
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
                                   intent(out)   :: str_xy_GME !< Smoothed cross term in the
                                                        !! stress tensor from GME [L2 T-2 ~> m2 s-2]
   ! Local variables

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -322,7 +322,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
     div_xx_dy, &  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
     vbtav         ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJ_(G)) :: &
+  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
     dudx_bt, dvdy_bt, & ! components in the barotropic horizontal tension [T-1 ~> s-1]
     div_xx, &     ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
     sh_xx, &      ! horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
@@ -501,7 +501,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   skeb_use_frict = .false.
   if (present(STOCH)) skeb_use_frict = STOCH%skeb_use_frict
 
-  m_leithy(:,:) = 0.0 ! Initialize
+  m_leithy(:,:,1) = 0.0 ! Initialize
 
   if (present(OBC)) then ; if (associated(OBC)) then ; if (OBC%OBC_pe) then
     apply_OBC = OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally
@@ -571,7 +571,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Initialize diagnostic arrays with zeros
     GME_coeff_h(:,:,:) = 0.0
     GME_coeff_q(:,:,:) = 0.0
-    str_xx_GME(:,:) = 0.0
+    str_xx_GME(:,:,1) = 0.0
     str_xy_GME(:,:) = 0.0
 
     ! Get barotropic velocities and their gradients
@@ -582,13 +582,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Calculate the barotropic horizontal tension
     do j=js-2,je+2 ; do i=is-2,ie+2
-      dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j,1)) - &
+      dudx_bt(i,j,1) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j,1)) - &
                                      (G%IdyCu(I-1,j) * ubtav(I-1,j,1)))
-      dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J,1)) - &
+      dvdy_bt(i,j,1) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J,1)) - &
                                      (G%IdxCv(i,J-1) * vbtav(i,J-1,1)))
     enddo ; enddo
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
+      sh_xx_bt(i,j,1) = dudx_bt(i,j,1) - dvdy_bt(i,j,1)
     enddo ; enddo
 
     ! Components for the barotropic shearing strain
@@ -610,36 +610,36 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     do j=js-2,je+2 ; do i=is-2,ie+2
-      htot(i,j) = 0.0
+      htot(i,j,1) = 0.0
     enddo ; enddo
     do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-      htot(i,j) = htot(i,j) + h(i,j,k)
+      htot(i,j,1) = htot(i,j,1) + h(i,j,k)
     enddo ; enddo ; enddo
 
     I_GME_h0 = 1.0 / CS%GME_h0
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       boundary_mask_h = (G%mask2dCu(I,j) * G%mask2dCu(I-1,j)) * (G%mask2dCv(i,J) * G%mask2dCv(i,J-1))
-      grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j)**2 + dvdy_bt(i,j)**2 + &
+      grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j,1)**2 + dvdy_bt(i,j,1)**2 + &
             (0.25*((dvdx_bt(I,J)+dvdx_bt(I-1,J-1)) + (dvdx_bt(I,J-1)+dvdx_bt(I-1,J))))**2 + &
             (0.25*((dudy_bt(I,J)+dudy_bt(I-1,J-1)) + (dudy_bt(I,J-1)+dudy_bt(I-1,J))))**2)
       ! Probably the following test could be simplified to
       ! if (boundary_mask_h * G%mask2dT(I,J) > 0.0) then
       if (grad_vel_mag_bt_h > 0.0) then
-        GME_effic_h(i,j) = CS%GME_efficiency * G%mask2dT(I,J) * (MIN(htot(i,j) * I_GME_h0, 1.0)**2)
+        GME_effic_h(i,j,1) = CS%GME_efficiency * G%mask2dT(I,J) * (MIN(htot(i,j,1) * I_GME_h0, 1.0)**2)
       else
-        GME_effic_h(i,j) = 0.0
+        GME_effic_h(i,j,1) = 0.0
       endif
     enddo ; enddo
 
     do J=js-2,je+1 ; do I=is-2,ie+1
       boundary_mask_q = (G%mask2dCv(i,J) * G%mask2dCv(i+1,J)) * (G%mask2dCu(I,j) * G%mask2dCu(I,j+1))
       grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
-            (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1)) + (dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
-            (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1)) + (dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
+            (0.25*((dudx_bt(i,j,1)+dudx_bt(i+1,j+1,1)) + (dudx_bt(i,j+1,1)+dudx_bt(i+1,j,1))))**2 + &
+            (0.25*((dvdy_bt(i,j,1)+dvdy_bt(i+1,j+1,1)) + (dvdy_bt(i,j+1,1)+dvdy_bt(i+1,j,1))))**2)
       ! Probably the following test could be simplified to
       ! if (boundary_mask_q * G%mask2dBu(I,J) > 0.0) then
       if (grad_vel_mag_bt_q > 0.0) then
-        h_arith_q = 0.25 * ((htot(i,j) + htot(i+1,j+1)) + (htot(i+1,j) + htot(i,j+1)))
+        h_arith_q = 0.25 * ((htot(i,j,1) + htot(i+1,j+1,1)) + (htot(i+1,j,1) + htot(i,j+1,1)))
         GME_effic_q(I,J) = CS%GME_efficiency * G%mask2dBu(I,J) * (MIN(h_arith_q * I_GME_h0, 1.0)**2)
       else
         GME_effic_q(I,J) = 0.0
@@ -728,11 +728,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Calculate horizontal tension
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
+      dudx(i,j,1) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
                                   (G%IdyCu(I-1,j) * u(I-1,j,k)))
-      dvdy(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
+      dvdy(i,j,1) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
                                   (G%IdxCv(i,J-1) * v(i,J-1,k)))
-      sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
+      sh_xx(i,j,1) = dudx(i,j,1) - dvdy(i,j,1)
     enddo ; enddo
 
     ! Components for the shearing strain
@@ -744,11 +744,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        dudx_smooth(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
+        dudx_smooth(i,j,1) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
                                            (G%IdyCu(I-1,j) * u_smooth(I-1,j,k)))
-        dvdy_smooth(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
+        dvdy_smooth(i,j,1) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
                                            (G%IdxCv(i,J-1) * v_smooth(i,J-1,k)))
-        sh_xx_smooth(i,j) = dudx_smooth(i,j) - dvdy_smooth(i,j)
+        sh_xx_smooth(i,j,1) = dudx_smooth(i,j,1) - dvdy_smooth(i,j,1)
       enddo ; enddo
 
       ! Components for the shearing strain from smoothed velocity
@@ -762,7 +762,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if (CS%id_normstress > 0) then
       do j=js,je ; do i=is,ie
-        NoSt(i,j,k) = sh_xx(i,j)
+        NoSt(i,j,k) = sh_xx(i,j,1)
       enddo ; enddo
     endif
 
@@ -948,11 +948,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%biharmonic) then
       do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
         Del2u(I,j,1) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
-                     CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j)) - (CS%dy2h(i,j)*sh_xx(i,j)))
+                     CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j,1)) - (CS%dy2h(i,j)*sh_xx(i,j,1)))
       enddo ; enddo
       do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
         Del2v(i,J,1) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
-                     CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1)) - (CS%dx2h(i,j)*sh_xx(i,j)))
+                     CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1,1)) - (CS%dx2h(i,j)*sh_xx(i,j,1)))
       enddo ; enddo
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
         do n=1,OBC%number_of_segments
@@ -1048,20 +1048,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         ! Divergence
         do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
-          div_xx(i,j) = dudx(i,j) + dvdy(i,j)
+          div_xx(i,j,1) = dudx(i,j,1) + dvdy(i,j,1)
         enddo ; enddo
 
         ! Divergence gradient
         do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
-          div_xx_dx(I,j,1) = G%IdxCu(I,j)*(div_xx(i+1,j) - div_xx(i,j))
+          div_xx_dx(I,j,1) = G%IdxCu(I,j)*(div_xx(i+1,j,1) - div_xx(i,j,1))
         enddo ; enddo
         do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
-          div_xx_dy(i,J,1) = G%IdyCv(i,J)*(div_xx(i,j+1) - div_xx(i,j))
+          div_xx_dy(i,J,1) = G%IdyCv(i,J)*(div_xx(i,j+1,1) - div_xx(i,j,1))
         enddo ; enddo
 
         ! Magnitude of divergence gradient
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_div_mag_h(i,j) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I-1,j,1)))**2) + &
+          grad_div_mag_h(i,j,1) = sqrt(((0.5*(div_xx_dx(I,j,1) + div_xx_dx(I-1,j,1)))**2) + &
                                      ((0.5*(div_xx_dy(i,J,1) + div_xx_dy(i,J-1,1)))**2))
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1078,7 +1078,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           div_xx_dy(i,J,1) = 0.0
         enddo ; enddo
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_div_mag_h(i,j) = 0.0
+          grad_div_mag_h(i,j,1) = 0.0
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
           grad_div_mag_q(I,J) = 0.0
@@ -1099,7 +1099,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%use_QG_Leith_visc) then
 
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_vort_mag_h_2d(i,j) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
+          grad_vort_mag_h_2d(i,j,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
                                          ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
         enddo ; enddo
         do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1114,7 +1114,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        grad_vort_mag_h(i,j) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
+        grad_vort_mag_h(i,j,1) = SQRT(((0.5*(vort_xy_dx(i,J,1) + vort_xy_dx(i,J-1,1)))**2) + &
                                     ((0.5*(vort_xy_dy(I,j,1) + vort_xy_dy(I-1,j,1)))**2) )
       enddo ; enddo
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1135,7 +1135,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        sh_xx_sq = sh_xx(i,j)**2
+        sh_xx_sq = sh_xx(i,j,1)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1)**2) + (sh_xy(I,J)**2)) &
                           + ((sh_xy(I-1,J)**2) + (sh_xy(I,J-1)**2)) )
         Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
@@ -1157,13 +1157,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%use_QG_Leith_visc) then
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            grad_vort = grad_vort_mag_h(i,j) + grad_div_mag_h(i,j)
-            grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j)
+            grad_vort = grad_vort_mag_h(i,j,1) + grad_div_mag_h(i,j,1)
+            grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j,1)
             vert_vort_mag(i,j) = min(grad_vort, grad_vort_qg)
           enddo ; enddo
         else
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            vert_vort_mag(i,j) = grad_vort_mag_h(i,j) + grad_div_mag_h(i,j)
+            vert_vort_mag(i,j) = grad_vort_mag_h(i,j,1) + grad_div_mag_h(i,j,1)
           enddo ; enddo
         endif
       endif
@@ -1276,22 +1276,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (CS%id_div_xx_h>0) then
         do j=js,je ; do i=is,ie
-          div_xx_h(i,j,k) = dudx(i,j) + dvdy(i,j)
+          div_xx_h(i,j,k) = dudx(i,j,1) + dvdy(i,j,1)
         enddo ; enddo
       endif
 
       if (CS%id_sh_xx_h>0) then
         do j=js,je ; do i=is,ie
-          sh_xx_h(i,j,k) = sh_xx(i,j)
+          sh_xx_h(i,j,k) = sh_xx(i,j,1)
         enddo ; enddo
       endif
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = -Kh(i,j) * sh_xx(i,j)
+        str_xx(i,j,1) = -Kh(i,j) * sh_xx(i,j,1)
       enddo ; enddo
     else
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = 0.0
+        str_xx(i,j,1) = 0.0
       enddo ; enddo
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
@@ -1300,7 +1300,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Shearing-strain averaged to h-points
         local_strain = 0.25 * ( (sh_xy(I,J) + sh_xy(I-1,J-1)) + (sh_xy(I-1,J) + sh_xy(I,J-1)) )
         ! *Add* the shear-strain contribution to the xx-component of stress
-        str_xx(i,j) = str_xx(i,j) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
+        str_xx(i,j,1) = str_xx(i,j,1) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
       enddo ; enddo
     endif
 
@@ -1339,49 +1339,49 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         if (CS%use_Leithy) then
           ! Get m_leithy
-          if (CS%smooth_Ah) m_leithy(:,:) = 0.0 ! This is here to initialize domain edge halo values.
+          if (CS%smooth_Ah) m_leithy(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
                                  (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
             AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
             if (AhLth <= CS%Ah_bg_xx(i,j)) then
-              m_leithy(i,j) = 0.0
+              m_leithy(i,j,1) = 0.0
             else
               if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j)) < abs(vort_xy_smooth(i,j))) then
-                m_leithy(i,j) = CS%c_K * (vert_vort_mag(i,j) / vort_xy_smooth(i,j))**2
+                m_leithy(i,j,1) = CS%c_K * (vert_vort_mag(i,j) / vort_xy_smooth(i,j))**2
               else
-                m_leithy(i,j) = CS%m_leithy_max(i,j)
+                m_leithy(i,j,1) = CS%m_leithy_max(i,j)
               endif
-              m_leithy(i,j) = G%mask2dBu(i,j) * m_leithy(i,j)
+              m_leithy(i,j,1) = G%mask2dBu(i,j) * m_leithy(i,j,1)
             endif
           enddo ; enddo
 
           if (CS%smooth_Ah) then
             ! Smooth m_leithy.  A single call smoothes twice.
-            call pass_var(m_leithy, G%Domain, halo=2)
-            call smooth_x9_h(G, m_leithy, zero_land=.true.)
-            call pass_var(m_leithy, G%Domain)
+            call pass_var(m_leithy(:,:,1), G%Domain, halo=2)
+            call smooth_x9_h(G, m_leithy(:,:,1), zero_land=.true.)
+            call pass_var(m_leithy(:,:,1), G%Domain)
           endif
           ! Get Ah
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
                                  (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
             AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
-                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j)*vert_vort_mag_smooth(i,j)**2))
+                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,1)*vert_vort_mag_smooth(i,j)**2))
             Ah(i,j) = max(CS%Ah_bg_xx(i,j), AhLthy)
           enddo ; enddo
           if (CS%smooth_Ah) then
             ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
-            Ah_sq(:,:) = 0.0 ! This is here to initialize domain edge halo values.
+            Ah_sq(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_sq(i,j) = Ah(i,j)**2
+              Ah_sq(i,j,1) = Ah(i,j)**2
             enddo ; enddo
-            call pass_var(Ah_sq, G%Domain, halo=2)
+            call pass_var(Ah_sq(:,:,1), G%Domain, halo=2)
             ! A single call smoothes twice.
-            call smooth_x9_h(G, Ah_sq, zero_land=.false.)
-            call pass_var(Ah_sq, G%Domain)
+            call smooth_x9_h(G, Ah_sq(:,:,1), zero_land=.false.)
+            call pass_var(Ah_sq(:,:,1), G%Domain)
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j))))
+              Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,1))))
               Ah(i,j)     = Ah_h(i,j,k)
             enddo ; enddo
           else
@@ -1440,7 +1440,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j) = -m_leithy(i,j) * Ah(i,j)
+          Kh(i,j) = -m_leithy(i,j,1) * Ah(i,j)
           Kh_h(i,j,k) = Kh(i,j)
         enddo ; enddo
       endif
@@ -1458,12 +1458,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J,1)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,1))
         d_str = Ah(i,j) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
 
-        str_xx(i,j) = str_xx(i,j) + d_str
+        str_xx(i,j,1) = str_xx(i,j,1) + d_str
 
-        if (CS%use_Leithy) str_xx(i,j) = str_xx(i,j) - Kh(i,j) * sh_xx_smooth(i,j)
+        if (CS%use_Leithy) str_xx(i,j,1) = str_xx(i,j,1) - Kh(i,j) * sh_xx_smooth(i,j,1)
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
+        bhstr_xx(i,j,1) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
@@ -1482,7 +1482,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx_BS(i,j) = -Kh_BS(i,j) * sh_xx(i,j)
+        str_xx_BS(i,j,1) = -Kh_BS(i,j) * sh_xx(i,j,1)
       enddo ; enddo
 
       if (CS%id_BS_coeff_h>0) then
@@ -1492,7 +1492,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = str_xx(i,j) + str_xx_BS(i,j)
+        str_xx(i,j,1) = str_xx(i,j,1) + str_xx_BS(i,j,1)
       enddo ; enddo
     endif ! Backscatter
 
@@ -1531,8 +1531,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
       do J=js-1,Jeq ; do I=is-1,Ieq
         sh_xy_sq = sh_xy(I,J)**2
-        sh_xx_sq = 0.25 * ( ((sh_xx(i,j)**2) + (sh_xx(i+1,j+1)**2)) &
-                          + ((sh_xx(i,j+1)**2) + (sh_xx(i+1,j)**2)) )
+        sh_xx_sq = 0.25 * ( ((sh_xx(i,j,1)**2) + (sh_xx(i+1,j+1,1)**2)) &
+                          + ((sh_xx(i,j+1,1)**2) + (sh_xx(i+1,j,1)**2)) )
         Shear_mag(I,J) = sqrt(sh_xy_sq + sh_xx_sq)
       enddo ; enddo
     endif
@@ -1578,7 +1578,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then
-      call ZB2020_copy_gradient_and_thickness(sh_xx, sh_xy, vort_xy, hq, G, GV, CS%ZB2020, k)
+      call ZB2020_copy_gradient_and_thickness(sh_xx(:,:,1), sh_xy, vort_xy, hq, G, GV, CS%ZB2020, k)
     endif
 
     if (CS%Laplacian) then
@@ -1731,7 +1731,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%anisotropic) then
       do J=js-1,Jeq ; do I=is-1,Ieq
         ! Horizontal-tension averaged to q-points
-        local_strain = 0.25 * ( (sh_xx(i,j) + sh_xx(i+1,j+1)) + (sh_xx(i+1,j) + sh_xx(i,j+1)) )
+        local_strain = 0.25 * ( (sh_xx(i,j,1) + sh_xx(i+1,j+1,1)) + (sh_xx(i+1,j,1) + sh_xx(i,j+1,1)) )
         ! *Add* the tension contribution to the xy-component of stress
         str_xy(I,J) = str_xy(I,J) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
       enddo ; enddo
@@ -1867,12 +1867,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%use_GME) then
       ! The wider halo here is to permit one pass of smoothing without a halo update.
       do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-        GME_coeff = GME_effic_h(i,j) * 0.25 * &
+        GME_coeff = GME_effic_h(i,j,1) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
-        str_xx_GME(i,j) = GME_coeff * sh_xx_bt(i,j)
+        str_xx_GME(i,j,1) = GME_coeff * sh_xx_bt(i,j,1)
       enddo ; enddo
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
@@ -1886,12 +1886,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo ; enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
-      call smooth_GME(CS, G, GME_flux_h=str_xx_GME)
+      call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,1))
       call smooth_GME(CS, G, GME_flux_q=str_xy_GME)
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = (str_xx(i,j) + str_xx_GME(i,j)) * (h(i,j,k) * CS%reduction_xx(i,j))
+        str_xx(i,j,1) = (str_xx(i,j,1) + str_xx_GME(i,j,1)) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
 
       ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
@@ -1908,7 +1908,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
+        str_xx(i,j,1) = str_xx(i,j,1) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
@@ -1926,7 +1926,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
     do j=js,je ; do I=Isq,Ieq
       diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1)) - (CS%dx2q(I,J)*str_xy(I,J))) + &
-                       G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j)) - (CS%dy2h(i+1,j)*str_xx(i+1,j)))) * &
+                       G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j,1)) - (CS%dy2h(i+1,j)*str_xx(i+1,j,1)))) * &
                      G%IareaCu(I,j)) / (h_u(I,j,1) + h_neglect)
     enddo ; enddo
 
@@ -1946,7 +1946,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
     do J=Jsq,Jeq ; do i=is,ie
       diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
-                       G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j)) - (CS%dx2h(i,j+1)*str_xx(i,j+1)))) * &
+                       G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j,1)) - (CS%dx2h(i,j+1)*str_xx(i,j+1,1)))) * &
                      G%IareaCv(i,J)) / (h_v(i,J,1) + h_neglect)
     enddo ; enddo
 
@@ -1969,8 +1969,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! This is the old formulation that includes energy diffusion
         do j=js,je ; do i=is,ie
           FrictWork(i,j,k) = GV%H_to_RZ * ( &
-                  ((str_xx(i,j) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-                 - (str_xx(i,j) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+                  ((str_xx(i,j,1) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+                 - (str_xx(i,j,1) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
               + 0.25*(( (str_xy(I,J) *                                  &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
@@ -1987,10 +1987,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       else
         do j=js,je ; do i=is,ie
           FrictWork(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx(i,j)*CS%dy2h(i,j) * ( &
+            ((str_xx(i,j,1)*CS%dy2h(i,j) * ( &
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
-           - (str_xx(i,j)*CS%dx2h(i,j) * ( &
+           - (str_xx(i,j,1)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
           + (0.25*(((str_xy(I,J)*(                                     &
@@ -2030,8 +2030,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! This is the old formulation that includes energy diffusion !cyc
         do j=js,je ; do i=is,ie
           FrictWork_bh(i,j,k) = GV%H_to_RZ * ( &
-                  ((bhstr_xx(i,j) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
-                 - (bhstr_xx(i,j) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))) &
+                  ((bhstr_xx(i,j,1) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
+                 - (bhstr_xx(i,j,1) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))) &
               + 0.25*(( (bhstr_xy(I,J) *                              &
                        (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                       + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
@@ -2049,10 +2049,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do j=js,je ; do i=is,ie
           ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
           FrictWork_bh(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((bhstr_xx(i,j)*CS%dy2h(i,j) * ( &
+            ((bhstr_xx(i,j,1)*CS%dy2h(i,j) * ( &
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
-           - (bhstr_xx(i,j)*CS%dx2h(i,j) * ( &
+           - (bhstr_xx(i,j,1)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
           + (0.25*(((bhstr_xy(I,J)*(                                     &
@@ -2090,8 +2090,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
       ! This is the old formulation that includes energy diffusion
         FrictWork_GME(i,j,k) = GV%H_to_RZ * ( &
-                ((str_xx_GME(i,j)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-               - (str_xx_GME(i,j)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+                ((str_xx_GME(i,j,1)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+               - (str_xx_GME(i,j,1)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
               + 0.25*(( (str_xy_GME(I,J) *                              &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
@@ -2107,10 +2107,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         enddo ; enddo
       else ; do j=js,je ; do i=is,ie
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx_GME(i,j)*CS%dy2h(i,j) * ( &
+            ((str_xx_GME(i,j,1)*CS%dy2h(i,j) * ( &
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
-           - (str_xx_GME(i,j)*CS%dx2h(i,j) * ( &
+           - (str_xx_GME(i,j,1)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
        + (0.25*(((str_xy_GME(I,J)*(                                     &
@@ -2167,7 +2167,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do j=js,je ; do i=is,ie
           FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
                         (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
-          Shear_mag_bc = sqrt(sh_xx(i,j) * sh_xx(i,j) + &
+          Shear_mag_bc = sqrt(sh_xx(i,j,1) * sh_xx(i,j,1) + &
             0.25*(((sh_xy(I-1,J-1)*sh_xy(I-1,J-1)) + (sh_xy(I,J)*sh_xy(I,J))) + &
                   ((sh_xy(I-1,J)*sh_xy(I-1,J)) + (sh_xy(I,J-1)*sh_xy(I,J-1)))))
           if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
@@ -2235,8 +2235,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%id_GME_coeff_h > 0) call post_data(CS%id_GME_coeff_h, GME_coeff_h, CS%diag)
     if (CS%id_GME_coeff_q > 0) call post_data(CS%id_GME_coeff_q, GME_coeff_q, CS%diag)
     if (CS%id_FrictWork_GME>0) call post_data(CS%id_FrictWork_GME, FrictWork_GME, CS%diag)
-    if (CS%id_dudx_bt > 0) call post_data(CS%id_dudx_bt, dudx_bt, CS%diag)
-    if (CS%id_dvdy_bt > 0) call post_data(CS%id_dvdy_bt, dvdy_bt, CS%diag)
+    if (CS%id_dudx_bt > 0) call post_data(CS%id_dudx_bt, dudx_bt(:,:,1), CS%diag)
+    if (CS%id_dvdy_bt > 0) call post_data(CS%id_dvdy_bt, dvdy_bt(:,:,1), CS%diag)
     if (CS%id_dudy_bt > 0) call post_data(CS%id_dudy_bt, dudy_bt, CS%diag)
     if (CS%id_dvdx_bt > 0) call post_data(CS%id_dvdx_bt, dvdx_bt, CS%diag)
   endif
@@ -2264,22 +2264,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   if (CS%id_FrictWorkIntz > 0) then
     do j=js,je
-      do i=is,ie ; FrictWorkIntz(i,j) = FrictWork(i,j,1) ; enddo
+      do i=is,ie ; FrictWorkIntz(i,j,1) = FrictWork(i,j,1) ; enddo
       do k=2,nz ; do i=is,ie
-        FrictWorkIntz(i,j) = FrictWorkIntz(i,j) + FrictWork(i,j,k)
+        FrictWorkIntz(i,j,1) = FrictWorkIntz(i,j,1) + FrictWork(i,j,k)
       enddo ; enddo
     enddo
-    call post_data(CS%id_FrictWorkIntz, FrictWorkIntz, CS%diag)
+    call post_data(CS%id_FrictWorkIntz, FrictWorkIntz(:,:,1), CS%diag)
   endif
 
   if (CS%id_FrictWorkIntz_bh > 0) then
     do j=js,je
-      do i=is,ie ; FrictWorkIntz_bh(i,j) = FrictWork_bh(i,j,1) ; enddo
+      do i=is,ie ; FrictWorkIntz_bh(i,j,1) = FrictWork_bh(i,j,1) ; enddo
       do k=2,nz ; do i=is,ie
-        FrictWorkIntz_bh(i,j) = FrictWorkIntz_bh(i,j) + FrictWork_bh(i,j,k)
+        FrictWorkIntz_bh(i,j,1) = FrictWorkIntz_bh(i,j,1) + FrictWork_bh(i,j,k)
       enddo ; enddo
     enddo
-    call post_data(CS%id_FrictWorkIntz_bh, FrictWorkIntz_bh, CS%diag)
+    call post_data(CS%id_FrictWorkIntz_bh, FrictWorkIntz_bh(:,:,1), CS%diag)
   endif
 
   if (present(ADp)) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -332,11 +332,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real, dimension(SZI_(G),SZJ_(G)) :: &
     sh_xx_bt      ! barotropic horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
-    str_xx        ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
+    str_xx, &     ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
-  real, dimension(SZI_(G),SZJ_(G)) :: &
-    str_xx_GME    ! smoothed diagonal term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
-  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
+    str_xx_GME, & ! smoothed diagonal term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
     bhstr_xx, &   ! A copy of str_xx that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     FrictWorkIntz, & ! depth integrated energy dissipated by lateral friction [R Z L2 T-3 ~> W m-2]
     FrictWorkIntz_bh, & ! depth integrated energy dissipated by biharmonic lateral friction [R Z L2 T-3 ~> W m-2]
@@ -365,11 +363,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real, dimension(SZIB_(G),SZJB_(G)) :: &
     sh_xy_bt      ! barotropic horizontal shearing strain (du/dy + dv/dx) inc. metric terms [T-1 ~> s-1]
   real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
-    str_xy        ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
+    str_xy, &     ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
-  real, dimension(SZIB_(G),SZJB_(G)) :: &
-    str_xy_GME    ! smoothed cross term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
+    str_xy_GME, & ! smoothed cross term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
     bhstr_xy, &   ! A copy of str_xy that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     vort_xy, &    ! Vertical vorticity (dv/dx - du/dy) including metric terms [T-1 ~> s-1]
     vort_xy_smooth, & ! Vertical vorticity including metric terms, smoothed [T-1 ~> s-1]
@@ -583,8 +579,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Initialize diagnostic arrays with zeros
     GME_coeff_h(:,:,:) = 0.0
     GME_coeff_q(:,:,:) = 0.0
-    str_xx_GME(:,:) = 0.0
-    str_xy_GME(:,:) = 0.0
+    str_xx_GME(:,:,1) = 0.0
+    str_xy_GME(:,:,1) = 0.0
 
     ! Get barotropic velocities and their gradients
     call barotropic_get_tav(BT, ubtav, vbtav, G, US)
@@ -1885,7 +1881,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
-        str_xx_GME(i,j) = GME_coeff * sh_xx_bt(i,j)
+        str_xx_GME(i,j,1) = GME_coeff * sh_xx_bt(i,j)
       enddo ; enddo
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
@@ -1895,26 +1891,26 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if (CS%id_GME_coeff_q>0) GME_coeff_q(I,J,k) = GME_coeff
-        str_xy_GME(I,J) = GME_coeff * sh_xy_bt(I,J)
+        str_xy_GME(I,J,1) = GME_coeff * sh_xy_bt(I,J)
       enddo ; enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
-      call smooth_GME(CS, G, GME_flux_h=str_xx_GME)
-      call smooth_GME(CS, G, GME_flux_q=str_xy_GME)
+      call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,1))
+      call smooth_GME(CS, G, GME_flux_q=str_xy_GME(:,:,1))
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = (str_xx(i,j,1) + str_xx_GME(i,j)) * (h(i,j,k) * CS%reduction_xx(i,j))
+        str_xx(i,j,1) = (str_xx(i,j,1) + str_xx_GME(i,j,1)) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
 
       ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J)) * (hq(I,J,1) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * CS%reduction_xy(I,J))
         enddo ; enddo
       else
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J)) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
 
@@ -2103,45 +2099,45 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
       ! This is the old formulation that includes energy diffusion
         FrictWork_GME(i,j,k) = GV%H_to_RZ * ( &
-                ((str_xx_GME(i,j)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-               - (str_xx_GME(i,j)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy_GME(I,J) *                              &
+                ((str_xx_GME(i,j,1)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+               - (str_xx_GME(i,j,1)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+              + 0.25*(( (str_xy_GME(I,J,1) *                              &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy_GME(I-1,J-1) *                          &
+                      + (str_xy_GME(I-1,J-1,1) *                          &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy_GME(I-1,J) *                            &
+                    + ( (str_xy_GME(I-1,J,1) *                            &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy_GME(I,J-1) *                            &
+                      + (str_xy_GME(I,J-1,1) *                            &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo ; enddo
       else ; do j=js,je ; do i=is,ie
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx_GME(i,j)*CS%dy2h(i,j) * ( &
+            ((str_xx_GME(i,j,1)*CS%dy2h(i,j) * ( &
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
-           - (str_xx_GME(i,j)*CS%dx2h(i,j) * ( &
+           - (str_xx_GME(i,j,1)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
-       + (0.25*(((str_xy_GME(I,J)*(                                     &
+       + (0.25*(((str_xy_GME(I,J,1)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
-                +(str_xy_GME(I-1,J-1)*(                                 &
+                +(str_xy_GME(I-1,J-1,1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
-               +((str_xy_GME(I-1,J)*(                                   &
+               +((str_xy_GME(I-1,J,1)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
-                +(str_xy_GME(I,J-1)*(                                   &
+                +(str_xy_GME(I,J-1,1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1519,72 +1519,74 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = kstart + kk - 1
         if (visc_limit_h_flag(i,j,k) > 0) then
-          Kh_BS(i,j,1) = 0.
+          Kh_BS(i,j,kk) = 0.
         else
           if (use_kh_struct) then
-            Kh_BS(i,j,1) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+            Kh_BS(i,j,kk) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
           else
-            Kh_BS(i,j,1) = MEKE%Ku(i,j)
+            Kh_BS(i,j,kk) = MEKE%Ku(i,j)
           endif
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
 
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx_BS(i,j,1) = -Kh_BS(i,j,1) * sh_xx(i,j,1)
-      enddo ; enddo
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx_BS(i,j,kk) = -Kh_BS(i,j,kk) * sh_xx(i,j,kk)
+      enddo ; enddo ; enddo
 
       if (CS%id_BS_coeff_h>0) then
-        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-          BS_coeff_h(i,j,k) = Kh_BS(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+          k = kstart + kk - 1
+          BS_coeff_h(i,j,k) = Kh_BS(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = str_xx(i,j,1) + str_xx_BS(i,j,1)
-      enddo ; enddo
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx(i,j,kk) = str_xx(i,j,kk) + str_xx_BS(i,j,kk)
+      enddo ; enddo ; enddo
     endif ! Backscatter
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        dDel2vdx(I,J,1) = CS%DY_dxBu(I,J)*((Del2v(i+1,J,1)*G%IdyCv(i+1,J)) - (Del2v(i,J,1)*G%IdyCv(i,J)))
-        dDel2udy(I,J,1) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,1)*G%IdxCu(I,j+1)) - (Del2u(I,j,1)*G%IdxCu(I,j)))
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        dDel2vdx(I,J,kk) = CS%DY_dxBu(I,J)*((Del2v(i+1,J,kk)*G%IdyCv(i+1,J)) - (Del2v(i,J,kk)*G%IdyCv(i,J)))
+        dDel2udy(I,J,kk) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,kk)*G%IdxCu(I,j+1)) - (Del2u(I,j,kk)*G%IdxCu(I,j)))
+      enddo ; enddo ; enddo
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if ((OBC%strain_config == OBC_STRAIN_ZERO) .or. &
                                 (OBC%strain_config == OBC_STRAIN_FREESLIP)) then
         do n=1,OBC%number_of_segments
           J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
-            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+            do kk=1,kmax ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
-                dDel2vdx(I,J,1) = 0. ; dDel2udy(I,J,1) = 0.
+                dDel2vdx(I,J,kk) = 0. ; dDel2udy(I,J,kk) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
-                dDel2udy(I,J,1) = 0.
+                dDel2udy(I,J,kk) = 0.
               endif
-            enddo
+            enddo ; enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= Ieq)) then
-            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+            do kk=1,kmax ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
-                dDel2vdx(I,J,1) = 0. ; dDel2udy(I,J,1) = 0.
+                dDel2vdx(I,J,kk) = 0. ; dDel2udy(I,J,kk) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
-                dDel2vdx(I,J,1) = 0.
+                dDel2vdx(I,J,kk) = 0.
               endif
-            enddo
+            enddo ; enddo
           endif
         enddo
       endif ; endif
     endif
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        sh_xy_sq = sh_xy(I,J,1)**2
-        sh_xx_sq = 0.25 * ( ((sh_xx(i,j,1)**2) + (sh_xx(i+1,j+1,1)**2)) &
-                          + ((sh_xx(i,j+1,1)**2) + (sh_xx(i+1,j,1)**2)) )
-        Shear_mag(I,J,1) = sqrt(sh_xy_sq + sh_xx_sq)
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        sh_xy_sq = sh_xy(I,J,kk)**2
+        sh_xx_sq = 0.25 * ( ((sh_xx(i,j,kk)**2) + (sh_xx(i+1,j+1,kk)**2)) &
+                          + ((sh_xx(i,j+1,kk)**2) + (sh_xx(i+1,j,kk)**2)) )
+        Shear_mag(I,J,kk) = sqrt(sh_xy_sq + sh_xx_sq)
+      enddo ; enddo ; enddo
     endif
 
     do J=js-1,Jeq ; do I=is-1,Ieq

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -312,20 +312,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! Local variables
   real, dimension(SZIB_(G),SZJ_(G),nkblock) :: &
     Del2u, &      ! The u-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
-    h_u, &        ! Thickness interpolated to u points [H ~> m or kg m-2].
-    vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
-    vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
-    div_xx_dx     ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+    h_u           ! Thickness interpolated to u points [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJB_(G),nkblock) :: &
     Del2v, &      ! The v-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
-    h_v, &        ! Thickness interpolated to v points [H ~> m or kg m-2].
-    vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
-    vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
-    div_xx_dy     ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+    h_v           ! Thickness interpolated to v points [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJB_(G)) :: &
     dudx_bt, dvdy_bt ! components in the barotropic horizontal tension [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
-    div_xx, &     ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
     sh_xx, &      ! horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
     sh_xx_smooth  ! horizontal tension from smoothed velocity including metric terms [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G)) :: &
@@ -654,12 +647,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
   !$omp target enter data map(alloc: vort_xy, vort_xy_smooth) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
-  !$omp target enter data map(alloc: vort_xy_dx, vort_xy_dy, vort_xy_dx_smooth, vort_xy_dy_smooth, &
-  !$omp                              div_xx_dx, div_xx_dy) if (CS%use_QG_Leith_visc)
   !$omp target enter data map(alloc: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
   !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
-  !$omp target enter data map(alloc: div_xx) if (CS%Laplacian .or. CS%biharmonic)
   !$omp target enter data map(alloc: slope_x, slope_y) &
   !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
   !$omp target enter data map(alloc: dz) &
@@ -993,135 +983,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
 
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
-
-      ! Vorticity gradient
-      do concurrent (kk=1:kmax, J=js-2:je_Kh, i=is_Kh-1:ie_Kh+1) DO_LOCALITY(local(DY_dxBu))
-        DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-        vort_xy_dx(i,J,kk) = DY_dxBu * ((vort_xy(I,J,kk) * G%IdyCu(I,j)) - (vort_xy(I-1,J,kk) * G%IdyCu(I-1,j)))
-      enddo
-
-      do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, I=is-2:ie_Kh) DO_LOCALITY(local(DX_dyBu))
-        DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-        vort_xy_dy(I,j,kk) = DX_dyBu * ((vort_xy(I,J,kk) * G%IdxCv(i,J)) - (vort_xy(I,J-1,kk) * G%IdxCv(i,J-1)))
-      enddo
-
-      if (CS%use_Leithy) then
-        ! Gradient of smoothed vorticity
-        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(DY_dxBu))
-          DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-          vort_xy_dx_smooth(i,J,kk) = DY_dxBu * &
-                      ((vort_xy_smooth(I,J,kk) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,kk) * G%IdyCu(I-1,j)))
-        enddo
-
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, I=is_Kh-1:ie_Kh) DO_LOCALITY(local(DX_dyBu))
-          DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-          vort_xy_dy_smooth(I,j,kk) = DX_dyBu * &
-                      ((vort_xy_smooth(I,J,kk) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,kk) * G%IdxCv(i,J-1)))
-        enddo
-      endif ! If Leithy
-
-      ! Laplacian of vorticity
-      ! if (CS%Leith_Ah .or. CS%use_Leithy) then
-      do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh) DO_LOCALITY(local(DY_dxBu, DX_dyBu))
-        DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-        DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-
-        Del2vort_q(I,J,kk) = DY_dxBu * ((vort_xy_dx(i+1,J,kk) * G%IdyCv(i+1,J)) &
-                                        - (vort_xy_dx(i,J,kk) * G%IdyCv(i,J))) + &
-                          DX_dyBu * ((vort_xy_dy(I,j+1,kk) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,kk) * G%IdyCu(I,j)))
-      enddo
-      ! endif
-
-      if (CS%modified_Leith) then
-
-        ! Divergence
-        do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, i=is_Kh-1:ie_Kh+1)
-          div_xx(i,j,kk) = dudx(i,j,kk) + dvdy(i,j,kk)
-        enddo
-
-        ! Divergence gradient
-        do concurrent (kk=1:kmax, j=js-1:je+1, I=is_Kh-1:ie_Kh)
-          div_xx_dx(I,j,kk) = G%IdxCu(I,j)*(div_xx(i+1,j,kk) - div_xx(i,j,kk))
-        enddo
-        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is-1:ie+1)
-          div_xx_dy(i,J,kk) = G%IdyCv(i,J)*(div_xx(i,j+1,kk) - div_xx(i,j,kk))
-        enddo
-
-        ! Magnitude of divergence gradient
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-          grad_div_mag_h(i,j,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I-1,j,kk)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i,J-1,kk)))**2))
-        enddo
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
-          grad_div_mag_q(I,J,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I,j+1,kk)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i+1,J,kk)))**2))
-        enddo
-
-      else
-
-        do concurrent (kk=1:kmax, j=js-1:je+1, I=is_Kh-1:ie_Kh)
-          div_xx_dx(I,j,kk) = 0.0
-        enddo
-        do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is-1:ie+1)
-          div_xx_dy(i,J,kk) = 0.0
-        enddo
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-          grad_div_mag_h(i,j,kk) = 0.0
-        enddo
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
-          grad_div_mag_q(I,J,kk) = 0.0
-        enddo
-
-      endif ! CS%modified_Leith
-
-      ! Add in beta for the Leith viscosity
-      if (CS%use_beta_in_Leith) then
-        do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-1:ie+1)
-          vort_xy_dx(i,J,kk) = vort_xy_dx(i,J,kk) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
-        enddo
-        do concurrent (kk=1:kmax, j=js-1:je+1, I=is-2:Ieq+1)
-          vort_xy_dy(I,j,kk) = vort_xy_dy(I,j,kk) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
-        enddo
-      endif ! CS%use_beta_in_Leith
-
-      if (CS%use_QG_Leith_visc) then
-
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-          grad_vort_mag_h_2d(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
-        enddo
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
-          grad_vort_mag_q_2d(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
-        enddo
-
-        ! This accumulates terms, some of which are in VarMix.
-        do kk=1,kmax
-          k = kstart + kk - 1
-          call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,kk), div_xx_dy(:,:,kk), &
-                                       slope_x, slope_y, vort_xy_dx(:,:,kk), vort_xy_dy(:,:,kk))
-        enddo
-
-      endif
-
-      do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-        grad_vort_mag_h(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
-      enddo
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
-        grad_vort_mag_q(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
-      enddo
-
-      if (CS%use_Leithy) then
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
-          vert_vort_mag_smooth(i,j,kk) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,kk) + &
-                                                  vort_xy_dx_smooth(i,J-1,kk)))**2) + &
-                                           ((0.5*(vort_xy_dy_smooth(I,j,kk) + &
-                                                  vort_xy_dy_smooth(I-1,j,kk)))**2) )
-        enddo
-      endif ! Leithy
-
+      call hor_visc_Leith_grad(G, GV, US, CS, VarMix, nkblock, kstart, kmax, &
+                                is, ie, js, je, is_Kh, ie_Kh, js_Kh, je_Kh, Ieq, Jeq, &
+                                h, dz, slope_x, slope_y, dudx, dvdy, vort_xy, vort_xy_smooth, &
+                                grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
+                                grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, &
+                                vert_vort_mag_smooth, Del2vort_q)
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
@@ -2297,12 +2164,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth) if (CS%use_Leithy)
   !$omp target exit data map(delete: vort_xy, vort_xy_smooth) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
-  !$omp target exit data map(delete: vort_xy_dx, vort_xy_dy, vort_xy_dx_smooth, vort_xy_dy_smooth, &
-  !$omp                              div_xx_dx, div_xx_dy) if (CS%use_QG_Leith_visc)
   !$omp target exit data map(delete: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
   !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
-  !$omp target exit data map(delete: div_xx) if (CS%Laplacian .or. CS%biharmonic)
   !$omp target exit data map(delete: slope_x, slope_y) &
   !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
   !$omp target exit data map(delete: dz) &
@@ -2416,6 +2280,214 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   endif
 
 end subroutine horizontal_viscosity
+
+!> Calculates the magnitude of the vorticity and divergence gradients, and the
+!! Laplacian of vorticity, that are used within horizontal_viscosity by the Leith,
+!! modified Leith, Leith+E, and QG Leith viscosity schemes. The caller must only
+!! invoke this routine when CS%Leith_Kh, CS%Leith_Ah, or CS%use_Leithy is true.
+subroutine hor_visc_Leith_grad(G, GV, US, CS, VarMix, nkblock, kstart, kmax, &
+                                is, ie, js, je, is_Kh, ie_Kh, js_Kh, je_Kh, Ieq, Jeq, &
+                                h, dz, slope_x, slope_y, dudx, dvdy, vort_xy, vort_xy_smooth, &
+                                grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
+                                grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, &
+                                vert_vort_mag_smooth, Del2vort_q)
+  type(ocean_grid_type),         intent(in)    :: G      !< The ocean's grid structure.
+  type(verticalGrid_type),       intent(in)    :: GV     !< The ocean's vertical grid structure.
+  type(unit_scale_type),         intent(in)    :: US     !< A dimensional unit scaling type
+  type(hor_visc_CS),             intent(in)    :: CS     !< Horizontal viscosity control structure
+  type(VarMix_CS),               intent(inout) :: VarMix !< Variable mixing control structure
+  integer,                       intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
+  integer,                       intent(in)    :: kstart !< The first absolute k-layer of the current k-block
+  integer,                       intent(in)    :: kmax   !< The number of active k-layers in the current k-block
+  integer,                       intent(in)    :: is, ie, js, je !< Loop ranges for the h-point viscosities
+  integer,                       intent(in)    :: is_Kh, ie_Kh, js_Kh, je_Kh !< Loop ranges for the
+                                                       !! thickness point viscosities
+  integer,                       intent(in)    :: Ieq, Jeq !< The last index in each direction at q-points
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                  intent(in)    :: h      !< Layer thicknesses [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                  intent(in)    :: dz     !< Height change across layers [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), &
+                                  intent(inout) :: slope_x !< Isopycnal slope in i-direction [Z L-1 ~> nondim]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), &
+                                  intent(inout) :: slope_y !< Isopycnal slope in j-direction [Z L-1 ~> nondim]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                                  intent(in)    :: dudx   !< x-derivative of the horizontal tension [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                                  intent(in)    :: dvdy   !< y-derivative of the horizontal tension [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(in)    :: vort_xy !< Vertical vorticity (dv/dx - du/dy) including
+                                                       !! metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(in)    :: vort_xy_smooth !< Vertical vorticity including metric
+                                                       !! terms, smoothed [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                                  intent(out)   :: grad_vort_mag_h !< Magnitude of vorticity gradient at
+                                                       !! h-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                                  intent(out)   :: grad_vort_mag_h_2d !< Magnitude of 2d vorticity gradient
+                                                       !! at h-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                                  intent(out)   :: grad_div_mag_h !< Magnitude of divergence gradient at
+                                                       !! h-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(out)   :: grad_vort_mag_q !< Magnitude of vorticity gradient at
+                                                       !! q-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(out)   :: grad_vort_mag_q_2d !< Magnitude of 2d vorticity gradient
+                                                       !! at q-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(out)   :: grad_div_mag_q !< Magnitude of divergence gradient at
+                                                       !! q-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(out)   :: vert_vort_mag_smooth !< Magnitude of gradient of smoothed
+                                                       !! vertical vorticity (h or q) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                                  intent(out)   :: Del2vort_q !< Laplacian of vorticity at q-points
+                                                       !! [L-2 T-1 ~> m-2 s-1]
+  ! Local variables
+  real, dimension(SZI_(G),SZJB_(G),nkblock) :: &
+    vort_xy_dx, &        ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
+    vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
+    div_xx_dy            ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJ_(G),nkblock) :: &
+    vort_xy_dy, &        ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
+    vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
+    div_xx_dx            ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
+    div_xx               ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
+  real :: DY_dxBu ! Ratio of meridional over zonal grid spacing at vertices [nondim]
+  real :: DX_dyBu ! Ratio of zonal over meridional grid spacing at vertices [nondim]
+  integer :: i, j, k, kk
+
+  ! Vorticity gradient
+  do concurrent (kk=1:kmax, J=js-2:je_Kh, i=is_Kh-1:ie_Kh+1) DO_LOCALITY(local(DY_dxBu))
+    DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+    vort_xy_dx(i,J,kk) = DY_dxBu * ((vort_xy(I,J,kk) * G%IdyCu(I,j)) - (vort_xy(I-1,J,kk) * G%IdyCu(I-1,j)))
+  enddo
+
+  do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, I=is-2:ie_Kh) DO_LOCALITY(local(DX_dyBu))
+    DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+    vort_xy_dy(I,j,kk) = DX_dyBu * ((vort_xy(I,J,kk) * G%IdxCv(i,J)) - (vort_xy(I,J-1,kk) * G%IdxCv(i,J-1)))
+  enddo
+
+  if (CS%use_Leithy) then
+    ! Gradient of smoothed vorticity
+    do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(DY_dxBu))
+      DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+      vort_xy_dx_smooth(i,J,kk) = DY_dxBu * &
+                  ((vort_xy_smooth(I,J,kk) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,kk) * G%IdyCu(I-1,j)))
+    enddo
+
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, I=is_Kh-1:ie_Kh) DO_LOCALITY(local(DX_dyBu))
+      DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+      vort_xy_dy_smooth(I,j,kk) = DX_dyBu * &
+                  ((vort_xy_smooth(I,J,kk) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,kk) * G%IdxCv(i,J-1)))
+    enddo
+  endif ! If Leithy
+
+  ! Laplacian of vorticity
+  ! if (CS%Leith_Ah .or. CS%use_Leithy) then
+  do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, I=is_Kh-1:ie_Kh) DO_LOCALITY(local(DY_dxBu, DX_dyBu))
+    DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+    DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+
+    Del2vort_q(I,J,kk) = DY_dxBu * ((vort_xy_dx(i+1,J,kk) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J,kk) * G%IdyCv(i,J))) + &
+                      DX_dyBu * ((vort_xy_dy(I,j+1,kk) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,kk) * G%IdyCu(I,j)))
+  enddo
+  ! endif
+
+  if (CS%modified_Leith) then
+
+    ! Divergence
+    do concurrent (kk=1:kmax, j=js_Kh-1:je_Kh+1, i=is_Kh-1:ie_Kh+1)
+      div_xx(i,j,kk) = dudx(i,j,kk) + dvdy(i,j,kk)
+    enddo
+
+    ! Divergence gradient
+    do concurrent (kk=1:kmax, j=js-1:je+1, I=is_Kh-1:ie_Kh)
+      div_xx_dx(I,j,kk) = G%IdxCu(I,j)*(div_xx(i+1,j,kk) - div_xx(i,j,kk))
+    enddo
+    do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is-1:ie+1)
+      div_xx_dy(i,J,kk) = G%IdyCv(i,J)*(div_xx(i,j+1,kk) - div_xx(i,j,kk))
+    enddo
+
+    ! Magnitude of divergence gradient
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      grad_div_mag_h(i,j,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I-1,j,kk)))**2) + &
+                                 ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i,J-1,kk)))**2))
+    enddo
+    do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      grad_div_mag_q(I,J,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I,j+1,kk)))**2) + &
+                                 ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i+1,J,kk)))**2))
+    enddo
+
+  else
+
+    do concurrent (kk=1:kmax, j=js-1:je+1, I=is_Kh-1:ie_Kh)
+      div_xx_dx(I,j,kk) = 0.0
+    enddo
+    do concurrent (kk=1:kmax, J=js_Kh-1:je_Kh, i=is-1:ie+1)
+      div_xx_dy(i,J,kk) = 0.0
+    enddo
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      grad_div_mag_h(i,j,kk) = 0.0
+    enddo
+    do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      grad_div_mag_q(I,J,kk) = 0.0
+    enddo
+
+  endif ! CS%modified_Leith
+
+  ! Add in beta for the Leith viscosity
+  if (CS%use_beta_in_Leith) then
+    do concurrent (kk=1:kmax, J=js-2:Jeq+1, i=is-1:ie+1)
+      vort_xy_dx(i,J,kk) = vort_xy_dx(i,J,kk) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
+    enddo
+    do concurrent (kk=1:kmax, j=js-1:je+1, I=is-2:Ieq+1)
+      vort_xy_dy(I,j,kk) = vort_xy_dy(I,j,kk) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
+    enddo
+  endif ! CS%use_beta_in_Leith
+
+  if (CS%use_QG_Leith_visc) then
+
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      grad_vort_mag_h_2d(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
+                                     ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
+    enddo
+    do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+      grad_vort_mag_q_2d(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
+                                     ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
+    enddo
+
+    ! This accumulates terms, some of which are in VarMix.
+    do kk=1,kmax
+      k = kstart + kk - 1
+      call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,kk), div_xx_dy(:,:,kk), &
+                                   slope_x, slope_y, vort_xy_dx(:,:,kk), vort_xy_dy(:,:,kk))
+    enddo
+
+  endif
+
+  do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+    grad_vort_mag_h(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
+                                ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
+  enddo
+  do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+    grad_vort_mag_q(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
+                                ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
+  enddo
+
+  if (CS%use_Leithy) then
+    do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+      vert_vort_mag_smooth(i,j,kk) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,kk) + &
+                                              vort_xy_dx_smooth(i,J-1,kk)))**2) + &
+                                       ((0.5*(vort_xy_dy_smooth(I,j,kk) + &
+                                              vort_xy_dy_smooth(I-1,j,kk)))**2) )
+    enddo
+  endif ! Leithy
+
+end subroutine hor_visc_Leith_grad
 
 !> Returns the effective k-block size for horizontal_viscosity calls.
 integer function hor_visc_nkblock(CS, GV)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -684,6 +684,24 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! call pass_vector(slope_x, slope_y, G%Domain, halo=2)
   endif
 
+  if (find_FrictWork .and. allocated(MEKE%mom_src)) then
+    do j=js,je ; do i=is,ie
+      MEKE%mom_src(i,j) = 0.
+    enddo ; enddo
+
+    if (allocated(MEKE%mom_src_bh)) then
+      do j=js,je ; do i=is,ie
+        MEKE%mom_src_bh(i,j) = 0.
+      enddo ; enddo
+    endif
+
+    if (allocated(MEKE%GME_snk)) then
+      do j=js,je ; do i=is,ie
+        MEKE%GME_snk(i,j) = 0.
+      enddo ; enddo
+    endif
+  endif
+
   !$OMP parallel do default(none) if (.not. CS%smooth_AH) &
   !$OMP shared( &
   !$OMP   CS, G, GV, US, OBC, VarMix, MEKE, u, v, h, uh, vh, &
@@ -2217,6 +2235,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
       enddo ; enddo ; enddo ; endif
+      if (allocated(MEKE%GME_snk)) then
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart+kk-1
+          MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
+        enddo ; enddo ; enddo
+      endif
     endif
 
     if (skeb_use_frict) then ; do kk=1,kmax ; do j=js,je ; do i=is,ie
@@ -2232,23 +2256,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (find_FrictWork .and. allocated(MEKE%mom_src)) then
       do kk=1,kmax
         k = kstart + kk - 1
-        if (k==1) then
-          do j=js,je ; do i=is,ie
-            MEKE%mom_src(i,j) = 0.
-          enddo ; enddo
-
-          if (allocated(MEKE%mom_src_bh)) then
-            do j=js,je ; do i=is,ie
-              MEKE%mom_src_bh(i,j) = 0.
-            enddo ; enddo
-          endif
-
-          if (allocated(MEKE%GME_snk)) then
-            do j=js,je ; do i=is,ie
-              MEKE%GME_snk(i,j) = 0.
-            enddo ; enddo
-          endif
-        endif
         if (MEKE%backscatter_Ro_c /= 0.) then
           do j=js,je ; do i=is,ie
             FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
@@ -2292,11 +2299,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         endif ! MEKE%backscatter_Ro_c
 
-        if (CS%use_GME .and. allocated(MEKE%GME_snk)) then
-          do j=js,je ; do i=is,ie
-            MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
-          enddo ; enddo
-        endif
       enddo ! kk-loop
     endif ! find_FrictWork and associated(mom_src)
   enddo ! end of k loop

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -947,52 +947,54 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
-      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-        sh_xy(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,1) + dudy(I,J,1) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,1)
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        k = kstart + kk - 1
+        sh_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
+      enddo ; enddo ; enddo
     else
-      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-        sh_xy(I,J,1) = G%mask2dBu(I,J) * ( dvdx(I,J,1) + dudy(I,J,1) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,1)
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        k = kstart + kk - 1
+        sh_xy(I,J,kk) = G%mask2dBu(I,J) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
+      enddo ; enddo ; enddo
     endif
 
     if (CS%use_Leithy) then
       ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
       ! dudy_smooth and dvdx_smooth do not (yet) include modifications at OBCs from above.
       if (CS%no_slip) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_smooth(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,1) + dudy_smooth(I,J,1) )
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          sh_xy_smooth(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,kk) + dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       else
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_smooth(I,J,1) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,1) + dudy_smooth(I,J,1) )
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          sh_xy_smooth(I,J,kk) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,kk) + dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       endif
     endif ! use Leith+E
 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
-      do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
-        Del2u(I,j,1) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J,1)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1,1))) + &
-                     CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j,1)) - (CS%dy2h(i,j)*sh_xx(i,j,1)))
-      enddo ; enddo
-      do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
-        Del2v(i,J,1) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J,1)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J,1))) - &
-                     CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1,1)) - (CS%dx2h(i,j)*sh_xx(i,j,1)))
-      enddo ; enddo
+      do kk=1,kmax ; do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        Del2u(I,j,kk) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J,kk)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1,kk))) + &
+                     CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j,kk)) - (CS%dy2h(i,j)*sh_xx(i,j,kk)))
+      enddo ; enddo ; enddo
+      do kk=1,kmax ; do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
+        Del2v(i,J,kk) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J,kk)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J,kk))) - &
+                     CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1,kk)) - (CS%dx2h(i,j)*sh_xx(i,j,kk)))
+      enddo ; enddo ; enddo
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
         do n=1,OBC%number_of_segments
           I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
-            do I=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
-              Del2v(i,J,1) = 0.
-            enddo
+            do kk=1,kmax ; do I=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+              Del2v(i,J,kk) = 0.
+            enddo ; enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
-            do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
-              Del2u(I,j,1) = 0.
-            enddo
+            do kk=1,kmax ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+              Del2u(I,j,kk) = 0.
+            enddo ; enddo
           endif
         enddo
       endif ; endif

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2254,52 +2254,52 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! the vertically integrated MEKE source term, and adjusting for any
     ! energy loss seen as a reduction in the (biharmonic) frictional source term.
     if (find_FrictWork .and. allocated(MEKE%mom_src)) then
-      do kk=1,kmax
-        k = kstart + kk - 1
-        if (MEKE%backscatter_Ro_c /= 0.) then
-          do j=js,je ; do i=is,ie
-            FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
-                          (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
-            Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
-              0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
-                    ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
-            if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
-              FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
-              ! Note the hard-coded dimensional constant in the following line that can not
-              ! be rescaled for dimensional consistency.
-              Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
-                          * MEKE%backscatter_Ro_c ! c * D^n
-              ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
-              ! RoScl = 1 - g(Ro)
-              RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
+      if (MEKE%backscatter_Ro_c /= 0.) then
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
+          FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
+                        (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
+          Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
+            0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
+                  ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
+          if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
+            FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
+            ! Note the hard-coded dimensional constant in the following line that can not
+            ! be rescaled for dimensional consistency.
+            Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
+                        * MEKE%backscatter_Ro_c ! c * D^n
+            ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
+            ! RoScl = 1 - g(Ro)
+            RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
+          else
+            if (FatH <= backscat_subround*Shear_mag_bc) then
+              RoScl = 1.0
             else
-              if (FatH <= backscat_subround*Shear_mag_bc) then
-                RoScl = 1.0
-              else
-                Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
-                RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
-              endif
+              Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
+              RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
             endif
-
-            MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
-
-            if (allocated(MEKE%mom_src_bh)) &
-              MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
-                  + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
-          enddo ; enddo
-        else
-          do j=js,je ; do i=is,ie
-            MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
-          enddo ; enddo
-
-          if (allocated(MEKE%mom_src_bh)) then
-            do j=js,je ; do i=is,ie
-              MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
-            enddo ; enddo
           endif
-        endif ! MEKE%backscatter_Ro_c
 
-      enddo ! kk-loop
+          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
+
+          if (allocated(MEKE%mom_src_bh)) &
+            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
+                + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
+        enddo ; enddo ; enddo
+      else
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
+          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
+        enddo ; enddo ; enddo
+
+        if (allocated(MEKE%mom_src_bh)) then
+          do kk=1,kmax ; do j=js,je ; do i=is,ie
+            k = kstart + kk - 1
+            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
+          enddo ; enddo ; enddo
+        endif
+      endif ! MEKE%backscatter_Ro_c
+
     endif ! find_FrictWork and associated(mom_src)
   enddo ! end of k loop
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -467,7 +467,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   integer :: is_vort, ie_vort, js_vort, je_vort  ! Loop ranges for vorticity terms
   integer :: is_Kh, ie_Kh, js_Kh, je_Kh  ! Loop ranges for thickness point viscosities
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
-  integer :: i, j, k, n
+  integer :: i, j, k, kk, n, kstart, kend, kmax
   real :: inv_PI3, inv_PI2, inv_PI6 ! Powers of the inverse of pi [nondim]
   real :: tmp
 
@@ -722,7 +722,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$OMP   visc_limit_h, visc_limit_h_frac, visc_limit_h_flag, &
   !$OMP   visc_limit_q, visc_limit_q_frac, visc_limit_q_flag &
   !$OMP )
-  do k=1,nz
+  do kstart=1,nz,nkblock
+    kend = min(kstart+nkblock-1,nz)
+    kmax = kend-kstart+1
+    k=kstart
 
     ! The following are the forms of the horizontal tension and horizontal
     ! shearing strain advocated by Smagorinsky (1993) and discussed in
@@ -735,43 +738,48 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! TODO: Explore methods for retaining both the syntax and speedup.
 
     ! Calculate horizontal tension
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      dudx(i,j,1) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
-                                  (G%IdyCu(I-1,j) * u(I-1,j,k)))
-      dvdy(i,j,1) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
-                                  (G%IdxCv(i,J-1) * v(i,J-1,k)))
-      sh_xx(i,j,1) = dudx(i,j,1) - dvdy(i,j,1)
-    enddo ; enddo
+    do kk=1,kmax ; do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+      k = kstart + kk - 1
+      dudx(i,j,kk) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
+                                    (G%IdyCu(I-1,j) * u(I-1,j,k)))
+      dvdy(i,j,kk) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
+                                    (G%IdxCv(i,J-1) * v(i,J-1,k)))
+      sh_xx(i,j,kk) = dudx(i,j,kk) - dvdy(i,j,kk)
+    enddo ; enddo ; enddo
 
     ! Components for the shearing strain
-    do J=js_vort,je_vort ; do I=is_vort,ie_vort
-      dvdx(I,J,1) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
-      dudy(I,J,1) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
-    enddo ; enddo
+    do kk=1,kmax ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+      k = kstart + kk - 1
+      dvdx(I,J,kk) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
+      dudy(I,J,kk) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
+    enddo ; enddo ; enddo
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = kstart + kk - 1
         dudx_smooth = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
                                            (G%IdyCu(I-1,j) * u_smooth(I-1,j,k)))
         dvdy_smooth = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
                                            (G%IdxCv(i,J-1) * v_smooth(i,J-1,k)))
-        sh_xx_smooth(i,j,1) = dudx_smooth - dvdy_smooth
-      enddo ; enddo
+        sh_xx_smooth(i,j,kk) = dudx_smooth - dvdy_smooth
+      enddo ; enddo ; enddo
 
       ! Components for the shearing strain from smoothed velocity
-      do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-        dvdx_smooth(I,J,1) = CS%DY_dxBu(I,J) * &
+      do kk=1,kmax ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+        k = kstart + kk - 1
+        dvdx_smooth(I,J,kk) = CS%DY_dxBu(I,J) * &
                          ((v_smooth(i+1,J,k)*G%IdyCv(i+1,J)) - (v_smooth(i,J,k)*G%IdyCv(i,J)))
-        dudy_smooth(I,J,1) = CS%DX_dyBu(I,J) * &
+        dudy_smooth(I,J,kk) = CS%DX_dyBu(I,J) * &
                          ((u_smooth(I,j+1,k)*G%IdxCu(I,j+1)) - (u_smooth(I,j,k)*G%IdxCu(I,j)))
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif ! use Leith+E
 
     if (CS%id_normstress > 0) then
-      do j=js,je ; do i=is,ie
-        NoSt(i,j,k) = sh_xx(i,j,1)
-      enddo ; enddo
+      do kk=1,kmax ; do j=js,je ; do i=is,ie
+        k = kstart + kk - 1
+        NoSt(i,j,k) = sh_xx(i,j,kk)
+      enddo ; enddo ; enddo
     endif
 
     ! Interpolate the thicknesses to velocity points.
@@ -780,26 +788,32 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
     if (use_cont_huv) then
-      do j=js-2,je+2 ; do I=Isq-1,Ieq+1
-        h_u(I,j,1) = hu_cont(I,j,k)
-      enddo ; enddo
-      do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J,1) = hv_cont(i,J,k)
-      enddo ; enddo
+      do kk=1,kmax ; do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+        k = kstart + kk - 1
+        h_u(I,j,kk) = hu_cont(I,j,k)
+      enddo ; enddo ; enddo
+      do kk=1,kmax ; do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
+        k = kstart + kk - 1
+        h_v(i,J,kk) = hv_cont(i,J,k)
+      enddo ; enddo ; enddo
     elseif (CS%use_land_mask) then
-      do j=js-2,je+2 ; do I=is-2,Ieq+1
-        h_u(I,j,1) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
-      enddo ; enddo
-      do J=js-2,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J,1) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
-      enddo ; enddo
+      do kk=1,kmax ; do j=js-2,je+2 ; do I=is-2,Ieq+1
+        k = kstart + kk - 1
+        h_u(I,j,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
+      enddo ; enddo ; enddo
+      do kk=1,kmax ; do J=js-2,Jeq+1 ; do i=is-2,ie+2
+        k = kstart + kk - 1
+        h_v(i,J,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
+      enddo ; enddo ; enddo
     else
-      do j=js-2,je+2 ; do I=is-2,Ieq+1
-        h_u(I,j,1) = 0.5 * (h(i,j,k) + h(i+1,j,k))
-      enddo ; enddo
-      do J=js-2,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J,1) = 0.5 * (h(i,j,k) + h(i,j+1,k))
-      enddo ; enddo
+      do kk=1,kmax ; do j=js-2,je+2 ; do I=is-2,Ieq+1
+        k = kstart + kk - 1
+        h_u(I,j,kk) = 0.5 * (h(i,j,k) + h(i+1,j,k))
+      enddo ; enddo ; enddo
+      do kk=1,kmax ; do J=js-2,Jeq+1 ; do i=is-2,ie+2
+        k = kstart + kk - 1
+        h_v(i,J,kk) = 0.5 * (h(i,j,k) + h(i,j+1,k))
+      enddo ; enddo ; enddo
     endif
 
     ! Adjust contributions to shearing strain and interpolated values of
@@ -808,59 +822,61 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (apply_OBC_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
-          do I = max(OBC%segment(n)%HI%IsdB,Is_vort), min(OBC%segment(n)%HI%IedB,Ie_vort)
+          do kk=1,kmax ; do I = max(OBC%segment(n)%HI%IsdB,Is_vort), min(OBC%segment(n)%HI%IedB,Ie_vort)
+            k = kstart + kk - 1
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
-                dvdx(I,J,1) = 0. ; dudy(I,J,1) = 0.
+                dvdx(I,J,kk) = 0. ; dudy(I,J,kk) = 0.
               case (OBC_STRAIN_FREESLIP)
-                dudy(I,J,1) = 0.
+                dudy(I,J,kk) = 0.
               case (OBC_STRAIN_COMPUTED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                  dudy(I,J,1) = 2.0*CS%DX_dyBu(I,J)* &
+                  dudy(I,J,kk) = 2.0*CS%DX_dyBu(I,J)* &
                               (OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%IdxCu(I,j)
                 else
-                  dudy(I,J,1) = 2.0*CS%DX_dyBu(I,J)* &
+                  dudy(I,J,kk) = 2.0*CS%DX_dyBu(I,J)* &
                               (u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdxCu(I,j+1)
                 endif
               case (OBC_STRAIN_SPECIFIED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                  dudy(I,J,1) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
+                  dudy(I,J,kk) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
                 else
-                  dudy(I,J,1) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
+                  dudy(I,J,kk) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
                 endif
             end select
             if (CS%use_Leithy) then
-              dvdx_smooth(I,J,1) = dvdx(I,J,1)
-              dudy_smooth(I,J,1) = dudy(I,J,1)
+              dvdx_smooth(I,J,kk) = dvdx(I,J,kk)
+              dudy_smooth(I,J,kk) = dudy(I,J,kk)
             endif
-          enddo
+          enddo ; enddo
         elseif (OBC%segment(n)%is_E_or_W .and. (I >= is_vort) .and. (I <= ie_vort)) then
-          do J = max(OBC%segment(n)%HI%JsdB,js_vort), min(OBC%segment(n)%HI%JedB,je_vort)
+          do kk=1,kmax ; do J = max(OBC%segment(n)%HI%JsdB,js_vort), min(OBC%segment(n)%HI%JedB,je_vort)
+            k = kstart + kk - 1
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
-                dvdx(I,J,1) = 0. ; dudy(I,J,1) = 0.
+                dvdx(I,J,kk) = 0. ; dudy(I,J,kk) = 0.
               case (OBC_STRAIN_FREESLIP)
-                dvdx(I,J,1) = 0.
+                dvdx(I,J,kk) = 0.
               case (OBC_STRAIN_COMPUTED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                  dvdx(I,J,1) = 2.0*CS%DY_dxBu(I,J)* &
+                  dvdx(I,J,kk) = 2.0*CS%DY_dxBu(I,J)* &
                               (OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%IdyCv(i,J)
                 else
-                  dvdx(I,J,1) = 2.0*CS%DY_dxBu(I,J)* &
+                  dvdx(I,J,kk) = 2.0*CS%DY_dxBu(I,J)* &
                               (v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdyCv(i+1,J)
                 endif
               case (OBC_STRAIN_SPECIFIED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                  dvdx(I,J,1) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
+                  dvdx(I,J,kk) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
                 else
-                  dvdx(I,J,1) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
+                  dvdx(I,J,kk) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
                 endif
             end select
             if (CS%use_Leithy) then
-              dvdx_smooth(I,J,1) = dvdx(I,J,1)
-              dudy_smooth(I,J,1) = dudy(I,J,1)
+              dvdx_smooth(I,J,kk) = dvdx(I,J,kk)
+              dudy_smooth(I,J,kk) = dudy(I,J,kk)
             endif
-          enddo
+          enddo ; enddo
         endif
       endif
 
@@ -870,27 +886,31 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! are always zeroed out at OBC points, in which case the i-loop below
         ! becomes do i=is-1,ie+1. -RWH
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
-            h_v(i,J,1) = h(i,j,k)
-          enddo
+          do kk=1,kmax ; do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
+            k = kstart + kk - 1
+            h_v(i,J,kk) = h(i,j,k)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
-            h_v(i,J,1) = h(i,j+1,k)
-          enddo
+          do kk=1,kmax ; do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
+            k = kstart + kk - 1
+            h_v(i,J,kk) = h(i,j+1,k)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
-            h_u(I,j,1) = h(i,j,k)
-          enddo
+          do kk=1,kmax ; do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
+            k = kstart + kk - 1
+            h_u(I,j,kk) = h(i,j,k)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
-            h_u(I,j,1) = h(i+1,j,k)
-          enddo
+          do kk=1,kmax ; do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
+            k = kstart + kk - 1
+            h_u(I,j,kk) = h(i+1,j,k)
+          enddo ; enddo
         endif
       endif
     enddo ; endif
@@ -899,27 +919,27 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
         if ((J >= js-2) .and. (J <= je)) then
-          do I = max(is-2,OBC%segment(n)%HI%IsdB), min(Ieq+1,OBC%segment(n)%HI%IedB)
-            h_u(I,j+1,1) = h_u(I,j,1)
-          enddo
+          do kk=1,kmax ; do I = max(is-2,OBC%segment(n)%HI%IsdB), min(Ieq+1,OBC%segment(n)%HI%IedB)
+            h_u(I,j+1,kk) = h_u(I,j,kk)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-1) .and. (J <= je+1)) then
-          do I = max(is-2,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
-            h_u(I,j,1) = h_u(I,j+1,1)
-          enddo
+          do kk=1,kmax ; do I = max(is-2,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
+            h_u(I,j,kk) = h_u(I,j+1,kk)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= ie)) then
-          do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
-            h_v(i+1,J,1) = h_v(i,J,1)
-          enddo
+          do kk=1,kmax ; do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
+            h_v(i+1,J,kk) = h_v(i,J,kk)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-1) .and. (I <= ie+1)) then
-          do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
-            h_v(i,J,1) = h_v(i+1,J,1)
-          enddo
+          do kk=1,kmax ; do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
+            h_v(i,J,kk) = h_v(i+1,J,kk)
+          enddo ; enddo
         endif
       endif
     enddo ; endif

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -469,7 +469,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! NOTE: Several of these are declared with the memory extent of q-points, but the
   !   same arrays are also used at h-points to reduce the memory footprint of this
   !   module, so they should never be used in halo point or checksum calls.
-  real, dimension(SZIB_(G),SZJB_(G)) :: &
+  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     Ah, &           ! biharmonic viscosity (h or q) [L4 T-1 ~> m4 s-1]
     Kh, &           ! Laplacian  viscosity (h or q) [L2 T-1 ~> m2 s-1]
     Kh_BS, &        ! Laplacian  antiviscosity [L2 T-1 ~> m2 s-1]
@@ -1124,7 +1124,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (CS%use_Leithy) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          vert_vort_mag_smooth(i,j) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,1) + &
+          vert_vort_mag_smooth(i,j,1) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,1) + &
                                                   vort_xy_dx_smooth(i,J-1,1)))**2) + &
                                            ((0.5*(vort_xy_dy_smooth(I,j,1) + &
                                                   vort_xy_dy_smooth(I-1,j,1)))**2) )
@@ -1138,14 +1138,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         sh_xx_sq = sh_xx(i,j,1)**2
         sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1,1)**2) + (sh_xy(I,J,1)**2)) &
                           + ((sh_xy(I-1,J,1)**2) + (sh_xy(I,J-1,1)**2)) )
-        Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
+        Shear_mag(i,j,1) = sqrt(sh_xx_sq + sh_xy_sq)
       enddo ; enddo
     endif
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         h_min = min(h_u(I,j,1), h_u(I-1,j,1), h_v(i,J,1), h_v(i,J-1,1))
-        hrat_min(i,j) = min(1.0, h_min / (h(i,j,k) + h_neglect))
+        hrat_min(i,j,1) = min(1.0, h_min / (h(i,j,k) + h_neglect))
       enddo ; enddo
     endif
 
@@ -1159,18 +1159,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
             grad_vort = grad_vort_mag_h(i,j,1) + grad_div_mag_h(i,j,1)
             grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j,1)
-            vert_vort_mag(i,j) = min(grad_vort, grad_vort_qg)
+            vert_vort_mag(i,j,1) = min(grad_vort, grad_vort_qg)
           enddo ; enddo
         else
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            vert_vort_mag(i,j) = grad_vort_mag_h(i,j,1) + grad_div_mag_h(i,j,1)
+            vert_vort_mag(i,j,1) = grad_vort_mag_h(i,j,1) + grad_div_mag_h(i,j,1)
           enddo ; enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Kh(i,j) = CS%Kh_bg_xx(i,j)
+        Kh(i,j,1) = CS%Kh_bg_xx(i,j)
       enddo ; enddo
 
       ! NOTE: The following do-block can be decomposed and vectorized after the
@@ -1178,14 +1178,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         if (CS%add_LES_viscosity) then
           if (CS%Smagorinsky_Kh) &
-            Kh(i,j) = Kh(i,j) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j)
+            Kh(i,j,1) = Kh(i,j,1) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,1)
           if (CS%Leith_Kh) &
-            Kh(i,j) = Kh(i,j) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3
+            Kh(i,j,1) = Kh(i,j,1) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,1) * inv_PI3
         else
           if (CS%Smagorinsky_Kh) &
-            Kh(i,j) = max(Kh(i,j), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j))
+            Kh(i,j,1) = max(Kh(i,j,1), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,1))
           if (CS%Leith_Kh) &
-            Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
+            Kh(i,j,1) = max(Kh(i,j,1), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,1) * inv_PI3)
         endif
       enddo ; enddo
 
@@ -1193,13 +1193,13 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (rescale_Kh) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j) = VarMix%Res_fn_h(i,j) * Kh(i,j)
+          Kh(i,j,1) = VarMix%Res_fn_h(i,j) * Kh(i,j,1)
         enddo ; enddo
       endif
 
       ! Place a floor on the viscosity, if desired.
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
+        Kh(i,j,1) = max(Kh(i,j,1), CS%Kh_bg_min)
       enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
@@ -1207,21 +1207,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
+              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
             enddo ; enddo
           else
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
             enddo ; enddo
           endif
         else
           if (CS%res_scale_MEKE) then
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
+              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
             enddo ; enddo
           else
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j)
+              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j)
             enddo ; enddo
           endif
         endif
@@ -1230,25 +1230,25 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%anisotropic) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           ! *Add* the tension component of anisotropic viscosity
-          Kh(i,j) = Kh(i,j) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
+          Kh(i,j,1) = Kh(i,j,1) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
         enddo ; enddo
       endif
 
       ! Newer method of bounding for stability
       if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          visc_bound_rem(i,j) = 1.0
-          Kh_max_here = hrat_min(i,j) * CS%Kh_Max_xx(i,j)
-          if (Kh(i,j) >= Kh_max_here) then
-            visc_bound_rem(i,j) = 0.0
-            Kh(i,j) = Kh_max_here
-          elseif ((Kh(i,j) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
-            visc_bound_rem(i,j) = 1.0 - Kh(i,j) / Kh_max_here
+          visc_bound_rem(i,j,1) = 1.0
+          Kh_max_here = hrat_min(i,j,1) * CS%Kh_Max_xx(i,j)
+          if (Kh(i,j,1) >= Kh_max_here) then
+            visc_bound_rem(i,j,1) = 0.0
+            Kh(i,j,1) = Kh_max_here
+          elseif ((Kh(i,j,1) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
+            visc_bound_rem(i,j,1) = 1.0 - Kh(i,j,1) / Kh_max_here
           endif
         enddo ; enddo
       elseif (CS%bound_Kh) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j) = min(Kh(i,j), hrat_min(i,j) * CS%Kh_Max_xx(i,j))
+          Kh(i,j,1) = min(Kh(i,j,1), hrat_min(i,j,1) * CS%Kh_Max_xx(i,j))
         enddo ; enddo
       endif
 
@@ -1256,20 +1256,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! The harmonic component of str_xx is added in the biharmonic loop.
       if (CS%use_Leithy) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j) = 0.
+          Kh(i,j,1) = 0.
         enddo ; enddo
       endif
 
       if (CS%id_Kh_h>0 .or. CS%debug) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh_h(i,j,k) = Kh(i,j)
+          Kh_h(i,j,k) = Kh(i,j,1)
         enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Kh>0) then
         do j=js,je ; do i=is,ie
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
-          grid_Kh = max(Kh(i,j), CS%min_grid_Kh)
+          grid_Kh = max(Kh(i,j,1), CS%min_grid_Kh)
           grid_Re_Kh(i,j,k) = (sqrt(KE) * sqrt(CS%grid_sp_h2(i,j))) / grid_Kh
         enddo ; enddo
       endif
@@ -1287,7 +1287,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = -Kh(i,j) * sh_xx(i,j,1)
+        str_xx(i,j,1) = -Kh(i,j,1) * sh_xx(i,j,1)
       enddo ; enddo
     else
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -1309,21 +1309,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
       do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Ah(i,j) = CS%Ah_bg_xx(i,j)
+        Ah(i,j,1) = CS%Ah_bg_xx(i,j)
       enddo ; enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              AhSm = Shear_mag(i,j) * (CS%Biharm_const_xx(i,j) &
-                  + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j))
-              Ah(i,j) = max(Ah(i,j), AhSm)
+              AhSm = Shear_mag(i,j,1) * (CS%Biharm_const_xx(i,j) &
+                  + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j,1))
+              Ah(i,j,1) = max(Ah(i,j,1), AhSm)
             enddo ; enddo
           else
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j)
-              Ah(i,j) = max(Ah(i,j), AhSm)
+              AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j,1)
+              Ah(i,j,1) = max(Ah(i,j,1), AhSm)
             enddo ; enddo
           endif
         endif
@@ -1333,7 +1333,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
                                  (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
-            Ah(i,j) = max(Ah(i,j), AhLth)
+            Ah(i,j,1) = max(Ah(i,j,1), AhLth)
           enddo ; enddo
         endif
 
@@ -1347,8 +1347,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             if (AhLth <= CS%Ah_bg_xx(i,j)) then
               m_leithy(i,j,1) = 0.0
             else
-              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j)) < abs(vort_xy_smooth(i,j,1))) then
-                m_leithy(i,j,1) = CS%c_K * (vert_vort_mag(i,j) / vort_xy_smooth(i,j,1))**2
+              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j,1)) < abs(vort_xy_smooth(i,j,1))) then
+                m_leithy(i,j,1) = CS%c_K * (vert_vort_mag(i,j,1) / vort_xy_smooth(i,j,1))**2
               else
                 m_leithy(i,j,1) = CS%m_leithy_max(i,j)
               endif
@@ -1367,14 +1367,14 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             Del2vort_h = 0.25 * ((Del2vort_q(I,J,1) + Del2vort_q(I-1,J-1,1)) + &
                                  (Del2vort_q(I-1,J,1) + Del2vort_q(I,J-1,1)))
             AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
-                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,1)*vert_vort_mag_smooth(i,j)**2))
-            Ah(i,j) = max(CS%Ah_bg_xx(i,j), AhLthy)
+                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,1)*vert_vort_mag_smooth(i,j,1)**2))
+            Ah(i,j,1) = max(CS%Ah_bg_xx(i,j), AhLthy)
           enddo ; enddo
           if (CS%smooth_Ah) then
             ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
             Ah_sq(:,:,1) = 0.0 ! This is here to initialize domain edge halo values.
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_sq(i,j,1) = Ah(i,j)**2
+              Ah_sq(i,j,1) = Ah(i,j,1)**2
             enddo ; enddo
             call pass_var(Ah_sq(:,:,1), G%Domain, halo=2)
             ! A single call smoothes twice.
@@ -1382,11 +1382,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             call pass_var(Ah_sq(:,:,1), G%Domain)
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,1))))
-              Ah(i,j)     = Ah_h(i,j,k)
+              Ah(i,j,1)     = Ah_h(i,j,k)
             enddo ; enddo
           else
             do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_h(i,j,k) = Ah(i,j)
+              Ah_h(i,j,k) = Ah(i,j,1)
             enddo ; enddo
           endif
         endif
@@ -1396,35 +1396,35 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Ah(i,j) = Ah(i,j) + MEKE%Au(i,j)
+          Ah(i,j,1) = Ah(i,j,1) + MEKE%Au(i,j)
         enddo ; enddo
       endif
 
       if (CS%Re_Ah > 0.0) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
-          Ah(i,j) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
+          Ah(i,j,1) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
         enddo ; enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Ah(i,j) = min(Ah(i,j), visc_bound_rem(i,j) * hrat_min(i,j) * CS%Ah_Max_xx(i,j))
+            Ah(i,j,1) = min(Ah(i,j,1), visc_bound_rem(i,j,1) * hrat_min(i,j,1) * CS%Ah_Max_xx(i,j))
           enddo ; enddo
         else
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Ah(i,j) = min(Ah(i,j), hrat_min(i,j) * CS%Ah_Max_xx(i,j))
+            Ah(i,j,1) = min(Ah(i,j,1), hrat_min(i,j,1) * CS%Ah_Max_xx(i,j))
           enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
           do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            tmp = CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j)
+            tmp = CS%KS_coef * hrat_min(i,j,1) * CS%Ah_Max_xx_KS(i,j)
             visc_limit_h(i,j,k) = tmp
-            visc_limit_h_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j))
-            if (Ah(i,j) >= tmp) then
+            visc_limit_h_frac(i,j,k) = Ah(i,j,1) / (CS%KS_coef * hrat_min(i,j,1) * CS%Ah_Max_xx_KS(i,j))
+            if (Ah(i,j,1) >= tmp) then
               visc_limit_h_flag(i,j,k) = 1.
             endif
           enddo ; enddo
@@ -1432,7 +1432,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Ah_h(i,j,k) = Ah(i,j)
+          Ah_h(i,j,k) = Ah(i,j,1)
         enddo ; enddo
       endif
 
@@ -1440,15 +1440,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
         do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j) = -m_leithy(i,j,1) * Ah(i,j)
-          Kh_h(i,j,k) = Kh(i,j)
+          Kh(i,j,1) = -m_leithy(i,j,1) * Ah(i,j,1)
+          Kh_h(i,j,k) = Kh(i,j,1)
         enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Ah > 0) then
         do j=js,je ; do i=is,ie
           KE = 0.125 * (((u(I,j,k) + u(I-1,j,k))**2) + ((v(i,J,k) + v(i,J-1,k))**2))
-          grid_Ah = max(Ah(i,j), CS%min_grid_Ah)
+          grid_Ah = max(Ah(i,j,1), CS%min_grid_Ah)
           grid_Re_Ah(i,j,k) = (sqrt(KE) * CS%grid_sp_h3(i,j)) / grid_Ah
         enddo ; enddo
       endif
@@ -1456,11 +1456,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         d_del2u = (G%IdyCu(I,j) * Del2u(I,j,1)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,1))
         d_del2v = (G%IdxCv(i,J) * Del2v(i,J,1)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,1))
-        d_str = Ah(i,j) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
+        d_str = Ah(i,j,1) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
 
         str_xx(i,j,1) = str_xx(i,j,1) + d_str
 
-        if (CS%use_Leithy) str_xx(i,j,1) = str_xx(i,j,1) - Kh(i,j) * sh_xx_smooth(i,j,1)
+        if (CS%use_Leithy) str_xx(i,j,1) = str_xx(i,j,1) - Kh(i,j,1) * sh_xx_smooth(i,j,1)
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xx(i,j,1) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
@@ -1471,23 +1471,23 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%EY24_EBT_BS) then
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         if (visc_limit_h_flag(i,j,k) > 0) then
-          Kh_BS(i,j) = 0.
+          Kh_BS(i,j,1) = 0.
         else
           if (use_kh_struct) then
-            Kh_BS(i,j) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+            Kh_BS(i,j,1) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
           else
-            Kh_BS(i,j) = MEKE%Ku(i,j)
+            Kh_BS(i,j,1) = MEKE%Ku(i,j)
           endif
         endif
       enddo ; enddo
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx_BS(i,j,1) = -Kh_BS(i,j) * sh_xx(i,j,1)
+        str_xx_BS(i,j,1) = -Kh_BS(i,j,1) * sh_xx(i,j,1)
       enddo ; enddo
 
       if (CS%id_BS_coeff_h>0) then
         do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-          BS_coeff_h(i,j,k) = Kh_BS(i,j)
+          BS_coeff_h(i,j,k) = Kh_BS(i,j,1)
         enddo ; enddo
       endif
 
@@ -1533,7 +1533,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         sh_xy_sq = sh_xy(I,J,1)**2
         sh_xx_sq = 0.25 * ( ((sh_xx(i,j,1)**2) + (sh_xx(i+1,j+1,1)**2)) &
                           + ((sh_xx(i,j+1,1)**2) + (sh_xx(i+1,j,1)**2)) )
-        Shear_mag(I,J) = sqrt(sh_xy_sq + sh_xx_sq)
+        Shear_mag(I,J,1) = sqrt(sh_xy_sq + sh_xx_sq)
       enddo ; enddo
     endif
 
@@ -1547,7 +1547,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%bound_Ah .or. CS%bound_Kh) then
       do J=js-1,Jeq ; do I=is-1,Ieq
         h_min = min(h_u(I,j,1), h_u(I,j+1,1), h_v(i,J,1), h_v(i+1,J,1))
-        hrat_min(I,J) = min(1.0, h_min / (hq(I,J,1) + h_neglect))
+        hrat_min(I,J,1) = min(1.0, h_min / (hq(I,J,1) + h_neglect))
       enddo ; enddo
 
     endif
@@ -1565,11 +1565,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                 (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
               ! Only one of hu and hv is nonzero, so just add them.
               hq(I,J,1) = hu + hv
-              hrat_min(I,J) = 1.0
+              hrat_min(I,J,1) = 1.0
             else
               ! Both hu and hv are nonzero, so take the harmonic mean.
               hq(I,J,1) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
-              hrat_min(I,J) = min(1.0, min(hu, hv) / (hq(I,J,1) + h_neglect) )
+              hrat_min(I,J,1) = min(1.0, min(hu, hv) / (hq(I,J,1) + h_neglect) )
             endif
           endif
         endif
@@ -1592,28 +1592,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           do J=js-1,Jeq ; do I=is-1,Ieq
             grad_vort = grad_vort_mag_q(I,J,1) + grad_div_mag_q(I,J,1)
             grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J,1)
-            vert_vort_mag(I,J) = min(grad_vort, grad_vort_qg)
+            vert_vort_mag(I,J,1) = min(grad_vort, grad_vort_qg)
           enddo ; enddo
         else
           do J=js-1,Jeq ; do I=is-1,Ieq
-            vert_vort_mag(I,J) = grad_vort_mag_q(I,J,1) + grad_div_mag_q(I,J,1)
+            vert_vort_mag(I,J,1) = grad_vort_mag_q(I,J,1) + grad_div_mag_q(I,J,1)
           enddo ; enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
       do J=js-1,Jeq ; do I=is-1,Ieq
-        Kh(I,J) = CS%Kh_bg_xy(I,J)
+        Kh(I,J,1) = CS%Kh_bg_xy(I,J)
       enddo ; enddo
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
           do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = Kh(I,J) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J)
+            Kh(I,J,1) = Kh(I,J,1) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,1)
           enddo ; enddo
         else
           do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = max(Kh(I,J), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J) )
+            Kh(I,J,1) = max(Kh(I,J,1), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,1) )
           enddo ; enddo
         endif
       endif
@@ -1621,11 +1621,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%Leith_Kh) then
         if (CS%add_LES_viscosity) then
           do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = Kh(I,J) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3 ! Is this right? -AJA
+            Kh(I,J,1) = Kh(I,J,1) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,1) * inv_PI3 ! Is this right? -AJA
           enddo ; enddo
         else
           do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = max(Kh(I,J), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3)
+            Kh(I,J,1) = max(Kh(I,J,1), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,1) * inv_PI3)
           enddo ; enddo
         endif
       endif
@@ -1634,12 +1634,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (rescale_Kh) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh(I,J) = VarMix%Res_fn_q(I,J) * Kh(I,J)
+          Kh(I,J,1) = VarMix%Res_fn_q(I,J) * Kh(I,J,1)
         enddo ; enddo
       endif
 
       do J=js-1,Jeq ; do I=is-1,Ieq
-        Kh(I,J) = max(Kh(I,J), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
+        Kh(I,J,1) = max(Kh(I,J,1), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
       enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
@@ -1648,7 +1648,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
-            Kh(I,J) = Kh(I,J) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+            Kh(I,J,1) = Kh(I,J,1) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
                                        (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
                                        ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
                                        (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
@@ -1658,7 +1658,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
-            Kh(I,J) = Kh(I,J) + 0.25 * ( &
+            Kh(I,J,1) = Kh(I,J,1) + 0.25 * ( &
                 (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
                                        (MEKE%Ku(i+1,j) + &
                                         MEKE%Ku(i,j+1)) ) * meke_res_fn
@@ -1669,36 +1669,36 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%anisotropic) then
         ! *Add* the shear component of anisotropic viscosity
         do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = Kh(I,J) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
+            Kh(I,J,1) = Kh(I,J,1) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
         enddo ; enddo
       endif
 
       do J=js-1,Jeq ; do I=is-1,Ieq
         ! Newer method of bounding for stability
         if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-          visc_bound_rem(I,J) = 1.0
-          Kh_max_here = hrat_min(I,J) * CS%Kh_Max_xy(I,J)
-          if (Kh(I,J) >= Kh_max_here) then
-            visc_bound_rem(I,J) = 0.0
-            Kh(I,J) = Kh_max_here
-          elseif ((Kh(I,J) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
-            visc_bound_rem(I,J) = 1.0 - Kh(I,J) / Kh_max_here
+          visc_bound_rem(I,J,1) = 1.0
+          Kh_max_here = hrat_min(I,J,1) * CS%Kh_Max_xy(I,J)
+          if (Kh(I,J,1) >= Kh_max_here) then
+            visc_bound_rem(I,J,1) = 0.0
+            Kh(I,J,1) = Kh_max_here
+          elseif ((Kh(I,J,1) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
+            visc_bound_rem(I,J,1) = 1.0 - Kh(I,J,1) / Kh_max_here
           endif
         elseif (CS%bound_Kh) then
-          Kh(I,J) = min(Kh(I,J), hrat_min(I,J) * CS%Kh_Max_xy(I,J))
+          Kh(I,J,1) = min(Kh(I,J,1), hrat_min(I,J,1) * CS%Kh_Max_xy(I,J))
         endif
       enddo ; enddo
 
       if (CS%use_Leithy) then
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
         do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh(I,J) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
+          Kh(I,J,1) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
         enddo ; enddo
       endif
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh_q(I,J,k) = Kh(I,J)
+          Kh_q(I,J,k) = Kh(I,J,1)
         enddo ; enddo
       endif
 
@@ -1716,11 +1716,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (.not. CS%use_Leithy) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = -Kh(I,J) * sh_xy(I,J,1)
+          str_xy(I,J,1) = -Kh(I,J,1) * sh_xy(I,J,1)
         enddo ; enddo
       else
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = -Kh(I,J) * sh_xy_smooth(I,J,1)
+          str_xy(I,J,1) = -Kh(I,J,1) * sh_xy_smooth(I,J,1)
         enddo ; enddo
       endif
     else
@@ -1743,21 +1743,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
       do J=js-1,Jeq ; do I=is-1,Ieq
-        Ah(I,J) = CS%Ah_bg_xy(I,J)
+        Ah(I,J,1) = CS%Ah_bg_xy(I,J)
       enddo ; enddo
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
             do J=js-1,Jeq ; do I=is-1,Ieq
-              AhSm = Shear_mag(I,J) * (CS%Biharm_const_xy(I,J) &
-                  + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J))
-              Ah(I,J) = max(Ah(I,J), AhSm)
+              AhSm = Shear_mag(I,J,1) * (CS%Biharm_const_xy(I,J) &
+                  + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J,1))
+              Ah(I,J,1) = max(Ah(I,J,1), AhSm)
             enddo ; enddo
           else
             do J=js-1,Jeq ; do I=is-1,Ieq
-              AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J)
-              Ah(I,J) = max(Ah(I,J), AhSm)
+              AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J,1)
+              Ah(I,J,1) = max(Ah(I,J,1), AhSm)
             enddo ; enddo
           endif
         endif
@@ -1765,7 +1765,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         if (CS%Leith_Ah) then
           do J=js-1,Jeq ; do I=is-1,Ieq
             AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J,1)) * inv_PI6
-            Ah(I,J) = max(Ah(I,J), AhLth)
+            Ah(I,J,1) = max(Ah(I,J,1), AhLth)
           enddo ; enddo
         endif
       endif ! Smagorinsky_Ah or Leith_Ah
@@ -1773,7 +1773,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
         do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah(I,J) = Ah(I,J) + 0.25 * ( &
+          Ah(I,J,1) = Ah(I,J,1) + 0.25 * ( &
               (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) + (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
         enddo ; enddo
       endif
@@ -1781,28 +1781,28 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%Re_Ah > 0.0) then
         do J=js-1,Jeq ; do I=is-1,Ieq
           KE = 0.125 * (((u(I,j,k) + u(I,j+1,k))**2) + ((v(i,J,k) + v(i+1,J,k))**2))
-          Ah(I,J) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
+          Ah(I,J,1) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
         enddo ; enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
           do J=js-1,Jeq ; do I=is-1,Ieq
-            Ah(I,J) = min(Ah(I,J), visc_bound_rem(I,J) * hrat_min(I,J) * CS%Ah_Max_xy(I,J))
+            Ah(I,J,1) = min(Ah(I,J,1), visc_bound_rem(I,J,1) * hrat_min(I,J,1) * CS%Ah_Max_xy(I,J))
           enddo ; enddo
         else
           do J=js-1,Jeq ; do I=is-1,Ieq
-            Ah(I,J) = min(Ah(I,J), hrat_min(I,J) * CS%Ah_Max_xy(I,J))
+            Ah(I,J,1) = min(Ah(I,J,1), hrat_min(I,J,1) * CS%Ah_Max_xy(I,J))
           enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
           do J=js-1,Jeq ; do I=is-1,Ieq
-            tmp = CS%KS_coef *hrat_min(I,J) * CS%Ah_Max_xy_KS(I,J)
+            tmp = CS%KS_coef *hrat_min(I,J,1) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
-            visc_limit_q_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xy_KS(i,j))
-            if (Ah(I,J) >= tmp) then
+            visc_limit_q_frac(i,j,k) = Ah(i,j,1) / (CS%KS_coef * hrat_min(i,j,1) * CS%Ah_Max_xy_KS(i,j))
+            if (Ah(I,J,1) >= tmp) then
               visc_limit_q_flag(I,J,k) = 1.
             endif
           enddo ; enddo
@@ -1811,19 +1811,19 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Leith+E doesn't recompute Ah at q points, it just interpolates it from h to q points
       if (CS%use_Leithy) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah(I,J) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
+          Ah(I,J,1) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
         enddo ; enddo
       endif
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah_q(I,J,k) = Ah(I,J)
+          Ah_q(I,J,k) = Ah(I,J,1)
         enddo ; enddo
       endif
 
       ! Again, need to initialize str_xy as if its biharmonic
       do J=js-1,Jeq ; do I=is-1,Ieq
-        d_str = Ah(I,J) * (dDel2vdx(I,J,1) + dDel2udy(I,J,1))
+        d_str = Ah(I,J,1) * (dDel2vdx(I,J,1) + dDel2udy(I,J,1))
 
         str_xy(I,J,1) = str_xy(I,J,1) + d_str
 
@@ -1836,27 +1836,27 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%EY24_EBT_BS) then
       do J=js-1,Jeq ; do I=is-1,Ieq
         if (visc_limit_q_flag(I,J,k) > 0) then
-          Kh_BS(I,J) = 0.
+          Kh_BS(I,J,1) = 0.
         else
           if (use_kh_struct) then
-            Kh_BS(I,J) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+            Kh_BS(I,J,1) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
                                  (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
                                 ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
                                  (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
           else
-            Kh_BS(I,J) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
+            Kh_BS(I,J,1) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
                                 (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
           endif
         endif
       enddo ; enddo
 
       do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy_BS(I,J,1) = -Kh_BS(I,J) * (sh_xy(I,J,1))
+        str_xy_BS(I,J,1) = -Kh_BS(I,J,1) * (sh_xy(I,J,1))
       enddo ; enddo
 
       if (CS%id_BS_coeff_q>0) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          BS_coeff_q(I,J,k) = Kh_BS(I,J)
+          BS_coeff_q(I,J,k) = Kh_BS(I,J,1)
         enddo ; enddo
       endif
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -448,6 +448,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   logical :: skeb_use_frict
   logical :: use_cont_huv
   logical :: use_kh_struct
+  logical :: use_Leith    ! True if any Leith parameterizations are enabled
+  logical :: use_vort_xy  ! True if vort_xy must be computed
   logical :: use_Smag     ! True if a Smagorinsky viscosity is enabled
   integer :: is_vort, ie_vort, js_vort, je_vort  ! Loop ranges for vorticity terms
   integer :: is_Kh, ie_Kh, js_Kh, je_Kh  ! Loop ranges for thickness point viscosities
@@ -613,6 +615,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
   endif
 
+  use_Leith = CS%Leith_Kh .or. CS%Leith_Ah .or. CS%use_Leithy
+  use_vort_xy = use_Leith .or. CS%id_vort_xy_q > 0 .or. CS%use_ZB2020
   use_Smag = CS%Smagorinsky_Kh .or. CS%Smagorinsky_Ah
 
   !$omp target enter data map(alloc: dudx, dudy, dvdx, dvdy, sh_xx, sh_xy)
@@ -937,7 +941,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
     ! Vorticity
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
+    if (use_vort_xy) then
       if (CS%no_slip) then
         do concurrent (kk=1:kmax, J=js_vort:je_vort, I=is_vort:ie_vort)
           vort_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) - dudy(I,J,kk) )
@@ -972,7 +976,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
 
 
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
+    if (use_Leith) then
       call hor_visc_Leith_grad(G, GV, US, CS, VarMix, nkblock, kstart, kmax, &
                                 is, ie, js, je, is_Kh, ie_Kh, js_Kh, je_Kh, Ieq, Jeq, &
                                 h, dz, slope_x, slope_y, dudx, dvdy, vort_xy, vort_xy_smooth, &
@@ -1206,17 +1210,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        !$omp target update from(Ah)
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Ah(i,j,kk) = Ah(i,j,kk) + MEKE%Au(i,j)
-        enddo
+        enddo ; enddo ; enddo
+        !$omp target update to(Ah)
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k, KE))
+        !$omp target update from(Ah)
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           k = kstart + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
           Ah(i,j,kk) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
-        enddo
+        enddo ; enddo ; enddo
+        !$omp target update to(Ah)
       endif
 
       if (CS%bound_Ah) then
@@ -1578,10 +1586,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        !$omp target update from(Ah)
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
           Ah(I,J,kk) = Ah(I,J,kk) + 0.25 * ( &
               (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) + (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
-        enddo
+        enddo ; enddo ; enddo
+        !$omp target update to(Ah)
       endif
 
       if (CS%Re_Ah > 0.0) then
@@ -1941,14 +1951,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
       enddo ; endif
       if (find_FrictWork .and. allocated(MEKE%mom_src) .and. allocated(MEKE%GME_snk)) then
-        do concurrent (j=js:je)
-          do kk=1,kmax
-            do concurrent (i=is:ie) DO_LOCALITY(local(k))
-              k = kstart+kk-1
-              MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
-            enddo
-          enddo
-        enddo
+        !$omp target update from(FrictWork_GME)
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart+kk-1
+          MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
+        enddo ; enddo ; enddo
       endif
     endif
 
@@ -1964,60 +1971,51 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! energy loss seen as a reduction in the (biharmonic) frictional source term.
     if (find_FrictWork .and. allocated(MEKE%mom_src)) then
       if (MEKE%backscatter_Ro_c /= 0.) then
-        do concurrent (j=js:je)
-          do kk=1,kmax
-            do concurrent (i=is:ie) DO_LOCALITY(local(k, FatH, Shear_mag_bc, RoScl, Sh_F_pow))
-              k = kstart + kk - 1
-              FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
-                            (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
-              Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
-                0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
-                      ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
-              if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
-                FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
-                ! Note the hard-coded dimensional constant in the following line that can not
-                ! be rescaled for dimensional consistency.
-                Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
-                            * MEKE%backscatter_Ro_c ! c * D^n
-                ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
-                ! RoScl = 1 - g(Ro)
-                RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
-              else
-                if (FatH <= backscat_subround*Shear_mag_bc) then
-                  RoScl = 1.0
-                else
-                  Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
-                  RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
-                endif
-              endif
+        !$omp target update from(FrictWork, FrictWork_bh, sh_xx, sh_xy)
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
+          FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
+                        (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
+          Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
+            0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
+                  ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
+          if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
+            FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
+            ! Note the hard-coded dimensional constant in the following line that can not
+            ! be rescaled for dimensional consistency.
+            Shear_mag_bc = (((US%s_to_T * Shear_mag_bc)**MEKE%backscatter_Ro_pow) + 1.e-30) &
+                        * MEKE%backscatter_Ro_c ! c * D^n
+            ! The Rossby number function is g(Ro) = 1/(1+c.Ro^n)
+            ! RoScl = 1 - g(Ro)
+            RoScl = Shear_mag_bc / (FatH + Shear_mag_bc) ! = 1 - f^n/(f^n+c*D^n)
+          else
+            if (FatH <= backscat_subround*Shear_mag_bc) then
+              RoScl = 1.0
+            else
+              Sh_F_pow = MEKE%backscatter_Ro_c * (Shear_mag_bc / FatH)**MEKE%backscatter_Ro_pow
+              RoScl = Sh_F_pow / (1.0 + Sh_F_pow) ! = 1 - f^n/(f^n+c*D^n)
+            endif
+          endif
 
-              MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
+          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + (FrictWork(i,j,k) - RoScl*FrictWork_bh(i,j,k))
 
-              if (allocated(MEKE%mom_src_bh)) &
-                MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
-                    + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
-            enddo
-          enddo
-        enddo
+          if (allocated(MEKE%mom_src_bh)) &
+            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
+                + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
+        enddo ; enddo ; enddo
       else
-        do concurrent (j=js:je)
-          do kk=1,kmax
-            do concurrent (i=is:ie) DO_LOCALITY(local(k))
-              k = kstart + kk - 1
-              MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
-            enddo
-          enddo
-        enddo
+        !$omp target update from(FrictWork)
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
+          MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
+        enddo ; enddo ; enddo
 
         if (allocated(MEKE%mom_src_bh)) then
-          do concurrent (j=js:je)
-            do kk=1,kmax
-              do concurrent (i=is:ie) DO_LOCALITY(local(k))
-                k = kstart + kk - 1
-                MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
-              enddo
-            enddo
-          enddo
+          !$omp target update from(FrictWork_bh)
+          do kk=1,kmax ; do j=js,je ; do i=is,ie
+            k = kstart + kk - 1
+            MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
+          enddo ; enddo ; enddo
         endif
       endif ! MEKE%backscatter_Ro_c
 
@@ -2413,7 +2411,7 @@ subroutine hor_visc_backscatter_h(G, CS, MEKE, VarMix, use_kh_struct, nkblock, k
     str_xx_BS    ! The diagonal term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
   integer :: i, j, k, kk
 
-  do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
+  do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     k = kstart + kk - 1
     if (visc_limit_h_flag(i,j,k) > 0) then
       Kh_BS(i,j,kk) = 0.
@@ -2424,7 +2422,7 @@ subroutine hor_visc_backscatter_h(G, CS, MEKE, VarMix, use_kh_struct, nkblock, k
         Kh_BS(i,j,kk) = MEKE%Ku(i,j)
       endif
     endif
-  enddo
+  enddo ; enddo ; enddo
 
   do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
     str_xx_BS(i,j,kk) = -Kh_BS(i,j,kk) * sh_xx(i,j,kk)
@@ -2479,7 +2477,7 @@ subroutine hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, nkbloc
     str_xy_BS    ! The cross term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
   integer :: i, j, k, kk
 
-  do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
+  do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
     k = kstart + kk - 1
     if (visc_limit_q_flag(I,J,k) > 0) then
       Kh_BS(I,J,kk) = 0.
@@ -2494,7 +2492,7 @@ subroutine hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, nkbloc
                             (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
       endif
     endif
-  enddo
+  enddo ; enddo ; enddo
 
   do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
     str_xy_BS(I,J,kk) = -Kh_BS(I,J,kk) * (sh_xy(I,J,kk))

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -344,7 +344,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     grad_vort_mag_h_2d, & ! Magnitude of 2d vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
     grad_div_mag_h, &     ! Magnitude of divergence gradient at h-points [L-1 T-1 ~> m-1 s-1]
     dudx, dvdy, &    ! components in the horizontal tension [T-1 ~> s-1]
-    dudx_smooth, dvdy_smooth, & ! components in the horizontal tension from smoothed velocity [T-1 ~> s-1]
     GME_effic_h, &  ! The filtered efficiency of the GME terms at h points [nondim]
     m_leithy, &   ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
     Ah_sq, &      ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
@@ -458,6 +457,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real :: grad_vort_qg ! QG-based vorticity gradient magnitude [L-1 T-1 ~> m-1 s-1]
   real :: grid_Kh   ! Laplacian viscosity bound by grid [L2 T-1 ~> m2 s-1]
   real :: grid_Ah   ! Biharmonic viscosity bound by grid [L4 T-1 ~> m4 s-1]
+  real :: dudx_smooth, dvdy_smooth ! components in the horizontal tension from smoothed velocity [T-1 ~> s-1]
 
   logical :: rescale_Kh
   logical :: find_FrictWork
@@ -756,11 +756,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        dudx_smooth(i,j,1) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
+        dudx_smooth = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
                                            (G%IdyCu(I-1,j) * u_smooth(I-1,j,k)))
-        dvdy_smooth(i,j,1) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
+        dvdy_smooth = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
                                            (G%IdxCv(i,J-1) * v_smooth(i,J-1,k)))
-        sh_xx_smooth(i,j,1) = dudx_smooth(i,j,1) - dvdy_smooth(i,j,1)
+        sh_xx_smooth(i,j,1) = dudx_smooth - dvdy_smooth
       enddo ; enddo
 
       ! Components for the shearing strain from smoothed velocity

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2042,60 +2042,63 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * ( &
-                  ((str_xx(i,j,1) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-                 - (str_xx(i,j,1) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy(I,J,1) *                                  &
+                  ((str_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+                 - (str_xx(i,j,kk) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+              + 0.25*(( (str_xy(I,J,kk) *                                  &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy(I-1,J-1,1) *                              &
+                      + (str_xy(I-1,J-1,kk) *                              &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy(I-1,J,1) *                                &
+                    + ( (str_xy(I-1,J,kk) *                                &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy(I,J-1,1) *                                &
+                      + (str_xy(I,J-1,kk) *                                &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo
+        enddo ; enddo ; enddo
       else
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx(i,j,1)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
-           - (str_xx(i,j,1)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
-          + (0.25*(((str_xy(I,J,1)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
-                +(str_xy(I-1,J-1,1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
-               +((str_xy(I-1,J,1)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
-                +(str_xy(I,J-1,1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)))) )) ) )) )
+            ((str_xx(i,j,kk)*CS%dy2h(i,j) * ( &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) ) ) &
+           - (str_xx(i,j,kk)*CS%dx2h(i,j) * ( &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) ) )) &
+          + (0.25*(((str_xy(I,J,kk)*(                                     &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,kk)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect))))            &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,kk)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)))) ))          &
+                +(str_xy(I-1,J-1,kk)*(                                 &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,kk)+h_neglect))))    &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,kk)+h_neglect)))) )) ) &
+               +((str_xy(I-1,J,kk)*(                                   &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,kk)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect))))      &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,kk)+h_neglect)))) ))        &
+                +(str_xy(I,J-1,kk)*(                                   &
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
 
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
       if (CS%EY24_EBT_BS) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           FrictWork(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork(i,j,k)
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
     endif
 
@@ -2103,65 +2106,69 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           FrictWork_bh(i,j,k) = GV%H_to_RZ * ( &
-                  ((bhstr_xx(i,j,1) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
-                 - (bhstr_xx(i,j,1) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))) &
-              + 0.25*(( (bhstr_xy(I,J,1) *                              &
+                  ((bhstr_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
+                 - (bhstr_xx(i,j,kk) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))) &
+              + 0.25*(( (bhstr_xy(I,J,kk) *                              &
                        (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                       + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                    + (bhstr_xy(I-1,J-1,1) *                            &
+                    + (bhstr_xy(I-1,J-1,kk) *                            &
                        (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                       + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                  + ( (bhstr_xy(I-1,J,1) *                              &
+                  + ( (bhstr_xy(I-1,J,kk) *                              &
                        (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                       + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                    + (bhstr_xy(I,J-1,1) *                              &
+                    + (bhstr_xy(I,J-1,kk) *                              &
                        (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                       + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo
+        enddo ; enddo ; enddo
       else
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
           FrictWork_bh(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((bhstr_xx(i,j,1)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
-           - (bhstr_xx(i,j,1)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
-          + (0.25*(((bhstr_xy(I,J,1)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
-                +(bhstr_xy(I-1,J-1,1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
-               +((bhstr_xy(I-1,J,1)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
-                +(bhstr_xy(I,J-1,1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)))) )) ) )) )
-        enddo ; enddo
+            ((bhstr_xx(i,j,kk)*CS%dy2h(i,j) * ( &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) ) ) &
+           - (bhstr_xx(i,j,kk)*CS%dx2h(i,j) * ( &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) ) )) &
+          + (0.25*(((bhstr_xy(I,J,kk)*(                                     &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,kk)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect))))            &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,kk)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)))) ))          &
+                +(bhstr_xy(I-1,J-1,kk)*(                                 &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,kk)+h_neglect))))    &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,kk)+h_neglect)))) )) ) &
+               +((bhstr_xy(I-1,J,kk)*(                                   &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,kk)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect))))      &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,kk)+h_neglect)))) ))        &
+                +(bhstr_xy(I,J-1,kk)*(                                   &
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
+        enddo ; enddo ; enddo
       endif
 
       if (CS%EY24_EBT_BS) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           FrictWork_bh(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork_bh(i,j,k)
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
     endif
 
     if (CS%use_GME) then
-      if (CS%FrictWork_bug) then ; do j=js,je ; do i=is,ie
+      if (CS%FrictWork_bug) then ; do kk=1,kmax ; do j=js,je ; do i=is,ie
+        k = kstart + kk - 1
       ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
       ! This is the old formulation that includes energy diffusion
         FrictWork_GME(i,j,k) = GV%H_to_RZ * ( &
@@ -2179,36 +2186,37 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                       + (str_xy_GME(I,J-1,1) *                            &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo
-      else ; do j=js,je ; do i=is,ie
+        enddo ; enddo ; enddo
+      else ; do kk=1,kmax ; do j=js,je ; do i=is,ie
+        k = kstart + kk - 1
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
             ((str_xx_GME(i,j,1)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) ) ) &
            - (str_xx_GME(i,j,1)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) ) )) &
        + (0.25*(((str_xy_GME(I,J,1)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,kk)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect))))            &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,kk)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)))) ))          &
                 +(str_xy_GME(I-1,J-1,1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,kk)+h_neglect))))    &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,kk)+h_neglect)))) )) ) &
                +((str_xy_GME(I-1,J,1)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,kk)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect))))      &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,kk)+h_neglect)))) ))        &
                 +(str_xy_GME(I,J-1,1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)))) )) ) )) )
-      enddo ; enddo ; endif
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
+      enddo ; enddo ; enddo ; endif
     endif
 
     if (skeb_use_frict) then ; do j=js,je ; do i=is,ie

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -338,8 +338,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     GME_effic_h   ! The filtered efficiency of the GME terms at h points [nondim]
   real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
     m_leithy, &   ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
-    Ah_sq, &      ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
-    str_xx_BS      ! The diagonal term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
+    Ah_sq         ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
   real :: Del2vort_h ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
 
   real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
@@ -368,8 +367,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                    ! This form guarantees that hq/hu < 4.
   real, dimension(SZIB_(G),SZJB_(G)) :: &
     GME_effic_q   ! The filtered efficiency of the GME terms at q points [nondim]
-  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
-    str_xy_BS      ! The cross term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
 
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)) :: &
     Ah_q, &      ! biharmonic viscosity at corner points [L4 T-1 ~> m4 s-1]
@@ -470,7 +467,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     Ah, &           ! biharmonic viscosity (h or q) [L4 T-1 ~> m4 s-1]
     Kh, &           ! Laplacian  viscosity (h or q) [L2 T-1 ~> m2 s-1]
-    Kh_BS, &        ! Laplacian  antiviscosity [L2 T-1 ~> m2 s-1]
     Shear_mag, &    ! magnitude of the shear (h or q) [T-1 ~> s-1]
     vert_vort_mag, &  ! magnitude of the vertical vorticity gradient (h or q) [L-1 T-1 ~> m-1 s-1]
     vert_vort_mag_smooth, &  ! magnitude of gradient of smoothed vertical vorticity (h or q) [L-1 T-1 ~> m-1 s-1]
@@ -638,7 +634,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: sh_xy_q) &
   !$omp   if (CS%id_sh_xy_q > 0)
 
-  !$omp target enter data map(alloc: Kh_BS, str_xx_BS, str_xy_BS, BS_coeff_h, BS_coeff_q) &
+  !$omp target enter data map(alloc: BS_coeff_h, BS_coeff_q) &
   !$omp   if (CS%EY24_EBT_BS)
   !$omp target enter data map(alloc: vert_vort_mag, vert_vort_mag_smooth) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
@@ -1352,33 +1348,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
-        k = kstart + kk - 1
-        if (visc_limit_h_flag(i,j,k) > 0) then
-          Kh_BS(i,j,kk) = 0.
-        else
-          if (use_kh_struct) then
-            Kh_BS(i,j,kk) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
-          else
-            Kh_BS(i,j,kk) = MEKE%Ku(i,j)
-          endif
-        endif
-      enddo
-
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
-        str_xx_BS(i,j,kk) = -Kh_BS(i,j,kk) * sh_xx(i,j,kk)
-      enddo
-
-      if (CS%id_BS_coeff_h>0) then
-        do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
-          k = kstart + kk - 1
-          BS_coeff_h(i,j,k) = Kh_BS(i,j,kk)
-        enddo
-      endif
-
-      do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
-        str_xx(i,j,kk) = str_xx(i,j,kk) + str_xx_BS(i,j,kk)
-      enddo
+      call hor_visc_backscatter_h(G, CS, MEKE, VarMix, use_kh_struct, nkblock, kstart, kmax, &
+                                   Isq, Ieq, Jsq, Jeq, visc_limit_h_flag, sh_xx, str_xx, BS_coeff_h)
     endif ! Backscatter
 
     if (CS%biharmonic) then
@@ -1731,37 +1702,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
-        k = kstart + kk - 1
-        if (visc_limit_q_flag(I,J,k) > 0) then
-          Kh_BS(I,J,kk) = 0.
-        else
-          if (use_kh_struct) then
-            Kh_BS(I,J,kk) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
-                                 (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
-                                ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
-                                 (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
-          else
-            Kh_BS(I,J,kk) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
-                                (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
-          endif
-        endif
-      enddo
-
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
-        str_xy_BS(I,J,kk) = -Kh_BS(I,J,kk) * (sh_xy(I,J,kk))
-      enddo
-
-      if (CS%id_BS_coeff_q>0) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
-          k = kstart + kk - 1
-          BS_coeff_q(I,J,k) = Kh_BS(I,J,kk)
-        enddo
-      endif
-
-      do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
-        str_xy(I,J,kk) = str_xy(I,J,kk) + str_xy_BS(I,J,kk)
-      enddo
+      call hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, nkblock, kstart, kmax, &
+                                   is, js, Ieq, Jeq, visc_limit_q_flag, sh_xy, str_xy, BS_coeff_q)
     endif ! Backscatter
 
     if (CS%use_GME) then
@@ -2155,7 +2097,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: visc_bound_rem) &
   !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
 
-  !$omp target exit data map(delete: Kh_BS, str_xx_BS, str_xy_BS, BS_coeff_h, BS_coeff_q) &
+  !$omp target exit data map(delete: BS_coeff_h, BS_coeff_q) &
   !$omp   if (CS%EY24_EBT_BS)
   !$omp target exit data map(delete: vert_vort_mag, vert_vort_mag_smooth) &
   !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020)
@@ -2488,6 +2430,136 @@ subroutine hor_visc_Leith_grad(G, GV, US, CS, VarMix, nkblock, kstart, kmax, &
   endif ! Leithy
 
 end subroutine hor_visc_Leith_grad
+
+!> Adds the MEKE-based (EY24_EBT_BS) backscatter contribution to the diagonal term of
+!! the stress tensor at h-points. The caller must only invoke this routine when
+!! CS%EY24_EBT_BS is true.
+subroutine hor_visc_backscatter_h(G, CS, MEKE, VarMix, use_kh_struct, nkblock, kstart, kmax, &
+                                   Isq, Ieq, Jsq, Jeq, visc_limit_h_flag, sh_xx, str_xx, BS_coeff_h)
+  type(ocean_grid_type), intent(in)    :: G   !< The ocean's grid structure.
+  type(hor_visc_CS),     intent(in)    :: CS  !< Horizontal viscosity control structure
+  type(MEKE_type),       intent(in)    :: MEKE !< MEKE fields related to Mesoscale Eddy Kinetic Energy.
+  type(VarMix_CS),       intent(in)    :: VarMix !< Variable mixing control structure
+  logical,               intent(in)    :: use_kh_struct !< If true, shape the backscatter coefficient
+                                                 !! with VarMix%BS_struct
+  integer,               intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
+  integer,               intent(in)    :: kstart  !< The first absolute k-layer of the current k-block
+  integer,               intent(in)    :: kmax    !< The number of active k-layers in the current k-block
+  integer,               intent(in)    :: Isq, Ieq, Jsq, Jeq !< Loop ranges for the stress tensor at h-points
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(in)    :: visc_limit_h_flag !< determines whether backscatter is shut off [nondim]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                         intent(in)    :: sh_xx !< horizontal tension (du/dx - dv/dy) including
+                                                 !! metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock), &
+                         intent(inout) :: str_xx !< The diagonal term in the stress tensor
+                                                 !! [H L2 T-2 ~> m3 s-2 or kg s-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(inout) :: BS_coeff_h !< A diagnostic array of the backscatter
+                                                 !! coefficient [L2 T-1 ~> m2 s-1]
+  ! Local variables
+  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
+    Kh_BS, &     ! Laplacian antiviscosity [L2 T-1 ~> m2 s-1]
+    str_xx_BS    ! The diagonal term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
+  integer :: i, j, k, kk
+
+  do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
+    k = kstart + kk - 1
+    if (visc_limit_h_flag(i,j,k) > 0) then
+      Kh_BS(i,j,kk) = 0.
+    else
+      if (use_kh_struct) then
+        Kh_BS(i,j,kk) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+      else
+        Kh_BS(i,j,kk) = MEKE%Ku(i,j)
+      endif
+    endif
+  enddo
+
+  do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+    str_xx_BS(i,j,kk) = -Kh_BS(i,j,kk) * sh_xx(i,j,kk)
+  enddo
+
+  if (CS%id_BS_coeff_h>0) then
+    do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1) DO_LOCALITY(local(k))
+      k = kstart + kk - 1
+      BS_coeff_h(i,j,k) = Kh_BS(i,j,kk)
+    enddo
+  endif
+
+  do concurrent (kk=1:kmax, j=Jsq:Jeq+1, i=Isq:Ieq+1)
+    str_xx(i,j,kk) = str_xx(i,j,kk) + str_xx_BS(i,j,kk)
+  enddo
+
+end subroutine hor_visc_backscatter_h
+
+!> Adds the MEKE-based (EY24_EBT_BS) backscatter contribution to the cross term of
+!! the stress tensor at q-points. The caller must only invoke this routine when
+!! CS%EY24_EBT_BS is true.
+subroutine hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, nkblock, kstart, kmax, &
+                                   is, js, Ieq, Jeq, visc_limit_q_flag, sh_xy, str_xy, BS_coeff_q)
+  type(ocean_grid_type),   intent(in)    :: G   !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV  !< The ocean's vertical grid structure.
+  type(hor_visc_CS),       intent(in)    :: CS  !< Horizontal viscosity control structure
+  type(MEKE_type),         intent(in)    :: MEKE !< MEKE fields related to Mesoscale Eddy Kinetic Energy.
+  type(VarMix_CS),         intent(in)    :: VarMix !< Variable mixing control structure
+  logical,                 intent(in)    :: use_kh_struct !< If true, shape the backscatter coefficient
+                                                 !! with VarMix%BS_struct
+  integer,                 intent(in)    :: nkblock !< The k-block size used to size the following arrays [nondim]
+  integer,                 intent(in)    :: kstart  !< The first absolute k-layer of the current k-block
+  integer,                 intent(in)    :: kmax    !< The number of active k-layers in the current k-block
+  integer,                 intent(in)    :: is, js  !< Loop start indices for the q-point stress tensor
+  integer,                 intent(in)    :: Ieq, Jeq !< Loop end indices for the q-point stress tensor
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
+                           intent(in)    :: visc_limit_q_flag !< determines whether backscatter is shut off [nondim]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                           intent(in)    :: sh_xy !< horizontal shearing strain (du/dy + dv/dx) including
+                                                 !! metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock), &
+                           intent(inout) :: str_xy !< The cross term in the stress tensor
+                                                 !! [H L2 T-2 ~> m3 s-2 or kg s-2]
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
+                           intent(inout) :: BS_coeff_q !< A diagnostic array of the backscatter
+                                                 !! coefficient [L2 T-1 ~> m2 s-1]
+  ! Local variables
+  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
+    Kh_BS, &     ! Laplacian antiviscosity [L2 T-1 ~> m2 s-1]
+    str_xy_BS    ! The cross term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
+  integer :: i, j, k, kk
+
+  do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
+    k = kstart + kk - 1
+    if (visc_limit_q_flag(I,J,k) > 0) then
+      Kh_BS(I,J,kk) = 0.
+    else
+      if (use_kh_struct) then
+        Kh_BS(I,J,kk) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+                             (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
+                            ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
+                             (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
+      else
+        Kh_BS(I,J,kk) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
+                            (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
+      endif
+    endif
+  enddo
+
+  do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+    str_xy_BS(I,J,kk) = -Kh_BS(I,J,kk) * (sh_xy(I,J,kk))
+  enddo
+
+  if (CS%id_BS_coeff_q>0) then
+    do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k))
+      k = kstart + kk - 1
+      BS_coeff_q(I,J,k) = Kh_BS(I,J,kk)
+    enddo
+  endif
+
+  do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+    str_xy(I,J,kk) = str_xy(I,J,kk) + str_xy_BS(I,J,kk)
+  enddo
+
+end subroutine hor_visc_backscatter_q
 
 !> Returns the effective k-block size for horizontal_viscosity calls.
 integer function hor_visc_nkblock(CS, GV)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -625,7 +625,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: Del2u, Del2v) if (CS%biharmonic)
   !$omp target enter data map(alloc: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target enter data map(alloc: Shear_mag) if (use_Smag)
-  !$omp target enter data map(alloc: Kh) if (CS%Laplacian)
+  !$omp target enter data map(alloc: Kh) if (CS%Laplacian .or. CS%biharmonic)
   !$omp target enter data map(alloc: Ah) if (CS%biharmonic)
   ! TODO: Only needed if FrictWork_bh is true, and currently only used on CPU,
   !   but I do not yet see any benefit to breaking up the calculation.
@@ -638,21 +638,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target enter data map(alloc: sh_xy_q) &
   !$omp   if (CS%id_sh_xy_q > 0)
 
-  !$omp target enter data map(alloc: BS_coeff_h, BS_coeff_q) &
-  !$omp   if (CS%EY24_EBT_BS)
-  !$omp target enter data map(alloc: vert_vort_mag, vert_vort_mag_smooth)
-  !$omp target enter data map(alloc: m_leithy)
-  !$omp target enter data map(alloc: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
-  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth)
-  !$omp target enter data map(alloc: vort_xy, vort_xy_smooth)
-  !$omp target enter data map(alloc: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
-  !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
-  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
-  !$omp target enter data map(alloc: slope_x, slope_y) &
-  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
-  !$omp target enter data map(alloc: dz) &
-  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
-  !$omp target enter data map(alloc: u_smooth, v_smooth) if (CS%use_Leithy)
+  !$omp target enter data map(alloc: vert_vort_mag)
+  !$omp target enter data map(alloc: sh_xx_smooth) if (CS%use_Leithy .or. CS%biharmonic)
+  !!$omp target enter data map(alloc: CS%use_Leithy)
 
   do kstart=1,nz,nkblock
     kend = min(kstart+nkblock-1,nz)
@@ -2028,7 +2016,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: Del2u, Del2v) if (CS%biharmonic)
   !$omp target exit data map(delete: dDel2vdx, dDel2udy) if (CS%biharmonic)
   !$omp target exit data map(delete: Shear_mag) if (use_Smag)
-  !$omp target exit data map(delete: Kh) if (CS%Laplacian)
+  !$omp target exit data map(delete: Kh) if (CS%Laplacian .or. CS%biharmonic)
   !$omp target exit data map(delete: Ah) if (CS%biharmonic)
   !$omp target exit data map(delete: bhstr_xx, bhstr_xy) if (CS%biharmonic)
 
@@ -2037,27 +2025,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$omp target exit data map(delete: visc_bound_rem) &
   !$omp   if (CS%bound_Kh .or. CS%bound_Ah)
 
-  !$omp target exit data map(delete: BS_coeff_h, BS_coeff_q) &
-  !$omp   if (CS%EY24_EBT_BS)
-  !$omp target exit data map(delete: vert_vort_mag, vert_vort_mag_smooth)
-  !$omp target exit data map(delete: m_leithy)
-  !$omp target exit data map(delete: dudx_smooth, dvdy_smooth, sh_xx_smooth, &
-  !$omp                              dvdx_smooth, dudy_smooth, sh_xy_smooth)
-  !$omp target exit data map(delete: vort_xy, vort_xy_smooth)
-  !$omp target exit data map(delete: grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
-  !$omp                              grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, Del2vort_q) &
-  !$omp   if ((CS%Leith_Kh) .or. (CS%Leith_Ah))
-  !$omp target exit data map(delete: slope_x, slope_y) &
-  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
-  !$omp target exit data map(delete: dz) &
-  !$omp   if (CS%use_QG_Leith_visc .and. ((CS%Leith_Kh) .or. (CS%Leith_Ah)))
-  !$omp target exit data map(delete: u_smooth, v_smooth) if (CS%use_Leithy)
-
-  !$omp target exit data map(delete: sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME) &
-  !$omp   if (CS%use_GME)
-  !$omp target exit data map(delete: str_xx_GME, str_xy_GME) if (CS%use_GME)
-  ! GME_coeff_h/q are only diagnostic outputs beyond this point, so bring them back to the host.
-  !$omp target exit data map(from: GME_coeff_h, GME_coeff_q) if (CS%use_GME)
+  !$omp target exit data map(delete: vert_vort_mag)
+  !$omp target exit data map(delete: sh_xx_smooth) if (CS%use_Leithy .or. CS%biharmonic)
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1169,19 +1169,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        sh_xx_sq = sh_xx(i,j,1)**2
-        sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1,1)**2) + (sh_xy(I,J,1)**2)) &
-                          + ((sh_xy(I-1,J,1)**2) + (sh_xy(I,J-1,1)**2)) )
-        Shear_mag(i,j,1) = sqrt(sh_xx_sq + sh_xy_sq)
-      enddo ; enddo
+      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        sh_xx_sq = sh_xx(i,j,kk)**2
+        sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1,kk)**2) + (sh_xy(I,J,kk)**2)) &
+                          + ((sh_xy(I-1,J,kk)**2) + (sh_xy(I,J-1,kk)**2)) )
+        Shear_mag(i,j,kk) = sqrt(sh_xx_sq + sh_xy_sq)
+      enddo ; enddo ; enddo
     endif
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        h_min = min(h_u(I,j,1), h_u(I-1,j,1), h_v(i,J,1), h_v(i,J-1,1))
-        hrat_min(i,j,1) = min(1.0, h_min / (h(i,j,k) + h_neglect))
-      enddo ; enddo
+      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        k = kstart + kk - 1
+        h_min = min(h_u(I,j,kk), h_u(I-1,j,kk), h_v(i,J,kk), h_v(i,J-1,kk))
+        hrat_min(i,j,kk) = min(1.0, h_min / (h(i,j,k) + h_neglect))
+      enddo ; enddo ; enddo
     endif
 
     if (CS%Laplacian) then
@@ -1191,143 +1192,149 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%use_QG_Leith_visc) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            grad_vort = grad_vort_mag_h(i,j,1) + grad_div_mag_h(i,j,1)
-            grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j,1)
-            vert_vort_mag(i,j,1) = min(grad_vort, grad_vort_qg)
-          enddo ; enddo
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            grad_vort = grad_vort_mag_h(i,j,kk) + grad_div_mag_h(i,j,kk)
+            grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j,kk)
+            vert_vort_mag(i,j,kk) = min(grad_vort, grad_vort_qg)
+          enddo ; enddo ; enddo
         else
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            vert_vort_mag(i,j,1) = grad_vort_mag_h(i,j,1) + grad_div_mag_h(i,j,1)
-          enddo ; enddo
+          do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            vert_vort_mag(i,j,kk) = grad_vort_mag_h(i,j,kk) + grad_div_mag_h(i,j,kk)
+          enddo ; enddo ; enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Kh(i,j,1) = CS%Kh_bg_xx(i,j)
-      enddo ; enddo
+      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        Kh(i,j,kk) = CS%Kh_bg_xx(i,j)
+      enddo ; enddo ; enddo
 
       ! NOTE: The following do-block can be decomposed and vectorized after the
       !   stack size has been reduced.
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         if (CS%add_LES_viscosity) then
           if (CS%Smagorinsky_Kh) &
-            Kh(i,j,1) = Kh(i,j,1) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,1)
+            Kh(i,j,kk) = Kh(i,j,kk) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,kk)
           if (CS%Leith_Kh) &
-            Kh(i,j,1) = Kh(i,j,1) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,1) * inv_PI3
+            Kh(i,j,kk) = Kh(i,j,kk) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,kk) * inv_PI3
         else
           if (CS%Smagorinsky_Kh) &
-            Kh(i,j,1) = max(Kh(i,j,1), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,1))
+            Kh(i,j,kk) = max(Kh(i,j,kk), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,kk))
           if (CS%Leith_Kh) &
-            Kh(i,j,1) = max(Kh(i,j,1), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,1) * inv_PI3)
+            Kh(i,j,kk) = max(Kh(i,j,kk), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,kk) * inv_PI3)
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j,1) = VarMix%Res_fn_h(i,j) * Kh(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          Kh(i,j,kk) = VarMix%Res_fn_h(i,j) * Kh(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       ! Place a floor on the viscosity, if desired.
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Kh(i,j,1) = max(Kh(i,j,1), CS%Kh_bg_min)
-      enddo ; enddo
+      do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        Kh(i,j,kk) = max(Kh(i,j,kk), CS%Kh_bg_min)
+      enddo ; enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              k = kstart + kk - 1
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
+            enddo ; enddo ; enddo
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              k = kstart + kk - 1
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+            enddo ; enddo ; enddo
           endif
         else
           if (CS%res_scale_MEKE) then
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
+            enddo ; enddo ; enddo
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j,1) = Kh(i,j,1) + MEKE%Ku(i,j)
-            enddo ; enddo
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j)
+            enddo ; enddo ; enddo
           endif
         endif
       endif
 
       if (CS%anisotropic) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           ! *Add* the tension component of anisotropic viscosity
-          Kh(i,j,1) = Kh(i,j,1) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
-        enddo ; enddo
+          Kh(i,j,kk) = Kh(i,j,kk) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
+        enddo ; enddo ; enddo
       endif
 
       ! Newer method of bounding for stability
       if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          visc_bound_rem(i,j,1) = 1.0
-          Kh_max_here = hrat_min(i,j,1) * CS%Kh_Max_xx(i,j)
-          if (Kh(i,j,1) >= Kh_max_here) then
-            visc_bound_rem(i,j,1) = 0.0
-            Kh(i,j,1) = Kh_max_here
-          elseif ((Kh(i,j,1) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
-            visc_bound_rem(i,j,1) = 1.0 - Kh(i,j,1) / Kh_max_here
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          visc_bound_rem(i,j,kk) = 1.0
+          Kh_max_here = hrat_min(i,j,kk) * CS%Kh_Max_xx(i,j)
+          if (Kh(i,j,kk) >= Kh_max_here) then
+            visc_bound_rem(i,j,kk) = 0.0
+            Kh(i,j,kk) = Kh_max_here
+          elseif ((Kh(i,j,kk) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
+            visc_bound_rem(i,j,kk) = 1.0 - Kh(i,j,kk) / Kh_max_here
           endif
-        enddo ; enddo
+        enddo ; enddo ; enddo
       elseif (CS%bound_Kh) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j,1) = min(Kh(i,j,1), hrat_min(i,j,1) * CS%Kh_Max_xx(i,j))
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          Kh(i,j,kk) = min(Kh(i,j,kk), hrat_min(i,j,kk) * CS%Kh_Max_xx(i,j))
+        enddo ; enddo ; enddo
       endif
 
       ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
       ! The harmonic component of str_xx is added in the biharmonic loop.
       if (CS%use_Leithy) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j,1) = 0.
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          Kh(i,j,kk) = 0.
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_Kh_h>0 .or. CS%debug) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh_h(i,j,k) = Kh(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = kstart + kk - 1
+          Kh_h(i,j,k) = Kh(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Kh>0) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
-          grid_Kh = max(Kh(i,j,1), CS%min_grid_Kh)
+          grid_Kh = max(Kh(i,j,kk), CS%min_grid_Kh)
           grid_Re_Kh(i,j,k) = (sqrt(KE) * sqrt(CS%grid_sp_h2(i,j))) / grid_Kh
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_div_xx_h>0) then
-        do j=js,je ; do i=is,ie
-          div_xx_h(i,j,k) = dudx(i,j,1) + dvdy(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
+          div_xx_h(i,j,k) = dudx(i,j,kk) + dvdy(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_sh_xx_h>0) then
-        do j=js,je ; do i=is,ie
-          sh_xx_h(i,j,k) = sh_xx(i,j,1)
-        enddo ; enddo
+        do kk=1,kmax ; do j=js,je ; do i=is,ie
+          k = kstart + kk - 1
+          sh_xx_h(i,j,k) = sh_xx(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = -Kh(i,j,1) * sh_xx(i,j,1)
-      enddo ; enddo
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx(i,j,kk) = -Kh(i,j,kk) * sh_xx(i,j,kk)
+      enddo ; enddo ; enddo
     else
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = 0.0
-      enddo ; enddo
+      do kk=1,kmax ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx(i,j,kk) = 0.0
+      enddo ; enddo ; enddo
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1644,144 +1644,149 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            grad_vort = grad_vort_mag_q(I,J,1) + grad_div_mag_q(I,J,1)
-            grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J,1)
-            vert_vort_mag(I,J,1) = min(grad_vort, grad_vort_qg)
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            grad_vort = grad_vort_mag_q(I,J,kk) + grad_div_mag_q(I,J,kk)
+            grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J,kk)
+            vert_vort_mag(I,J,kk) = min(grad_vort, grad_vort_qg)
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            vert_vort_mag(I,J,1) = grad_vort_mag_q(I,J,1) + grad_div_mag_q(I,J,1)
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            vert_vort_mag(I,J,kk) = grad_vort_mag_q(I,J,kk) + grad_div_mag_q(I,J,kk)
+          enddo ; enddo ; enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        Kh(I,J,1) = CS%Kh_bg_xy(I,J)
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        Kh(I,J,kk) = CS%Kh_bg_xy(I,J)
+      enddo ; enddo ; enddo
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J,1) = Kh(I,J,1) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,1)
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = Kh(I,J,kk) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,kk)
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J,1) = max(Kh(I,J,1), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,1) )
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = max(Kh(I,J,kk), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,kk) )
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%Leith_Kh) then
         if (CS%add_LES_viscosity) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J,1) = Kh(I,J,1) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,1) * inv_PI3 ! Is this right? -AJA
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = Kh(I,J,kk) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,kk) * inv_PI3 ! Is this right? -AJA
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J,1) = max(Kh(I,J,1), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,1) * inv_PI3)
-          enddo ; enddo
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = max(Kh(I,J,kk), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,kk) * inv_PI3)
+          enddo ; enddo ; enddo
         endif
       endif
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh(I,J,1) = VarMix%Res_fn_q(I,J) * Kh(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          Kh(I,J,kk) = VarMix%Res_fn_q(I,J) * Kh(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        Kh(I,J,1) = max(Kh(I,J,1), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        Kh(I,J,kk) = max(Kh(I,J,kk), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
+      enddo ; enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         if (use_kh_struct) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            k = kstart + kk - 1
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
-            Kh(I,J,1) = Kh(I,J,1) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+            Kh(I,J,kk) = Kh(I,J,kk) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
                                        (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
                                        ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
                                        (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
-          enddo ; enddo
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
-            Kh(I,J,1) = Kh(I,J,1) + 0.25 * ( &
+            Kh(I,J,kk) = Kh(I,J,kk) + 0.25 * ( &
                 (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
                                        (MEKE%Ku(i+1,j) + &
                                         MEKE%Ku(i,j+1)) ) * meke_res_fn
-          enddo ; enddo
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%anisotropic) then
         ! *Add* the shear component of anisotropic viscosity
-        do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J,1) = Kh(I,J,1) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = Kh(I,J,kk) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
+        enddo ; enddo ; enddo
       endif
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
         ! Newer method of bounding for stability
         if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-          visc_bound_rem(I,J,1) = 1.0
-          Kh_max_here = hrat_min(I,J,1) * CS%Kh_Max_xy(I,J)
-          if (Kh(I,J,1) >= Kh_max_here) then
-            visc_bound_rem(I,J,1) = 0.0
-            Kh(I,J,1) = Kh_max_here
-          elseif ((Kh(I,J,1) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
-            visc_bound_rem(I,J,1) = 1.0 - Kh(I,J,1) / Kh_max_here
+          visc_bound_rem(I,J,kk) = 1.0
+          Kh_max_here = hrat_min(I,J,kk) * CS%Kh_Max_xy(I,J)
+          if (Kh(I,J,kk) >= Kh_max_here) then
+            visc_bound_rem(I,J,kk) = 0.0
+            Kh(I,J,kk) = Kh_max_here
+          elseif ((Kh(I,J,kk) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
+            visc_bound_rem(I,J,kk) = 1.0 - Kh(I,J,kk) / Kh_max_here
           endif
         elseif (CS%bound_Kh) then
-          Kh(I,J,1) = min(Kh(I,J,1), hrat_min(I,J,1) * CS%Kh_Max_xy(I,J))
+          Kh(I,J,kk) = min(Kh(I,J,kk), hrat_min(I,J,kk) * CS%Kh_Max_xy(I,J))
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
 
       if (CS%use_Leithy) then
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh(I,J,1) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
+          Kh(I,J,kk) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh_q(I,J,k) = Kh(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
+          Kh_q(I,J,k) = Kh(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_vort_xy_q > 0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          vort_xy_q(I,J,k) = vort_xy(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
+          vort_xy_q(I,J,k) = vort_xy(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_sh_xy_q > 0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_q(I,J,k) = sh_xy(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = kstart + kk - 1
+          sh_xy_q(I,J,k) = sh_xy(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (.not. CS%use_Leithy) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = -Kh(I,J,1) * sh_xy(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = -Kh(I,J,kk) * sh_xy(I,J,kk)
+        enddo ; enddo ; enddo
       else
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = -Kh(I,J,1) * sh_xy_smooth(I,J,1)
-        enddo ; enddo
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = -Kh(I,J,kk) * sh_xy_smooth(I,J,kk)
+        enddo ; enddo ; enddo
       endif
     else
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J,1) = 0.
-      enddo ; enddo
+      do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
+        str_xy(I,J,kk) = 0.
+      enddo ; enddo ; enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -313,24 +313,30 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     h_u, &        ! Thickness interpolated to u points [H ~> m or kg m-2].
     vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
     vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
-    div_xx_dx, &  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+    div_xx_dx     ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJ_(G)) :: &
     ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),nkblock) :: &
     Del2v, &      ! The v-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
     h_v, &        ! Thickness interpolated to v points [H ~> m or kg m-2].
     vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
     vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
-    div_xx_dy, &  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-    vbtav         ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+    div_xx_dy     ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZI_(G),SZJB_(G)) :: &
+    vbtav, &      ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+    dudx_bt, dvdy_bt ! components in the barotropic horizontal tension [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
-    dudx_bt, dvdy_bt, & ! components in the barotropic horizontal tension [T-1 ~> s-1]
     div_xx, &     ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
     sh_xx, &      ! horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
-    sh_xx_smooth, & ! horizontal tension from smoothed velocity including metric terms [T-1 ~> s-1]
-    sh_xx_bt, &   ! barotropic horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
-    str_xx,&      ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
+    sh_xx_smooth  ! horizontal tension from smoothed velocity including metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    sh_xx_bt      ! barotropic horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
+    str_xx        ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
-    str_xx_GME,&  ! smoothed diagonal term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    str_xx_GME    ! smoothed diagonal term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
+  real, dimension(SZI_(G),SZJ_(G),nkblock) :: &
     bhstr_xx, &   ! A copy of str_xx that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     FrictWorkIntz, & ! depth integrated energy dissipated by lateral friction [R Z L2 T-3 ~> W m-2]
     FrictWorkIntz_bh, & ! depth integrated energy dissipated by biharmonic lateral friction [R Z L2 T-3 ~> W m-2]
@@ -351,14 +357,20 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     dvdx, dudy, & ! components in the shearing strain [T-1 ~> s-1]
     dvdx_smooth, dudy_smooth, & ! components in the shearing strain from smoothed velocity [T-1 ~> s-1]
-    dDel2vdx, dDel2udy, & ! Components in the biharmonic equivalent of the shearing strain [L-2 T-1 ~> m-2 s-1]
-    dvdx_bt, dudy_bt,   & ! components in the barotropic shearing strain [T-1 ~> s-1]
+    dDel2vdx, dDel2udy ! Components in the biharmonic equivalent of the shearing strain [L-2 T-1 ~> m-2 s-1]
+  real, dimension(SZIB_(G),SZJB_(G)) :: &
+    dvdx_bt, dudy_bt   ! components in the barotropic shearing strain [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     sh_xy,  &     ! horizontal shearing strain (du/dy + dv/dx) including metric terms [T-1 ~> s-1]
-    sh_xy_smooth,  & ! horizontal shearing strain from smoothed velocity including metric terms [T-1 ~> s-1]
-    sh_xy_bt, &   ! barotropic horizontal shearing strain (du/dy + dv/dx) inc. metric terms [T-1 ~> s-1]
-    str_xy, &     ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
+    sh_xy_smooth  ! horizontal shearing strain from smoothed velocity including metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)) :: &
+    sh_xy_bt      ! barotropic horizontal shearing strain (du/dy + dv/dx) inc. metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
+    str_xy        ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
-    str_xy_GME, & ! smoothed cross term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
+  real, dimension(SZIB_(G),SZJB_(G)) :: &
+    str_xy_GME    ! smoothed cross term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
+  real, dimension(SZIB_(G),SZJB_(G),nkblock) :: &
     bhstr_xy, &   ! A copy of str_xy that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     vort_xy, &    ! Vertical vorticity (dv/dx - du/dy) including metric terms [T-1 ~> s-1]
     vort_xy_smooth, & ! Vertical vorticity including metric terms, smoothed [T-1 ~> s-1]
@@ -571,41 +583,41 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Initialize diagnostic arrays with zeros
     GME_coeff_h(:,:,:) = 0.0
     GME_coeff_q(:,:,:) = 0.0
-    str_xx_GME(:,:,1) = 0.0
-    str_xy_GME(:,:,1) = 0.0
+    str_xx_GME(:,:) = 0.0
+    str_xy_GME(:,:) = 0.0
 
     ! Get barotropic velocities and their gradients
-    call barotropic_get_tav(BT, ubtav(:,:,1), vbtav(:,:,1), G, US)
+    call barotropic_get_tav(BT, ubtav, vbtav, G, US)
 
-    call pass_vector(ubtav(:,:,1), vbtav(:,:,1), G%Domain)
+    call pass_vector(ubtav, vbtav, G%Domain)
     call pass_var(h, G%domain, halo=2)
 
     ! Calculate the barotropic horizontal tension
     do j=js-2,je+2 ; do i=is-2,ie+2
-      dudx_bt(i,j,1) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j,1)) - &
-                                     (G%IdyCu(I-1,j) * ubtav(I-1,j,1)))
-      dvdy_bt(i,j,1) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J,1)) - &
-                                     (G%IdxCv(i,J-1) * vbtav(i,J-1,1)))
+      dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j)) - &
+                                     (G%IdyCu(I-1,j) * ubtav(I-1,j)))
+      dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J)) - &
+                                     (G%IdxCv(i,J-1) * vbtav(i,J-1)))
     enddo ; enddo
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      sh_xx_bt(i,j,1) = dudx_bt(i,j,1) - dvdy_bt(i,j,1)
+      sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
     enddo ; enddo
 
     ! Components for the barotropic shearing strain
     do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
-      dvdx_bt(I,J,1) = CS%DY_dxBu(I,J)*((vbtav(i+1,J,1)*G%IdyCv(i+1,J)) &
-                                    - (vbtav(i,J,1)*G%IdyCv(i,J)))
-      dudy_bt(I,J,1) = CS%DX_dyBu(I,J)*((ubtav(I,j+1,1)*G%IdxCu(I,j+1)) &
-                                    - (ubtav(I,j,1)*G%IdxCu(I,j)))
+      dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J)*G%IdyCv(i+1,J)) &
+                                    - (vbtav(i,J)*G%IdyCv(i,J)))
+      dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1)*G%IdxCu(I,j+1)) &
+                                    - (ubtav(I,j)*G%IdxCu(I,j)))
     enddo ; enddo
 
     if (CS%no_slip) then
       do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J,1) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J,1) + dudy_bt(I,J,1) )
+        sh_xy_bt(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
       enddo ; enddo
     else
       do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J,1) = G%mask2dBu(I,J) * ( dvdx_bt(I,J,1) + dudy_bt(I,J,1) )
+        sh_xy_bt(I,J) = G%mask2dBu(I,J) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
       enddo ; enddo
     endif
 
@@ -619,9 +631,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     I_GME_h0 = 1.0 / CS%GME_h0
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       boundary_mask_h = (G%mask2dCu(I,j) * G%mask2dCu(I-1,j)) * (G%mask2dCv(i,J) * G%mask2dCv(i,J-1))
-      grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j,1)**2 + dvdy_bt(i,j,1)**2 + &
-            (0.25*((dvdx_bt(I,J,1)+dvdx_bt(I-1,J-1,1)) + (dvdx_bt(I,J-1,1)+dvdx_bt(I-1,J,1))))**2 + &
-            (0.25*((dudy_bt(I,J,1)+dudy_bt(I-1,J-1,1)) + (dudy_bt(I,J-1,1)+dudy_bt(I-1,J,1))))**2)
+      grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j)**2 + dvdy_bt(i,j)**2 + &
+            (0.25*((dvdx_bt(I,J)+dvdx_bt(I-1,J-1)) + (dvdx_bt(I,J-1)+dvdx_bt(I-1,J))))**2 + &
+            (0.25*((dudy_bt(I,J)+dudy_bt(I-1,J-1)) + (dudy_bt(I,J-1)+dudy_bt(I-1,J))))**2)
       ! Probably the following test could be simplified to
       ! if (boundary_mask_h * G%mask2dT(I,J) > 0.0) then
       if (grad_vel_mag_bt_h > 0.0) then
@@ -633,9 +645,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
     do J=js-2,je+1 ; do I=is-2,ie+1
       boundary_mask_q = (G%mask2dCv(i,J) * G%mask2dCv(i+1,J)) * (G%mask2dCu(I,j) * G%mask2dCu(I,j+1))
-      grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J,1)**2 + dudy_bt(I,J,1)**2 + &
-            (0.25*((dudx_bt(i,j,1)+dudx_bt(i+1,j+1,1)) + (dudx_bt(i,j+1,1)+dudx_bt(i+1,j,1))))**2 + &
-            (0.25*((dvdy_bt(i,j,1)+dvdy_bt(i+1,j+1,1)) + (dvdy_bt(i,j+1,1)+dvdy_bt(i+1,j,1))))**2)
+      grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
+            (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1)) + (dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
+            (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1)) + (dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
       ! Probably the following test could be simplified to
       ! if (boundary_mask_q * G%mask2dBu(I,J) > 0.0) then
       if (grad_vel_mag_bt_q > 0.0) then
@@ -1873,7 +1885,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
-        str_xx_GME(i,j,1) = GME_coeff * sh_xx_bt(i,j,1)
+        str_xx_GME(i,j) = GME_coeff * sh_xx_bt(i,j)
       enddo ; enddo
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
@@ -1883,26 +1895,26 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if (CS%id_GME_coeff_q>0) GME_coeff_q(I,J,k) = GME_coeff
-        str_xy_GME(I,J,1) = GME_coeff * sh_xy_bt(I,J,1)
+        str_xy_GME(I,J) = GME_coeff * sh_xy_bt(I,J)
       enddo ; enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
-      call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,1))
-      call smooth_GME(CS, G, GME_flux_q=str_xy_GME(:,:,1))
+      call smooth_GME(CS, G, GME_flux_h=str_xx_GME)
+      call smooth_GME(CS, G, GME_flux_q=str_xy_GME)
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j,1) = (str_xx(i,j,1) + str_xx_GME(i,j,1)) * (h(i,j,k) * CS%reduction_xx(i,j))
+        str_xx(i,j,1) = (str_xx(i,j,1) + str_xx_GME(i,j)) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
 
       ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J)) * (hq(I,J,1) * CS%reduction_xy(I,J))
         enddo ; enddo
       else
         do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J,1)) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+          str_xy(I,J,1) = (str_xy(I,J,1) + str_xy_GME(I,J)) * (hq(I,J,1) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
         enddo ; enddo
       endif
 
@@ -2091,45 +2103,45 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
       ! This is the old formulation that includes energy diffusion
         FrictWork_GME(i,j,k) = GV%H_to_RZ * ( &
-                ((str_xx_GME(i,j,1)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-               - (str_xx_GME(i,j,1)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy_GME(I,J,1) *                              &
+                ((str_xx_GME(i,j)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+               - (str_xx_GME(i,j)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+              + 0.25*(( (str_xy_GME(I,J) *                              &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy_GME(I-1,J-1,1) *                          &
+                      + (str_xy_GME(I-1,J-1) *                          &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy_GME(I-1,J,1) *                            &
+                    + ( (str_xy_GME(I-1,J) *                            &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy_GME(I,J-1,1) *                            &
+                      + (str_xy_GME(I,J-1) *                            &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
         enddo ; enddo
       else ; do j=js,je ; do i=is,ie
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx_GME(i,j,1)*CS%dy2h(i,j) * ( &
+            ((str_xx_GME(i,j)*CS%dy2h(i,j) * ( &
                   (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                 - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) ) ) &
-           - (str_xx_GME(i,j,1)*CS%dx2h(i,j) * ( &
+           - (str_xx_GME(i,j)*CS%dx2h(i,j) * ( &
                   (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                 - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) ) )) &
-       + (0.25*(((str_xy_GME(I,J,1)*(                                     &
+       + (0.25*(((str_xy_GME(I,J)*(                                     &
                      (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,1)+h_neglect)) &
                                   - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect))))            &
                    + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,1)+h_neglect)) &
                                   - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)))) ))          &
-                +(str_xy_GME(I-1,J-1,1)*(                                 &
+                +(str_xy_GME(I-1,J-1)*(                                 &
                      (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect)) &
                                       - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,1)+h_neglect))))    &
                    + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,1)+h_neglect)) &
                                       - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,1)+h_neglect)))) )) ) &
-               +((str_xy_GME(I-1,J,1)*(                                   &
+               +((str_xy_GME(I-1,J)*(                                   &
                      (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,1)+h_neglect)) &
                                     - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,1)+h_neglect))))      &
                    + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,1)+h_neglect)) &
                                     - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,1)+h_neglect)))) ))        &
-                +(str_xy_GME(I,J-1,1)*(                                   &
+                +(str_xy_GME(I,J-1)*(                                   &
                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,1)+h_neglect)) &
                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,1)+h_neglect))))          &
                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,1)+h_neglect)) &
@@ -2236,10 +2248,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     if (CS%id_GME_coeff_h > 0) call post_data(CS%id_GME_coeff_h, GME_coeff_h, CS%diag)
     if (CS%id_GME_coeff_q > 0) call post_data(CS%id_GME_coeff_q, GME_coeff_q, CS%diag)
     if (CS%id_FrictWork_GME>0) call post_data(CS%id_FrictWork_GME, FrictWork_GME, CS%diag)
-    if (CS%id_dudx_bt > 0) call post_data(CS%id_dudx_bt, dudx_bt(:,:,1), CS%diag)
-    if (CS%id_dvdy_bt > 0) call post_data(CS%id_dvdy_bt, dvdy_bt(:,:,1), CS%diag)
-    if (CS%id_dudy_bt > 0) call post_data(CS%id_dudy_bt, dudy_bt(:,:,1), CS%diag)
-    if (CS%id_dvdx_bt > 0) call post_data(CS%id_dvdx_bt, dvdx_bt(:,:,1), CS%diag)
+    if (CS%id_dudx_bt > 0) call post_data(CS%id_dudx_bt, dudx_bt, CS%diag)
+    if (CS%id_dvdy_bt > 0) call post_data(CS%id_dvdy_bt, dvdy_bt, CS%diag)
+    if (CS%id_dudy_bt > 0) call post_data(CS%id_dudy_bt, dudy_bt, CS%diag)
+    if (CS%id_dvdx_bt > 0) call post_data(CS%id_dvdx_bt, dvdx_bt, CS%diag)
   endif
   if (CS%EY24_EBT_BS) then
     if (CS%id_visc_limit_h>0) call post_data(CS%id_visc_limit_h, visc_limit_h, CS%diag)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1043,9 +1043,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+        !$omp target update from(Kh)
+        do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j,kk) = VarMix%Res_fn_h(i,j) * Kh(i,j,kk)
-        enddo
+        enddo ; enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
       ! Place a floor on the viscosity, if desired.
@@ -1054,30 +1056,32 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
+        !$omp target update from(Kh)
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               k = kstart + kk - 1
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
-            enddo
+            enddo ; enddo ; enddo
           else
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh) DO_LOCALITY(local(k))
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               k = kstart + kk - 1
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
-            enddo
+            enddo ; enddo ; enddo
           endif
         else
           if (CS%res_scale_MEKE) then
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
-            enddo
+            enddo ; enddo ; enddo
           else
-            do concurrent (kk=1:kmax, j=js_Kh:je_Kh, i=is_Kh:ie_Kh)
+            do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j)
-            enddo
+            enddo ; enddo ; enddo
           endif
         endif
+        !$omp target update to(Kh)
       endif
 
       if (CS%anisotropic) then
@@ -1428,9 +1432,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
+        !$omp target update from(Kh)
+        do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J,kk) = VarMix%Res_fn_q(I,J) * Kh(I,J,kk)
-        enddo
+        enddo ; enddo ; enddo
+        !$omp target update to(Kh)
       endif
 
       do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq)
@@ -1438,8 +1444,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
+        !$omp target update from(Kh)
         if (use_kh_struct) then
-          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(k, meke_res_fn))
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
             k = kstart + kk - 1
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
@@ -1448,9 +1455,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                        (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
                                        ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
                                        (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
-          enddo
+          enddo ; enddo ; enddo
         else
-          do concurrent (kk=1:kmax, J=js-1:Jeq, I=is-1:Ieq) DO_LOCALITY(local(meke_res_fn))
+          do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
@@ -1458,8 +1465,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                 (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
                                        (MEKE%Ku(i+1,j) + &
                                         MEKE%Ku(i,j+1)) ) * meke_res_fn
-          enddo
+          enddo ; enddo ; enddo
         endif
+        !$omp target update to(Kh)
       endif
 
       if (CS%anisotropic) then


### PR DESCRIPTION
got claude to implement k blocking for horizontal viscosity. 

Needs input on how block size is passed into horizontal_viscosity.

## Timings

CPU flags: `ifort -O2 -qno-opt-dynamic-align -fp-model source`
GPU flags: `nvfortran -stdpar=gpu -O4 -Mnofma -Mnovect -mp=gpu -gpu=mem:separate,cc80,cuda12.9 -Minline=name:flux_elem,name:flux_elem_obc,name:ratio_max`
Tested on A100
<img width="820" height="480" alt="image" src="https://github.com/user-attachments/assets/ddc3ea7b-f339-47cd-a156-6e19ad9b5489" />
Note that there is a 15% slowdown in CPU. coradcalc k blocking doesn't have a cpu slowdown hence why I'm keeping the PRs separate. I'm not sure why there is a slowdown here. maybe because of the large no. of tmp arrays. 

the speedup on gpu is huge, but i understand that the 15% cpu slowdown is a problem, so I'm not expecting this to be merged until it's resolved. hence leaving as draft.