### PR TITLE
MOM_isopycnal_slopes.F90 refactor and GPU port

### DIFF
--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -136,11 +136,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
 
-  ! For now, push tv sub arrays to device
-  ! TODO: This should be done outside of this routine
-  !$omp target enter data map(to: h, tv%T, tv%S, e)
-  !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
-
   ! Allocate locals on device
   !$omp target enter data map(alloc: T, S)
 
@@ -217,6 +212,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     else
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, 1)
     endif
+    ! Bring T and S back from device
+    !$omp target update from(T, S)
   endif
 
   if ((use_EOS .and. allocated(tv%SpV_avg) .and. (tv%valid_SpV_halo < 1)) .and. &
@@ -586,11 +583,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   !$omp target exit data map(delete: GxSpV_u) if (present_N2_u .or. present(dzSxN))
   !$omp target exit data map(delete: GxSpV_v) if (present_N2_v .or. present(dzSyN))
-
-  ! For now, release tv types in subroutine
-  ! TODO: Move this outside of subroutine
-  !$omp target exit data map(release: h, tv%T, tv%S, e)
-  !$omp target exit data map(from: tv%SpV_avg) if (allocated(tv%SpV_avg))
 
   ! Delete locals from device
   !$omp target exit data map(delete: T, S)

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -293,7 +293,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! Push derivatives to device
   !$omp target enter data map(to: drho_dT, drho_dS)
-  !$omp target enter data map(to: drho_dT_dT_h) if (use_stanley)
+  ! UMW TODO: This transfer should only be happening if (use_stanely),
+  ! but for some reason that just causes per row transfers, so doing it unconditionally for now.
+  !$omp target enter data map(to: drho_dT_dT_h)
 
   !UMW: untested
   !$omp target enter data map(alloc: GxSpV_u) if (present_N2_u .or. present(dzSxN))
@@ -466,7 +468,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! Push derivatives to device
   !$omp target update to (drho_dT, drho_dS)
-  !$omp target update to (drho_dT_dT_h) if (use_stanley)
+  ! UMW TODO: This transfer should only be happening if (use_stanely),
+  ! but for some reason that just causes per row transfers, so doing it unconditionally for now
+  !$omp target update to (drho_dT_dT_h)
 
   !UMW: untested
   !$omp target enter data map(alloc: GxSpV_v) if (present_N2_v .or. present(dzSyN))
@@ -582,7 +586,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! Delete derivatives from device
   !$omp target exit data map(delete: drho_dT, drho_dS)
-  !$omp target exit data map(delete: drho_dT_dT_h) if (use_stanley)
+  !$omp target exit data map(delete: drho_dT_dT_h)
 
   !$omp target exit data map(delete: GxSpV_u) if (present_N2_u .or. present(dzSxN))
   !$omp target exit data map(delete: GxSpV_v) if (present_N2_v .or. present(dzSyN))

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -85,12 +85,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                     ! both u and v points [R C-1 ~> kg m-3 degC-1].
     drho_dS, &      ! The derivative of density with salinity calculated at
                     ! both u and v points [R S-1 ~> kg m-3 ppt-1].
-  !UMW TODO: Find better name for these variables
     drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
-    T_uvh, &        ! Array used to hold temperature at the u,v or h-points for derivative calculations[C ~> degC].
-    S_uvh, &        ! Array used to hold salinity at the u,v or h-points for derivative calculations[S ~> ppt].
+    T_uvh, &        ! Array used to hold temperature at the u,v or h-points for derivative calculations [C ~> degC].
+    S_uvh, &        ! Array used to hold salinity at the u,v or h-points for derivative calculations [S ~> ppt].
     GxSpV_uvh, &    ! Gravitiational acceleration times the specific volume at an interface
-                    ! at the u-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+                    ! at u and v points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
     pres_uvh        ! Array used to hold pressure on the interface at the u,v or h-points [R L2 T-2 ~> Pa].
   real :: drdiA, drdiB  ! Along layer zonal potential density  gradients in the layers above (A)
                         ! and below (B) the interface times the grid spacing [R ~> kg m-3].
@@ -235,7 +234,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     enddo
   enddo
 
-  ! UMW TODO: Merge with above once I figure out how I want to handle indexing
   do concurrent( I=is-1:ie, J=js-1:je, k=1:nz )
     GxSpV_uvh(I,J,k) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
@@ -254,13 +252,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
     ! UMW NOTE: Vibe-coded and untested.
-    ! Apply OBC overrides to T_uvh, S_uvh, and pres_uvh at u-points before the density
-    ! derivative calculation. At open boundary faces the EOS inputs must be one-sided
-    ! (using only the interior cell's T/S/P) rather than the two-cell average filled in
-    ! the do concurrent above. East-facing OBCs (OBC_DIRECTION_E) use the interior (i)
-    ! cell; west-facing OBCs (OBC_DIRECTION_W) use the exterior (i+1) cell. This loop
-    ! runs on the CPU since it requires access to OBC%segnum_u, a derived-type component
-    ! that is not mapped to the device.
     if (OBC_friendly) then
       ! East-facing open boundaries: interior cell is at i, so use pres/T/S(i,j,K)
       if (OBC%u_E_OBCs_on_PE) then
@@ -292,11 +283,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
     endif
 
-    ! Pre-fill GxSpV_uvh at u-points with the specific-volume-weighted buoyancy factor.
-    ! This four-cell average over layers k and k-1 on both sides i and i+1 of each u-face
-    ! replaces the G_Rho0 default set earlier. It is only needed when N2_u or dzSxN are
-    ! requested; otherwise GxSpV_uvh retains its G_Rho0 default throughout the slope loop.
-    ! Individual OBC faces will override their entries further inside the slope compute loop.
     if (present_N2_u .or. present(dzSxN)) then
       if (allocated(tv%SpV_avg)) then
         do concurrent( j = js:je , K = 2:nz, i = is-1:ie )
@@ -306,9 +292,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
     endif
 
-    ! calculate_density_derivs expects 1D slices over the i dimension. The loop over j and K
-    ! is necessary because EOSdom_u encodes a 1D index offset (shifted by IsdB-1) that maps
-    ! the SZIB_-based first dimension of T_uvh to the EOS routine's internal indexing.
     do j=js,je ; do k=nz,2,-1
       call calculate_density_derivs(T_uvh(:,j,k), S_uvh(:,j,k), pres_uvh(:,j,k), drho_dT(:,j,k), &
                                   drho_dS(:,j,k), tv%eqn_of_state, EOSdom_u)
@@ -327,8 +310,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
-      ! UMW: Currently doing this over i slices, for simplicity - will eventually combine
-      ! with above
       do j=js,je ; do K=nz,2,-1
         call calculate_density_second_derivs(T_uvh(:,j,K), S_uvh(:,j,K), pres_uvh(:,j,K), &
                    scrap, scrap, drho_dT_dT_h(:,j,K), scrap, scrap, &
@@ -347,8 +328,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !$omp target enter data map(to: drho_dT_dT_h)
 
   do concurrent( j=js:je , K=2:nz , I=is-1:ie ) local(drdkL, drdkR, drdiA, drdiB)
-    ! UMW: Since stanley parameterization requies EOS anyways, I'm putting
-    ! the use_stanley loop inside of the use_EOS loop for clarity
+    ! UMW: Since stanley parameterization requies EOS anyways, putting
+    ! the use_stanley loop inside of the use_EOS loop
     if (use_EOS) then
       ! Estimate the horizontal density gradients along layers.
       drdiA = drho_dT(I,j,K) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
@@ -402,15 +383,13 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ! which is an estimate of the gradient of density across geopotentials.
     if (present_N2_u) then
       if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
+        ! UMW NOTE: vibe-coded and untested.
         if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
           drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
         elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
           drdz = drdkR / dzaR
-          ! UMW NOTE: vibe-coded and untested.
-          ! OBC_DIRECTION_W: the interior cell is at i+1 but N2_u reads GxSpV_uvh(i,j,k),
-          ! so override the (i,j,k) entry using SpV_avg from i+1, not i+1 as the array index.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
         endif
@@ -480,11 +459,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
     ! UMW NOTE: Vibe-coded and untested.
-    ! Apply OBC overrides to T_uvh, S_uvh, and pres_uvh at v-points before the density
-    ! derivative calculation. Analogous to the zonal OBC block above: north-facing OBCs
-    ! (OBC_DIRECTION_N) use only the interior (j) cell's T/S/P; south-facing OBCs
-    ! (OBC_DIRECTION_S) use only the exterior (j+1) cell's T/S/P. This loop runs on
-    ! the CPU since it requires access to OBC%segnum_v.
     if (OBC_friendly) then
       ! North-facing open boundaries: interior cell is at j, so use pres/T/S(i,j,K)
       if (OBC%v_N_OBCs_on_PE) then
@@ -516,11 +490,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
     endif
 
-    ! Pre-fill GxSpV_uvh at v-points with the specific-volume-weighted buoyancy factor.
-    ! The v-face at J lies between h-rows j=J and j+1=J+1, so the four-cell average spans
-    ! both rows and both vertical layers (k and k-1). This differs from the u-point fill
-    ! above (which averaged over i and i+1). Individual OBC faces will override their
-    ! entries further inside the slope compute loop.
     if (present_N2_v .or. present(dzSyN)) then
       if (allocated(tv%SpV_avg)) then
         do concurrent( J = js-1:je, K = 2:nz, i = is:ie)
@@ -530,9 +499,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
     endif
 
-    ! As with the zonal loop, calculate_density_derivs is called with 1D J-slices because
-    ! EOSdom_v encodes a 1D i-offset. The J loop runs from js-1 to je to cover v-faces,
-    ! which are staggered one half-cell south of the h-point j-rows.
     do J=js-1,je ; do K=nz,2,-1
       call calculate_density_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), drho_dT(:,J,K), &
                                   drho_dS(:,J,K), tv%eqn_of_state, EOSdom_v)
@@ -551,9 +517,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
-      ! UMW: Currently doing this over i slices, for simplicity - will eventually combine
-      ! with above
-      ! UMW NOTE: changed J bounds to js-1:je+1 to account for extra J acces below
+      ! UMW NOTE: changed J bounds from js-1:je to js-1:je+1 to account for extra J access below
       ! when calculate drdj 
       do J=js-1,je+1 ; do K=nz,2,-1
         call calculate_density_second_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), &
@@ -628,15 +592,13 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ! which is an estimate of the gradient of density across geopotentials.
     if (present_N2_v) then
       if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
+        ! UMW NOTE: vibe-coded and untested.
         if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
           drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
         elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
           drdz = drdkL / dzaL
-          ! UMW NOTE: vibe-coded and untested.
-          ! OBC_DIRECTION_S: the interior cell is at j+1 but N2_v reads GxSpV_uvh(i,j,k),
-          ! so override the (i,j,k) entry using SpV_avg from j+1, not j+1 as the array index.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
         endif
@@ -684,11 +646,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   enddo ! end of meridional do concurrent
 
-  ! Delete derivatives from device
+  ! Delete variables from device
   !$omp target exit data map(delete: drho_dT, drho_dS)
   !$omp target exit data map(delete: drho_dT_dT_h)
-
-  ! Delete locals from device
   !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh)
 
 end subroutine calc_isoneutral_slopes

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -136,6 +136,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
 
+  ! For now, push tv sub arrays to device
+  ! TODO: This should be done outside of this routine
+  !$omp target enter data map(to: h, tv%T, tv%S, e)
+  !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
+
+  ! Allocate locals on device
+  !$omp target enter data map(alloc: T, S)
+
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
     EOSdom_h1(:) = EOS_domain(G%HI, halo=halo+1)
@@ -204,15 +212,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   endif
 
   if (use_EOS) then
-    !$omp target enter data map(to: h, tv%T, tv%S)
-    !$omp target enter data map(alloc: T, S)
     if (present(halo)) then
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, halo+1)
     else
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, 1)
     endif
-    !$omp target exit data map(from: T, S)
-    !$omp target exit data map(release: h, tv%T, tv%S)
   endif
 
   if ((use_EOS .and. allocated(tv%SpV_avg) .and. (tv%valid_SpV_halo < 1)) .and. &
@@ -262,7 +266,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ! UMW TODO: Add OBC and GxSpV logic
 
     ! Get density derivatives with i slices of T, S, and P at u points.
-    ! UMW TODO: Does this still have to be over I? 
+    ! UMW TODO: Does this still have to be over I?
     do j=js,je ; do k=nz,2,-1
       call calculate_density_derivs(T_uvh(:,j,k), S_uvh(:,j,k), pres_uvh(:,j,k), drho_dT(:,j,k), &
                                   drho_dS(:,j,k), tv%eqn_of_state, EOSdom_u)
@@ -294,7 +298,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
   endif
 
-  do j=js,je ; do K=nz,2,-1 ; do I=is-1,ie
+  ! Push derivatives to device
+  !$omp target enter data map(to: drho_dT, drho_dS)
+  !$omp target enter data map(to: drho_dT_dT_h) if (use_stanley)
+
+  !UMW: untested
+  !$omp target enter data map(alloc: GxSpV_u) if (present_N2_u .or. present(dzSxN))
+
+  do concurrent( j=js:je , K=nz:2 , I=is-1:ie )
     ! UMW: Since stanley parameterization requies EOS anyways, I'm putting
     ! the use_stanley loop inside of the use_EOS loop for clarity
     if (use_EOS) then
@@ -399,7 +410,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                                               + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
                       * abs(slope) * G%mask2dCu(I,j) ! x-direction contribution to S^2
 
-  enddo ; enddo ; enddo ! end of j-loop
+  enddo ! end of do zonal concurrent
 
   do i=is,ie
     GxSpV_v(i) = G_Rho0  !This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
@@ -456,7 +467,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
   endif
 
-  do J=js-1,je ; do K=nz,2,-1 ; do i=is,ie
+  ! Push derivatives to device
+  !$omp target update to (drho_dT, drho_dS)
+  !$omp target update to (drho_dT_dT_h) if (use_stanley)
+
+  !UMW: untested
+  !$omp target enter data map(alloc: GxSpV_v) if (present_N2_v .or. present(dzSyN))
+
+  do concurrent(J=js-1:je, K=nz:2, i=is:ie)
 
     if (use_EOS) then
       ! Estimate the horizontal density gradients along layers.
@@ -560,7 +578,22 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                                               + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
                       * abs(slope) * G%mask2dCv(i,J) ! x-direction contribution to S^2
 
-  enddo ; enddo ; enddo ! end of j-loop
+  enddo ! end of meridional do concurrent
+
+  ! Delete derivatives from device
+  !$omp target exit data map(delete: drho_dT, drho_dS)
+  !$omp target exit data map(delete: drho_dT_dT_h) if (use_stanley)
+
+  !$omp target exit data map(delete: GxSpV_u) if (present_N2_u .or. present(dzSxN))
+  !$omp target exit data map(delete: GxSpV_v) if (present_N2_v .or. present(dzSyN))
+
+  ! For now, release tv types in subroutine
+  ! TODO: Move this outside of subroutine
+  !$omp target exit data map(release: h, tv%T, tv%S, e)
+  !$omp target exit data map(from: tv%SpV_avg) if (allocated(tv%SpV_avg))
+
+  ! Delete locals from device
+  !$omp target exit data map(delete: T, S)
 
 end subroutine calc_isoneutral_slopes
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -247,7 +247,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! deferred EOS subroutines cannot be called on the GPU
   if (use_EOS) then
     ! Calculate density derivatives using T,S,and P at u points. 
-    do concurrent(j=js:je, K=nz:2, I=is-1:ie)
+    do concurrent(j=js:je, K=2:nz, I=is-1:ie)
       pres_uvh(I,j,K) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
       T_uvh(I,j,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
       S_uvh(I,j,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
@@ -267,7 +267,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     if (use_stanley) then
       ! Recalculate T, S, and press at h-points for the second derivative calculation.
-      do concurrent(j=js:je, K=nz:2, i=is-1:ie+1)
+      do concurrent(j=js:je, K=2:nz, i=is-1:ie+1)
         pres_uvh(i,j,K) = pres(i,j,K)
         T_uvh(i,j,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
         S_uvh(i,j,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
@@ -301,7 +301,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !UMW: untested
   !$omp target enter data map(alloc: GxSpV_u) if (present_N2_u .or. present(dzSxN))
 
-  do concurrent( j=js:je , K=nz:2 , I=is-1:ie )
+  do concurrent( j=js:je , K=2:nz , I=is-1:ie ) local(drdkL, drdkR, drdiA, drdiB)
     ! UMW: Since stanley parameterization requies EOS anyways, I'm putting
     ! the use_stanley loop inside of the use_EOS loop for clarity
     if (use_EOS) then
@@ -418,7 +418,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! meridional direciton
   if (use_EOS) then
     ! Calculate density derivatives using T,S,and P at v points. 
-    do concurrent(J=js-1:je, K=nz:2, i=is:ie)
+    do concurrent(J=js-1:je, K=2:nz, i=is:ie)
       pres_uvh(i,J,K) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
       T_uvh(i,J,K) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
       S_uvh(i,J,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
@@ -438,7 +438,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     if (use_stanley) then
       ! Recalculate T, S, and press at h-points for the second derivative calculation.
-      do concurrent(J=js-1:je, K=nz:2, i=is:ie)
+      do concurrent(J=js-1:je, K=2:nz, i=is:ie)
         pres_uvh(i,J,K) = pres(i,j,K)
         T_uvh(i,J,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
         S_uvh(i,J,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
@@ -476,7 +476,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !UMW: untested
   !$omp target enter data map(alloc: GxSpV_v) if (present_N2_v .or. present(dzSyN))
 
-  do concurrent(J=js-1:je, K=nz:2, i=is:ie)
+  do concurrent(J=js-1:je, K=2:nz, i=is:ie) local(drdkL, drdkR, drdjA, drdjB)
 
     if (use_EOS) then
       ! Estimate the horizontal density gradients along layers.

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -247,13 +247,65 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       S_uvh(I,j,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
     enddo
 
-    ! Bring T, S, and press back from device for density deriv calc
+    ! Bring T, S, and press back from device for deriv and OBC calcs
     !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
-    ! UMW TODO: Add OBC and GxSpV logic
+    ! UMW NOTE: Vibe-coded and untested.
+    ! Apply OBC overrides to T_uvh, S_uvh, and pres_uvh at u-points before the density
+    ! derivative calculation. At open boundary faces the EOS inputs must be one-sided
+    ! (using only the interior cell's T/S/P) rather than the two-cell average filled in
+    ! the do concurrent above. East-facing OBCs (OBC_DIRECTION_E) use the interior (i)
+    ! cell; west-facing OBCs (OBC_DIRECTION_W) use the exterior (i+1) cell. This loop
+    ! runs on the CPU since it requires access to OBC%segnum_u, a derived-type component
+    ! that is not mapped to the device.
+    if (OBC_friendly) then
+      ! East-facing open boundaries: interior cell is at i, so use pres/T/S(i,j,K)
+      if (OBC%u_E_OBCs_on_PE) then
+        do j = max(js, OBC%js_u_E_obc), min(je, OBC%je_u_E_obc)
+          do K = nz, 2, -1
+            do I = max(is-1, OBC%Is_u_E_obc), min(ie, OBC%Ie_u_E_obc)
+              if (OBC%segnum_u(I,j) > 0) then ! OBC_DIRECTION_E
+                pres_uvh(I,j,K) = pres(i,j,K)
+                T_uvh(I,j,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+                S_uvh(I,j,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+              endif
+            enddo
+          enddo
+        enddo
+      endif
+      ! West-facing open boundaries: interior cell is at i+1, so use pres/T/S(i+1,j,K)
+      if (OBC%u_W_OBCs_on_PE) then
+        do j = max(js, OBC%js_u_W_obc), min(je, OBC%je_u_W_obc)
+          do K = nz, 2, -1
+            do I = max(is-1, OBC%Is_u_W_obc), min(ie, OBC%Ie_u_W_obc)
+              if (OBC%segnum_u(I,j) < 0) then ! OBC_DIRECTION_W
+                pres_uvh(I,j,K) = pres(i+1,j,K)
+                T_uvh(I,j,K) = 0.5*(T(i+1,j,K) + T(i+1,j,K-1))
+                S_uvh(I,j,K) = 0.5*(S(i+1,j,K) + S(i+1,j,K-1))
+              endif
+            enddo
+          enddo
+        enddo
+      endif
+    endif
 
-    ! Get density derivatives with i slices of T, S, and P at u points.
-    ! UMW TODO: Does this still have to be over I?
+    ! Pre-fill GxSpV_uvh at u-points with the specific-volume-weighted buoyancy factor.
+    ! This four-cell average over layers k and k-1 on both sides i and i+1 of each u-face
+    ! replaces the G_Rho0 default set earlier. It is only needed when N2_u or dzSxN are
+    ! requested; otherwise GxSpV_uvh retains its G_Rho0 default throughout the slope loop.
+    ! Individual OBC faces will override their entries further inside the slope compute loop.
+    if (present_N2_u .or. present(dzSxN)) then
+      if (allocated(tv%SpV_avg)) then
+        do concurrent( j = js:je , K = 2:nz, i = is-1:ie )
+            GxSpV_uvh(i,j,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i+1,j,K)) + &
+                                                      (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i+1,j,K-1)))
+        enddo
+      endif
+    endif
+
+    ! calculate_density_derivs expects 1D slices over the i dimension. The loop over j and K
+    ! is necessary because EOSdom_u encodes a 1D index offset (shifted by IsdB-1) that maps
+    ! the SZIB_-based first dimension of T_uvh to the EOS routine's internal indexing.
     do j=js,je ; do k=nz,2,-1
       call calculate_density_derivs(T_uvh(:,j,k), S_uvh(:,j,k), pres_uvh(:,j,k), drho_dT(:,j,k), &
                                   drho_dS(:,j,k), tv%eqn_of_state, EOSdom_u)
@@ -353,6 +405,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
         elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
           drdz = drdkR / dzaR
+          ! UMW NOTE: vibe-coded and untested.
+          ! OBC_DIRECTION_W: the interior cell is at i+1 but N2_u reads GxSpV_uvh(i,j,k),
+          ! so override the (i,j,k) entry using SpV_avg from i+1, not i+1 as the array index.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
         endif
@@ -421,10 +476,60 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ! Bring T, S, and press back from device for density deriv calc
     !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
-    ! UMW TODO: Add OBC and GxSpV logic
+    ! UMW NOTE: Vibe-coded and untested.
+    ! Apply OBC overrides to T_uvh, S_uvh, and pres_uvh at v-points before the density
+    ! derivative calculation. Analogous to the zonal OBC block above: north-facing OBCs
+    ! (OBC_DIRECTION_N) use only the interior (j) cell's T/S/P; south-facing OBCs
+    ! (OBC_DIRECTION_S) use only the exterior (j+1) cell's T/S/P. This loop runs on
+    ! the CPU since it requires access to OBC%segnum_v.
+    if (OBC_friendly) then
+      ! North-facing open boundaries: interior cell is at j, so use pres/T/S(i,j,K)
+      if (OBC%v_N_OBCs_on_PE) then
+        do J = max(js-1, OBC%Js_v_N_obc), min(je, OBC%Je_v_N_obc)
+          do K = nz, 2, -1
+            do i = max(is, OBC%is_v_N_obc), min(ie, OBC%ie_v_N_obc)
+              if (OBC%segnum_v(i,J) > 0) then ! OBC_DIRECTION_N
+                pres_uvh(i,J,K) = pres(i,j,K)
+                T_uvh(i,J,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+                S_uvh(i,J,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+              endif
+            enddo
+          enddo
+        enddo
+      endif
+      ! South-facing open boundaries: interior cell is at j+1, so use pres/T/S(i,j+1,K)
+      if (OBC%v_S_OBCs_on_PE) then
+        do J = max(js-1, OBC%Js_v_S_obc), min(je, OBC%Je_v_S_obc)
+          do K = nz, 2, -1
+            do i = max(is, OBC%is_v_S_obc), min(ie, OBC%ie_v_S_obc)
+              if (OBC%segnum_v(i,J) < 0) then ! OBC_DIRECTION_S
+                pres_uvh(i,J,K) = pres(i,j+1,K)
+                T_uvh(i,J,K) = 0.5*(T(i,j+1,K) + T(i,j+1,K-1))
+                S_uvh(i,J,K) = 0.5*(S(i,j+1,K) + S(i,j+1,K-1))
+              endif
+            enddo
+          enddo
+        enddo
+      endif
+    endif
 
-    ! Get density derivatives with i slices of T, S, and P at u points.
-    ! UMW TODO: Does this still have to be over I? 
+    ! Pre-fill GxSpV_uvh at v-points with the specific-volume-weighted buoyancy factor.
+    ! The v-face at J lies between h-rows j=J and j+1=J+1, so the four-cell average spans
+    ! both rows and both vertical layers (k and k-1). This differs from the u-point fill
+    ! above (which averaged over i and i+1). Individual OBC faces will override their
+    ! entries further inside the slope compute loop.
+    if (present_N2_v .or. present(dzSyN)) then
+      if (allocated(tv%SpV_avg)) then
+        do concurrent( J = js-1:je, K = 2:nz, i = is:ie)
+            GxSpV_uvh(i,J,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i,j+1,K)) + &
+                                                      (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i,j+1,K-1)))
+        end do
+      endif
+    endif
+
+    ! As with the zonal loop, calculate_density_derivs is called with 1D J-slices because
+    ! EOSdom_v encodes a 1D i-offset. The J loop runs from js-1 to je to cover v-faces,
+    ! which are staggered one half-cell south of the h-point j-rows.
     do J=js-1,je ; do K=nz,2,-1
       call calculate_density_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), drho_dT(:,J,K), &
                                   drho_dS(:,J,K), tv%eqn_of_state, EOSdom_v)
@@ -526,6 +631,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
         elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
           drdz = drdkL / dzaL
+          ! UMW NOTE: vibe-coded and untested.
+          ! OBC_DIRECTION_S: the interior cell is at j+1 but N2_v reads GxSpV_uvh(i,j,k),
+          ! so override the (i,j,k) entry using SpV_avg from j+1, not j+1 as the array index.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
             GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
         endif

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -170,40 +170,40 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   present_N2_v = PRESENT(N2_v)
   G_Rho0 = GV%g_Earth / GV%Rho0
   if (present_N2_u) then
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       N2_u(I,j,1) = 0.
       N2_u(I,j,nz+1) = 0.
-    enddo ; enddo
+    enddo
   endif
   if (present_N2_v) then
-    do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie)
       N2_v(i,J,1) = 0.
       N2_v(i,J,nz+1) = 0.
-    enddo ; enddo
+    enddo
   endif
   if (present(dzu)) then
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       dzu(I,j,1) = 0.
       dzu(I,j,nz+1) = 0.
-    enddo ; enddo
+    enddo
   endif
   if (present(dzv)) then
-    do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie)
       dzv(i,J,1) = 0.
       dzv(i,J,nz+1) = 0.
-    enddo ; enddo
+    enddo
   endif
   if (present(dzSxN)) then
-    do j=js,je ; do I=is-1,ie
+    do concurrent (j=js:je, I=is-1:ie)
       dzSxN(I,j,1) = 0.
       dzSxN(I,j,nz+1) = 0.
-    enddo ; enddo
+    enddo
   endif
   if (present(dzSyN)) then
-    do J=js-1,je ; do i=is,ie
+    do concurrent (J=js-1:je, i=is:ie)
       dzSyN(i,J,1) = 0.
       dzSyN(i,J,nz+1) = 0.
-    enddo ; enddo
+    enddo
   endif
 
   if (use_EOS) then

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -80,24 +80,17 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                   ! inconsistent units of [R S-1 C-1 ~> kg m-3 degC-1 ppt-1], [R S-2 ~> kg m-3 ppt-2],
                   ! [T2 S-1 L-2 ~> kg m-3 ppt-1 Pa-1] and [T2 C-1 L-2 ~> kg m-3 degC-1 Pa-1].
   !UMW Test: Promote to 3d to factor out calculate_density_derivs() calls
-  !UMW TODO: What are the best indices to use for these new 3d arrays?
-  real, dimension(SZIB_(G)) :: GxSpV_u  ! Gravitational acceleration times the specific volume at an interface
-                  ! at the u-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
-  real, dimension(SZI_(G)) :: GxSpV_v  ! Gravitational acceleration times the specific volume at an interface
-                  ! at the v-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
   real, dimension(SZIB_(G), SZJB_(G), SZK_(GV)) :: &
-    drho_dT, &  ! The derivative of density with temperature calculated at  
-                ! both u and v points [R C-1 ~> kg m-3 degC-1].
-    drho_dS     ! The derivative of density with salinity calculated at
-                ! both u and v points [R S-1 ~> kg m-3 ppt-1].
+    drho_dT, &      ! The derivative of density with temperature calculated at  
+                    ! both u and v points [R C-1 ~> kg m-3 degC-1].
+    drho_dS, &      ! The derivative of density with salinity calculated at
+                    ! both u and v points [R S-1 ~> kg m-3 ppt-1].
   !UMW TODO: Find better name for these variables
-  real, dimension(SZIB_(G), SZJB_(G), SZK_(GV)) :: &
     drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
     T_uvh, &        ! Array used to hold temperature at the u,v or h-points for derivative calculations[C ~> degC].
     S_uvh, &        ! Array used to hold salinity at the u,v or h-points for derivative calculations[S ~> ppt].
-    ! UMW TODO: figure out best way to integrate this array. 
-    ! GxSpV_uvh, &    ! Gravitiational acceleration times the specific volume at an interface
-                  ! at the u-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+    GxSpV_uvh, &    ! Gravitiational acceleration times the specific volume at an interface
+                    ! at the u-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
     pres_uvh        ! Array used to hold pressure on the interface at the u,v or h-points [R L2 T-2 ~> Pa].
   real :: drdiA, drdiB  ! Along layer zonal potential density  gradients in the layers above (A)
                         ! and below (B) the interface times the grid spacing [R ~> kg m-3].
@@ -137,7 +130,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer :: i, j, k
 
   ! Allocate locals on device
-  !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh)
+  !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh)
 
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
@@ -239,8 +232,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       pres(i,j,k+1) = pres(i,j,k) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
   enddo
 
-  do I=is-1,ie
-    GxSpV_u(I) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
+  ! UMW TODO: Merge with above once I figure out how I want to handle indexing
+  do concurrent( I=is-1:ie, J=js-1:je, k=1:nz )
+    GxSpV_uvh(I,J,k) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
 
   ! Calculate density derviatves outside of slope calculation since
@@ -296,9 +290,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! UMW TODO: This transfer should only be happening if (use_stanely),
   ! but for some reason that just causes per row transfers, so doing it unconditionally for now.
   !$omp target enter data map(to: drho_dT_dT_h)
-
-  !UMW: untested
-  !$omp target enter data map(alloc: GxSpV_u) if (present_N2_u .or. present(dzSxN))
 
   do concurrent( j=js:je , K=2:nz , I=is-1:ie ) local(drdkL, drdkR, drdiA, drdiB)
     ! UMW: Since stanley parameterization requies EOS anyways, I'm putting
@@ -359,15 +350,15 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
           drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
         elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
           drdz = drdkR / dzaR
           if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
+            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
         endif
       endif ; endif
 
-      N2_u(I,j,K) = GxSpV_u(I) * drdz * G%mask2dCu(I,j) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
+      N2_u(I,j,K) = GxSpV_uvh(i,j,k) * drdz * G%mask2dCu(I,j) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
     endif
 
     if (use_EOS) then
@@ -404,14 +395,15 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     slope_x(I,j,K) = slope
     if (present(dzSxN)) &
-      dzSxN(I,j,K) = sqrt( GxSpV_u(I) * max(0., (wtL * ( dzaL * drdkL )) &
+      dzSxN(I,j,K) = sqrt( GxSpV_uvh(i,j,k) * max(0., (wtL * ( dzaL * drdkL )) &
                                               + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
                       * abs(slope) * G%mask2dCu(I,j) ! x-direction contribution to S^2
 
   enddo ! end of do zonal concurrent
 
-  do i=is,ie
-    GxSpV_v(i) = G_Rho0  !This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
+  !UMW TODO: Is this still necessary?
+  do concurrent( I=is-1:ie, J=js-1:je, k=1:nz )
+    GxSpV_uvh(I,J,k) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
   ! Calculate the meridional isopycnal slope.
 
@@ -472,9 +464,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! but for some reason that just causes per row transfers, so doing it unconditionally for now
   !$omp target update to (drho_dT_dT_h)
 
-  !UMW: untested
-  !$omp target enter data map(alloc: GxSpV_v) if (present_N2_v .or. present(dzSyN))
-
   do concurrent(J=js-1:je, K=2:nz, i=is:ie) local(drdkL, drdkR, drdjA, drdjB)
 
     if (use_EOS) then
@@ -534,15 +523,15 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
           drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
           if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
         elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
           drdz = drdkL / dzaL
           if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
+            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
         endif
       endif ; endif
 
-      N2_v(i,J,K) = GxSpV_v(i) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
+      N2_v(i,J,K) = GxSpV_uvh(i,j,k) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
     endif
 
     if (use_EOS) then
@@ -578,7 +567,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     endif
     slope_y(i,J,K) = slope
     if (present(dzSyN)) &
-      dzSyN(i,J,K) = sqrt( GxSpV_v(i) * max(0., (wtL * ( dzaL * drdkL )) &
+      dzSyN(i,J,K) = sqrt( GxSpV_uvh(i,j,k) * max(0., (wtL * ( dzaL * drdkL )) &
                                               + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
                       * abs(slope) * G%mask2dCv(i,J) ! x-direction contribution to S^2
 
@@ -588,11 +577,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !$omp target exit data map(delete: drho_dT, drho_dS)
   !$omp target exit data map(delete: drho_dT_dT_h)
 
-  !$omp target exit data map(delete: GxSpV_u) if (present_N2_u .or. present(dzSxN))
-  !$omp target exit data map(delete: GxSpV_v) if (present_N2_v .or. present(dzSyN))
-
   ! Delete locals from device
-  !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh)
+  !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh)
 
 end subroutine calc_isoneutral_slopes
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -288,10 +288,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     
     endif ! end use_stanley
 
-  ! If not using EOS, just set gradients to zero
-  else
-    drdiA = 0.0 ; drdiB = 0.0
-    drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
+  ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
 
   ! Push derivatives to device
@@ -325,6 +322,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         drdiB = drdiB + 0.5 * ((drho_dT_dT_h(i+1,j,K) * tv%varT(i+1,j,K)) - &
                               (drho_dT_dT_h(i,j,K) * tv%varT(i,j,K)) )
       endif
+    else ! .not. use_EOS: layers are constant density
+      drdiA = 0.0 ; drdiB = 0.0
+      drdkL = GV%Rlay(K)-GV%Rlay(K-1) ; drdkR = drdkL
     endif
 
     hg2A = h(i,j,k-1)*h(i+1,j,k-1) + h_neglect2
@@ -461,12 +461,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     
     endif ! end use_stanley
 
-  ! If not using EOS, just set gradients to zero
-  ! UMW TODO: I think I could technically remove this, since 
-  ! they were set above
-  else
-    drdiA = 0.0 ; drdiB = 0.0
-    drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
+  ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
 
   ! Push derivatives to device
@@ -500,6 +495,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         drdjB = drdjB + 0.5 * ((drho_dT_dT_h(i,J+1,K) * tv%varT(i,j+1,K)) - &
                               (drho_dT_dT_h(i,J,K) * tv%varT(i,j,K)) )
       endif
+    else ! .not. use_EOS: layers are constant density
+      drdjA = 0.0 ; drdjB = 0.0
+      drdkL = GV%Rlay(K)-GV%Rlay(K-1) ; drdkR = drdkL
     endif
 
     hg2A = h(i,j,k-1)*h(i,j+1,k-1) + h_neglect2

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -137,7 +137,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer :: i, j, k
 
   ! Allocate locals on device
-  !$omp target enter data map(alloc: T, S)
+  !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh)
 
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
@@ -212,8 +212,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     else
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, 1)
     endif
-    ! Bring T and S back from device
-    !$omp target update from(T, S)
   endif
 
   if ((use_EOS .and. allocated(tv%SpV_avg) .and. (tv%valid_SpV_halo < 1)) .and. &
@@ -229,21 +227,16 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! Find the maximum and minimum permitted streamfunction.
   if (associated(tv%p_surf)) then
-    !$OMP parallel do default(shared)
-    do j=js-1,je+1 ; do i=is-1,ie+1
+    do concurrent (j=js-1:je+1, i=is-1:ie+1)
       pres(i,j,1) = tv%p_surf(i,j)
-    enddo ; enddo
+    enddo
   else
-    !$OMP parallel do default(shared)
-    do j=js-1,je+1 ; do i=is-1,ie+1
+    do concurrent (j=js-1:je+1, i=is-1:ie+1)
       pres(i,j,1) = 0.0
-    enddo ; enddo
+    enddo
   endif
-  !$OMP parallel do default(shared)
-  do j=js-1,je+1
-    do k=1,nz ; do i=is-1,ie+1
-      pres(i,j,K+1) = pres(i,j,K) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
-    enddo ; enddo
+  do concurrent( j=js-1:je+1, k=1:nz, i=is-1:ie+1 )
+      pres(i,j,k+1) = pres(i,j,k) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
   enddo
 
   do I=is-1,ie
@@ -254,11 +247,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! deferred EOS subroutines cannot be called on the GPU
   if (use_EOS) then
     ! Calculate density derivatives using T,S,and P at u points. 
-    do j=js,je ; do K=nz,2,-1 ; do I=is-1,ie
+    do concurrent(j=js:je, K=nz:2, I=is-1:ie)
       pres_uvh(I,j,K) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
       T_uvh(I,j,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
       S_uvh(I,j,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
-    enddo ; enddo ; enddo
+    enddo
+
+    ! Bring T, S, and press back from device for density deriv calc
+    !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
     ! UMW TODO: Add OBC and GxSpV logic
 
@@ -271,11 +267,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     if (use_stanley) then
       ! Recalculate T, S, and press at h-points for the second derivative calculation.
-      do j=js,je ; do K=nz,2,-1 ; do i=is-1,ie+1
+      do concurrent(j=js:je, K=nz:2, i=is-1:ie+1)
         pres_uvh(i,j,K) = pres(i,j,K)
         T_uvh(i,j,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
         S_uvh(i,j,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
-      enddo ; enddo ; enddo
+      enddo
+
+      ! Bring T, S, and press back from device for density deriv calc
+      !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
@@ -419,11 +418,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! meridional direciton
   if (use_EOS) then
     ! Calculate density derivatives using T,S,and P at v points. 
-    do J=js-1,je ; do K=nz,2,-1 ; do i=is,ie
+    do concurrent(J=js-1:je, K=nz:2, i=is:ie)
       pres_uvh(i,J,K) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
       T_uvh(i,J,K) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
       S_uvh(i,J,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
-    enddo ; enddo ; enddo
+    enddo
+
+    ! Bring T, S, and press back from device for density deriv calc
+    !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
     ! UMW TODO: Add OBC and GxSpV logic
 
@@ -436,11 +438,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     if (use_stanley) then
       ! Recalculate T, S, and press at h-points for the second derivative calculation.
-      do J=js-1,je ; do K=nz,2,-1 ; do i=is,ie
+      do concurrent(J=js-1:je, K=nz:2, i=is:ie)
         pres_uvh(i,J,K) = pres(i,j,K)
         T_uvh(i,J,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
         S_uvh(i,J,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
-      enddo ; enddo ; enddo
+      enddo
+
+      ! Bring T, S, and press back from device for density deriv calc
+      !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
@@ -585,7 +590,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !$omp target exit data map(delete: GxSpV_v) if (present_N2_v .or. present(dzSyN))
 
   ! Delete locals from device
-  !$omp target exit data map(delete: T, S)
+  !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh)
 
 end subroutine calc_isoneutral_slopes
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -228,8 +228,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       pres(i,j,1) = 0.0
     enddo
   endif
-  do concurrent( j=js-1:je+1, k=1:nz, i=is-1:ie+1 )
-      pres(i,j,k+1) = pres(i,j,k) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
+  ! UMW NOTE: K must be serial
+  do concurrent( j=js-1:je+1, i=is-1:ie+1 )
+    do k=1,nz
+      pres(i,j,K+1) = pres(i,j,K) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
+    enddo
   enddo
 
   ! UMW TODO: Merge with above once I figure out how I want to handle indexing

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -129,7 +129,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer :: i, j, k
 
   ! Allocate locals on device
-  !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh)
+  !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
+  !$omp & scrap, drho_dT, drho_dS, drho_dT_dT_h)
 
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
@@ -250,11 +251,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       S_uvh(I,j,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
     enddo
 
-    ! Bring T, S, and press back from device for deriv and OBC calcs
-    !$omp target update from(T_uvh, S_uvh, pres_uvh)
-
     ! UMW NOTE: Vibe-coded and untested.
     if (OBC_friendly) then
+      ! Bring T, S, and press back from device for OBC calcs
+      !$omp target update from(T_uvh, S_uvh, pres_uvh)
+
       ! East-facing open boundaries: interior cell is at i, so use pres/T/S(i,j,K)
       if (OBC%u_E_OBCs_on_PE) then
         do j = max(js, OBC%js_u_E_obc), min(je, OBC%je_u_E_obc)
@@ -283,6 +284,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           enddo
         enddo
       endif
+
+      !$omp target update to(T_uvh, S_uvh, pres_uvh)
     endif
 
     if (present_N2_u .or. present(dzSxN)) then
@@ -307,9 +310,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         S_uvh(i,j,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
       enddo
 
-      ! Bring T, S, and press back from device for density deriv calc
-      !$omp target update from(T_uvh, S_uvh, pres_uvh)
-
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
       do j=js,je ; do K=nz,2,-1
@@ -322,12 +322,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
-
-  ! Push derivatives to device
-  !$omp target enter data map(to: drho_dT, drho_dS)
-  ! UMW TODO: This transfer should only be happening if (use_stanely),
-  ! but for some reason that just causes per row transfers, so doing it unconditionally for now.
-  !$omp target enter data map(to: drho_dT_dT_h)
 
   do concurrent( j=js:je , K=2:nz , I=is-1:ie ) local(drdkL, drdkR, drdiA, drdiB)
     ! UMW: Since stanley parameterization requies EOS anyways, putting
@@ -457,11 +451,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       S_uvh(i,J,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
     enddo
 
-    ! Bring T, S, and press back from device for density deriv calc
-    !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
     ! UMW NOTE: Vibe-coded and untested.
     if (OBC_friendly) then
+      ! Bring T, S, and press back from device for OBC calc
+      !$omp target update from(T_uvh, S_uvh, pres_uvh)
+
       ! North-facing open boundaries: interior cell is at j, so use pres/T/S(i,j,K)
       if (OBC%v_N_OBCs_on_PE) then
         do J = max(js-1, OBC%Js_v_N_obc), min(je, OBC%Je_v_N_obc)
@@ -490,6 +485,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           enddo
         enddo
       endif
+
+      !$omp target update to(T_uvh, S_uvh, pres_uvh)
     endif
 
     if (present_N2_v .or. present(dzSyN)) then
@@ -514,9 +511,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         S_uvh(i,J,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
       enddo
 
-      ! Bring T, S, and press back from device for density deriv calc
-      !$omp target update from(T_uvh, S_uvh, pres_uvh)
-
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
       ! UMW NOTE: changed J bounds from js-1:je to js-1:je+1 to account for extra J access below
@@ -531,12 +525,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
-
-  ! Push derivatives to device
-  !$omp target update to (drho_dT, drho_dS)
-  ! UMW TODO: This transfer should only be happening if (use_stanely),
-  ! but for some reason that just causes per row transfers, so doing it unconditionally for now
-  !$omp target update to (drho_dT_dT_h)
 
   do concurrent(J=js-1:je, K=2:nz, i=is:ie) local(drdkL, drdkR, drdjA, drdjB)
 
@@ -649,7 +637,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   enddo ! end of meridional do concurrent
 
   ! Delete variables from device
-  !$omp target exit data map(delete: drho_dT, drho_dS)
+  !$omp target exit data map(delete: drho_dT, drho_dS, scrap)
   !$omp target exit data map(delete: drho_dT_dT_h)
   !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh)
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -701,7 +701,7 @@ subroutine vert_fill_TS(h, T_in, S_in, kappa_dt, T_f, S_f, G, GV, US, halo_here,
       T_f(i,j,k) = T_in(i,j,k) ; S_f(i,j,k) = S_in(i,j,k)
     enddo
   else
-    !$omp target teams distribute parallel do private( ent, b1, d1, c1 )
+    !$omp target teams loop private( ent, b1, d1, c1 )
     do j=js,je
       do concurrent( i=is:ie )
         ent(i,2) = kap_dt_x2 / ((h(i,j,1)+h(i,j,2)) + h0)

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -22,6 +22,12 @@ implicit none ; private
 
 public calc_isoneutral_slopes, vert_fill_TS
 
+! Default tile sizes for loop blocking. For CPU runs these small values improve cache reuse
+! by working over small sub-domains at a time. For GPU runs, calc_isoneutral_slopes overrides
+! these to cover the full computational domain in a single tile (see niblock/njblock below).
+integer, parameter :: default_niblock = 32 !< Default i-direction loop-tile size [nondim].
+integer, parameter :: default_njblock = 4  !< Default j-direction loop-tile size [nondim].
+
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
 ! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
@@ -76,22 +82,21 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                   ! in massless layers filled vertically by diffusion.
   real, dimension(SZI_(G), SZJ_(G),SZK_(GV)+1) :: &
     pres          ! The pressure at an interface [R L2 T-2 ~> Pa].
-  real, dimension(SZI_(G)) :: scrap ! An array to pass to calculate_density_second_derivs() that is
-                  ! set there but will be ignored, it is used simultaneously with four different
-                  ! inconsistent units of [R S-1 C-1 ~> kg m-3 degC-1 ppt-1], [R S-2 ~> kg m-3 ppt-2],
-                  ! [T2 S-1 L-2 ~> kg m-3 ppt-1 Pa-1] and [T2 C-1 L-2 ~> kg m-3 degC-1 Pa-1].
-  !UMW Test: Promote to 3d to factor out calculate_density_derivs() calls
-  real, dimension(SZIB_(G), SZJB_(G), SZK_(GV)) :: &
-    drho_dT, &      ! The derivative of density with temperature calculated at
-                    ! both u and v points [R C-1 ~> kg m-3 degC-1].
-    drho_dS, &      ! The derivative of density with salinity calculated at
-                    ! both u and v points [R S-1 ~> kg m-3 ppt-1].
+
+  ! Tiled work arrays. First and second dimensions use niblock+1 / njblock+1 so that
+  ! the Stanley h-point fills (which need one extra column/row beyond the u/v tile extent)
+  ! fit without a separate buffer. drho_dT and drho_dS only ever need niblock x njblock,
+  ! but are dimensioned +1 for alignment with the rest.
+  real, dimension(niblock+1, njblock+1, SZK_(GV)) :: &
+    drho_dT, &      ! The derivative of density with temperature [R C-1 ~> kg m-3 degC-1].
+    drho_dS, &      ! The derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
     drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
-    T_uvh, &        ! Array used to hold temperature at the u,v or h-points for derivative calculations [C ~> degC].
-    S_uvh, &        ! Array used to hold salinity at the u,v or h-points for derivative calculations [S ~> ppt].
-    GxSpV_uvh, &    ! Gravitiational acceleration times the specific volume at an interface
-                    ! at u and v points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
-    pres_uvh        ! Array used to hold pressure on the interface at the u,v or h-points [R L2 T-2 ~> Pa].
+    T_uvh, &        ! Temperature at the u, v or h-points for derivative calculations [C ~> degC].
+    S_uvh, &        ! Salinity at the u, v or h-points for derivative calculations [S ~> ppt].
+    GxSpV_uvh, &    ! g * specific volume at u/v-point interfaces [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+    pres_uvh        ! Pressure at the u, v or h-points [R L2 T-2 ~> Pa].
+  real, dimension(niblock+1) :: scrap ! Ignored output from calculate_density_second_derivs()
+
   real :: drdiA, drdiB  ! Along layer zonal potential density  gradients in the layers above (A)
                         ! and below (B) the interface times the grid spacing [R ~> kg m-3].
   real :: drdjA, drdjB  ! Along layer meridional potential density  gradients in the layers above (A)
@@ -122,10 +127,15 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                         ! be used to calculate N2 at OBC faces.
   integer, dimension(2) :: EOSdom_h1 ! The shifted i-computational domain to use for equation of
                                      ! state calculations at h points with 1 extra halo point
-  integer, dimension(2,2) :: EOSdom  ! The shifted i- and j-computational domains to use for equation
-                                     ! of state calculations at u and v points
+  integer, dimension(2) :: EOSdom_tile   !< 1-based EOS domain for the current tile [nondim].
+  integer, dimension(2) :: EOSdom_tile_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
+  integer :: niblock_loc  !< i-direction tile size for the current subroutine call [nondim].
+  integer :: njblock_loc  !< j-direction tile size for the current subroutine call [nondim].
+  integer :: istart, iend !< First and last global i (or I) indices of the current tile [nondim].
+  integer :: jstart, jend !< First and last global j (or J) indices of the current tile [nondim].
+  integer :: ii, jj       !< Tile-local 1-based i and j indices [nondim].
 
   ! Allocate locals on device
   !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
@@ -144,6 +154,16 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   nz = GV%ke ; IsdB = G%IsdB
 
+  ! Set tile sizes. On CPU, use the module defaults (small tiles for cache locality).
+  ! On GPU, override to the full computational domain so the entire domain is processed
+  ! in a single tile, maximising parallelism. The zonal pass uses I=is-1:ie (extent
+  ! ie-is+2) and the meridional pass uses J=js-1:je (extent je-js+2); using these as
+  ! niblock_loc/njblock_loc ensures a single tile covers each pass on the GPU.
+  niblock_loc = default_niblock ; njblock_loc = default_njblock
+  !$ if (omp_get_num_devices() > 0) then
+  !$   niblock_loc = ie - is + 2  ! = (ie) - (is-1) + 1: covers I=is-1:ie in one tile
+  !$   njblock_loc = je - js + 2  ! = (je) - (js-1) + 1: covers J=js-1:je in one tile
+  !$ endif
 
   h_neglect = GV%H_subroundoff ; h_neglect2 = h_neglect**2
   dz_neglect = GV%dZ_subroundoff
@@ -205,6 +225,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     else
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, 1)
     endif
+#ifdef DEBUG
+    !$omp target update from(T, S)
+    call hchksum(T, "calc_isoneutral_slopes: T after vert_fill", G%HI)
+    call hchksum(S, "calc_isoneutral_slopes: S after vert_fill", G%HI)
+#endif
   endif
 
   if ((use_EOS .and. allocated(tv%SpV_avg) .and. (tv%valid_SpV_halo < 1)) .and. &
@@ -237,422 +262,412 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     enddo
   enddo
 
-  do concurrent( I=is-1:ie, J=js-1:je, k=1:nz )
-    GxSpV_uvh(I,J,k) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
-  enddo
+  ! ============================================================
+  ! Zonal tiling loop: compute zonal isopycnal slopes
+  ! ============================================================
+  ! Outer loop tiles the (I=is-1:ie, j=js:je) domain into niblock_loc x njblock_loc patches.
+  ! Within each tile:
+  !   1. Fill tile-sized T_uvh/S_uvh/pres_uvh at u-points on device (do concurrent).
+  !   2. Transfer tile arrays to host (target update from) for CPU-only EOS calls.
+  !   3. Apply OBC overrides (CPU, host-side OBC derived types).
+  !   4. Pre-fill GxSpV_uvh at u-points.
+  !   5. Call calculate_density_derivs over tile.
+  !   6. If use_stanley: refill at h-points, call calculate_density_second_derivs.
+  !   7. Transfer derivatives to device (target update to).
+  !   8. Compute slopes in do concurrent using tile-local indices.
+  do jstart=js, je, njblock_loc ; do istart=is-1, ie, niblock_loc
+    iend = min(istart + niblock_loc - 1, ie)
+    jend = min(jstart + njblock_loc - 1, je)
+    EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
 
-  ! Calculate density derviatves outside of slope calculation since
-  ! deferred EOS subroutines cannot be called on the GPU
-  if (use_EOS) then
-    ! Calculate density derivatives using T,S,and P at u points.
-    do concurrent(j=js:je, K=2:nz, I=is-1:ie)
-      pres_uvh(I,j,K) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
-      T_uvh(I,j,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
-      S_uvh(I,j,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
+    ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
+    ! non-Boussinesq SpV_avg is available.
+    do concurrent( jj=1:jend-jstart+1, k=1:nz, ii=1:iend-istart+1 )
+      GxSpV_uvh(ii,jj,k) = G_Rho0
     enddo
 
-    ! UMW NOTE: Vibe-coded and untested.
-    if (OBC_friendly) then
-      ! Bring T, S, and press back from device for OBC calcs
-      !$omp target update from(T_uvh, S_uvh, pres_uvh)
-
-      ! East-facing open boundaries: interior cell is at i, so use pres/T/S(i,j,K)
-      if (OBC%u_E_OBCs_on_PE) then
-        do j = max(js, OBC%js_u_E_obc), min(je, OBC%je_u_E_obc)
-          do K = nz, 2, -1
-            do I = max(is-1, OBC%Is_u_E_obc), min(ie, OBC%Ie_u_E_obc)
-              if (OBC%segnum_u(I,j) > 0) then ! OBC_DIRECTION_E
-                pres_uvh(I,j,K) = pres(i,j,K)
-                T_uvh(I,j,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-                S_uvh(I,j,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
-              endif
-            enddo
-          enddo
-        enddo
-      endif
-      ! West-facing open boundaries: interior cell is at i+1, so use pres/T/S(i+1,j,K)
-      if (OBC%u_W_OBCs_on_PE) then
-        do j = max(js, OBC%js_u_W_obc), min(je, OBC%je_u_W_obc)
-          do K = nz, 2, -1
-            do I = max(is-1, OBC%Is_u_W_obc), min(ie, OBC%Ie_u_W_obc)
-              if (OBC%segnum_u(I,j) < 0) then ! OBC_DIRECTION_W
-                pres_uvh(I,j,K) = pres(i+1,j,K)
-                T_uvh(I,j,K) = 0.5*(T(i+1,j,K) + T(i+1,j,K-1))
-                S_uvh(I,j,K) = 0.5*(S(i+1,j,K) + S(i+1,j,K-1))
-              endif
-            enddo
-          enddo
-        enddo
-      endif
-
-      !$omp target update to(T_uvh, S_uvh, pres_uvh)
-    endif
-
-    if (present_N2_u .or. present(dzSxN)) then
-      if (allocated(tv%SpV_avg)) then
-        do concurrent( j = js:je , K = 2:nz, i = is-1:ie )
-            GxSpV_uvh(i,j,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i+1,j,K)) + &
-                                                      (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i+1,j,K-1)))
-        enddo
-      endif
-    endif
-
-    do k=nz,2,-1
-      call calculate_density_derivs(T_uvh(:,:,k), S_uvh(:,:,k), pres_uvh(:,:,k), drho_dT(:,:,k), &
-                                  drho_dS(:,:,k), tv%eqn_of_state, EOSdom)
-    enddo
-
-    if (use_stanley) then
-      ! Recalculate T, S, and press at h-points for the second derivative calculation.
-      do concurrent(j=js:je, K=2:nz, i=is-1:ie+1)
-        pres_uvh(i,j,K) = pres(i,j,K)
-        T_uvh(i,j,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-        S_uvh(i,j,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+    if (use_EOS) then
+      ! Fill tile T_uvh/S_uvh/pres_uvh at u-points (u-face = average of i and i+1)
+      do concurrent(jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1)
+        i = istart + ii - 1  ! global I (u-face index)
+        j = jstart + jj - 1  ! global j
+        pres_uvh(ii,jj,K) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
+        T_uvh(ii,jj,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
+        S_uvh(ii,jj,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
       enddo
 
-      ! The second line below would correspond to arguments
-      !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
-      do j=js,je ; do K=nz,2,-1
-        ! UMW TODO: Implement 2d version of this subroutine
-        call calculate_density_second_derivs(T_uvh(:,j,K), S_uvh(:,j,K), pres_uvh(:,j,K), &
-                   scrap, scrap, drho_dT_dT_h(:,j,K), scrap, scrap, &
-                   tv%eqn_of_state, dom=EOSdom_h1)
-      enddo ; enddo
-
-    endif ! end use_stanley
-
-  ! If not using EOS, gradients are handled inside the do concurrent loop below
-  endif
-
-  do concurrent( j=js:je , K=2:nz , I=is-1:ie ) DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB)) &
-                                                DO_LOCALITY(local(hg2A, hg2B, hg2L, hg2R, haA, haB, haL, haR)) &
-                                                DO_LOCALITY(local(dzaL, dzaR, wtA, wtB, wtL, wtR, drdx, drdz)) &
-                                                DO_LOCALITY(local(slope, mag_grad2))
-    ! UMW: Since stanley parameterization requies EOS anyways, putting
-    ! the use_stanley loop inside of the use_EOS loop
-    if (use_EOS) then
-      ! Estimate the horizontal density gradients along layers.
-      drdiA = drho_dT(I,j,K) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
-              drho_dS(I,j,K) * (S(i+1,j,k-1)-S(i,j,k-1))
-      drdiB = drho_dT(I,j,K) * (T(i+1,j,k)-T(i,j,k)) + &
-              drho_dS(I,j,K) * (S(i+1,j,k)-S(i,j,k))
-
-      ! Estimate the vertical density gradients times the grid spacing.
-      drdkL = (drho_dT(I,j,K) * (T(i,j,k)-T(i,j,k-1)) + &
-                drho_dS(I,j,K) * (S(i,j,k)-S(i,j,k-1)))
-      drdkR = (drho_dT(I,j,K) * (T(i+1,j,k)-T(i+1,j,k-1)) + &
-                drho_dS(I,j,K) * (S(i+1,j,k)-S(i+1,j,k-1)))
-
-      if (use_stanley) then
-        ! Correction to the horizontal density gradient due to nonlinearity in
-        ! the EOS rectifying SGS temperature anomalies
-        drdiA = drdiA + 0.5 * ((drho_dT_dT_h(i+1,j,K) * tv%varT(i+1,j,K-1)) - &
-                              (drho_dT_dT_h(i,j,K) * tv%varT(i,j,K-1)) )
-        drdiB = drdiB + 0.5 * ((drho_dT_dT_h(i+1,j,K) * tv%varT(i+1,j,K)) - &
-                              (drho_dT_dT_h(i,j,K) * tv%varT(i,j,K)) )
-      endif
-    else ! .not. use_EOS: layers are constant density
-      drdiA = 0.0 ; drdiB = 0.0
-      drdkL = GV%Rlay(K)-GV%Rlay(K-1) ; drdkR = drdkL
-    endif
-
-    hg2A = h(i,j,k-1)*h(i+1,j,k-1) + h_neglect2
-    hg2B = h(i,j,k)*h(i+1,j,k) + h_neglect2
-    hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
-    hg2R = h(i+1,j,k-1)*h(i+1,j,k) + h_neglect2
-    haA = 0.5*(h(i,j,k-1) + h(i+1,j,k-1)) + h_neglect
-    haB = 0.5*(h(i,j,k) + h(i+1,j,k)) + h_neglect
-    haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
-    haR = 0.5*(h(i+1,j,k-1) + h(i+1,j,k)) + h_neglect
-    if (GV%Boussinesq) then
-      dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
-    else
-      dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
-      dzaR = 0.5*(e(i+1,j,K-1) - e(i+1,j,K+1)) + dz_neglect
-    endif
-    if (present(dzu)) dzu(I,j,K) = 0.5*( dzaL + dzaR )
-    ! Use the harmonic mean thicknesses to weight the horizontal gradients.
-    ! These unnormalized weights have been rearranged to minimize divisions.
-    wtA = hg2A*haB ; wtB = hg2B*haA
-    wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
-
-    drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
-    ! The expression for drdz above is mathematically equivalent to:
-    !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
-    !          ((hg2L/haL) + (hg2R/haR))
-    ! which is an estimate of the gradient of density across geopotentials.
-    if (present_N2_u) then
-      if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
-        ! UMW NOTE: vibe-coded and untested.
-        if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
-          drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
-          if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
-        elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
-          drdz = drdkR / dzaR
-          if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
-        endif
-      endif ; endif
-
-      N2_u(I,j,K) = GxSpV_uvh(i,j,k) * drdz * G%mask2dCu(I,j) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
-    endif
-
-    if (use_EOS) then
-      drdx = ((wtA * drdiA + wtB * drdiB) / (wtA + wtB) - &
-              drdz * (e(i,j,K)-e(i+1,j,K))) * G%IdxCu(I,j)
-
-      ! This estimate of slope is accurate for small slopes, but bounded
-      ! to be between -1 and 1.
-      mag_grad2 = (US%Z_to_L*drdx)**2 + drdz**2
-      if (mag_grad2 > 0.0) then
-        slope = drdx / sqrt(mag_grad2)
-      else ! Just in case mag_grad2 = 0 ever.
-        slope = 0.0
-      endif
-    else ! With .not.use_EOS, the layers are constant density.
-      slope = (e(i+1,j,K)-e(i,j,K)) * G%IdxCu(I,j)
-    endif
-
-    if (local_open_u_BC) then
-      if (OBC%segnum_u(I,j) /= 0) then
-        if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
-          slope = 0.
-          ! This and/or the masking code below is to make slopes match inside
-          ! land mask. Might not be necessary except for DEBUG output.
-!           if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
-!             slope_x(I+1,j,K) = 0.
-!           else
-!             slope_x(I-1,j,K) = 0.
-!           endif
-        endif
-      endif
-      slope = slope * max(G%mask2dT(i,j), G%mask2dT(i+1,j))
-    endif
-
-    slope_x(I,j,K) = slope
-    if (present(dzSxN)) &
-      dzSxN(I,j,K) = sqrt( GxSpV_uvh(i,j,k) * max(0., (wtL * ( dzaL * drdkL )) &
-                                              + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
-                      * abs(slope) * G%mask2dCu(I,j) ! x-direction contribution to S^2
-
-  enddo ! end of do zonal concurrent
-
-  !UMW TODO: Is this still necessary?
-  do concurrent( I=is-1:ie, J=js-1:je, k=1:nz )
-    GxSpV_uvh(I,J,k) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
-  enddo
-
-  ! Calculate the meridional isopycnal slope.
-  ! For meridional loop: v-points for j, tracer points for i
-  EOSdom(1,1) = is - (G%IsdB-1) ; EOSdom(1,2) = ie - (G%IsdB-1)
-  EOSdom(2,1) = js-1 - (G%Jsdb-1) ; EOSdom(2,2) = je - (G%Jsdb-1)
-
-
-  ! As before, calculate density derviatves outside of slope calculation since
-  ! deferred EOS subroutines cannot be called on the GPU, but this time in the
-  ! meridional direciton
-  if (use_EOS) then
-    ! Calculate density derivatives using T,S,and P at v points.
-    do concurrent(J=js-1:je, K=2:nz, i=is:ie)
-      pres_uvh(i,J,K) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
-      T_uvh(i,J,K) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
-      S_uvh(i,J,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
-    enddo
-
-
-    ! UMW NOTE: Vibe-coded and untested.
-    if (OBC_friendly) then
-      ! Bring T, S, and press back from device for OBC calc
+      ! Transfer tile arrays from device to host for CPU-only EOS and OBC operations
       !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
-      ! North-facing open boundaries: interior cell is at j, so use pres/T/S(i,j,K)
-      if (OBC%v_N_OBCs_on_PE) then
-        do J = max(js-1, OBC%Js_v_N_obc), min(je, OBC%Je_v_N_obc)
-          do K = nz, 2, -1
-            do i = max(is, OBC%is_v_N_obc), min(ie, OBC%ie_v_N_obc)
-              if (OBC%segnum_v(i,J) > 0) then ! OBC_DIRECTION_N
-                pres_uvh(i,J,K) = pres(i,j,K)
-                T_uvh(i,J,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-                S_uvh(i,J,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
-              endif
+      ! Apply OBC overrides: at open boundary faces use only the interior cell's T/S/P
+      ! rather than the two-cell average computed above. Runs on CPU because it requires
+      ! access to OBC%segnum_u, a derived-type component not mapped to the device.
+      if (OBC_friendly) then
+        ! East-facing open boundaries: interior cell is at i (=istart+ii-1), use pres/T/S(i,j,K)
+        if (OBC%u_E_OBCs_on_PE) then
+          do j = max(jstart, OBC%js_u_E_obc), min(jend, OBC%je_u_E_obc)
+            jj = j - jstart + 1
+            do K = nz, 2, -1
+              do i = max(istart, OBC%Is_u_E_obc), min(iend, OBC%Ie_u_E_obc)
+                ii = i - istart + 1
+                if (OBC%segnum_u(i,j) > 0) then ! OBC_DIRECTION_E
+                  pres_uvh(ii,jj,K) = pres(i,j,K)
+                  T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+                  S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+                endif
+              enddo
             enddo
           enddo
-        enddo
-      endif
-      ! South-facing open boundaries: interior cell is at j+1, so use pres/T/S(i,j+1,K)
-      if (OBC%v_S_OBCs_on_PE) then
-        do J = max(js-1, OBC%Js_v_S_obc), min(je, OBC%Je_v_S_obc)
-          do K = nz, 2, -1
-            do i = max(is, OBC%is_v_S_obc), min(ie, OBC%ie_v_S_obc)
-              if (OBC%segnum_v(i,J) < 0) then ! OBC_DIRECTION_S
-                pres_uvh(i,J,K) = pres(i,j+1,K)
-                T_uvh(i,J,K) = 0.5*(T(i,j+1,K) + T(i,j+1,K-1))
-                S_uvh(i,J,K) = 0.5*(S(i,j+1,K) + S(i,j+1,K-1))
-              endif
+        endif
+        ! West-facing open boundaries: interior cell is at i+1, use pres/T/S(i+1,j,K)
+        if (OBC%u_W_OBCs_on_PE) then
+          do j = max(jstart, OBC%js_u_W_obc), min(jend, OBC%je_u_W_obc)
+            jj = j - jstart + 1
+            do K = nz, 2, -1
+              do i = max(istart, OBC%Is_u_W_obc), min(iend, OBC%Ie_u_W_obc)
+                ii = i - istart + 1
+                if (OBC%segnum_u(i,j) < 0) then ! OBC_DIRECTION_W
+                  pres_uvh(ii,jj,K) = pres(i+1,j,K)
+                  T_uvh(ii,jj,K) = 0.5*(T(i+1,j,K) + T(i+1,j,K-1))
+                  S_uvh(ii,jj,K) = 0.5*(S(i+1,j,K) + S(i+1,j,K-1))
+                endif
+              enddo
             enddo
           enddo
-        enddo
+        endif
       endif
 
-      !$omp target update to(T_uvh, S_uvh, pres_uvh)
-    endif
-
-    if (present_N2_v .or. present(dzSyN)) then
-      if (allocated(tv%SpV_avg)) then
-        do concurrent( J = js-1:je, K = 2:nz, i = is:ie)
-            GxSpV_uvh(i,J,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i,j+1,K)) + &
-                                                      (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i,j+1,K-1)))
-        end do
+      ! Pre-fill GxSpV at u-points: four-cell SpV average over the u-face and the two
+      ! adjacent layers. Individual OBC faces may override this inside the slope loop.
+      if (present_N2_u .or. present(dzSxN)) then
+        if (allocated(tv%SpV_avg)) then
+          do jj=1, jend-jstart+1 ; do K=2,nz ; do ii=1, iend-istart+1
+            i = istart + ii - 1 ; j = jstart + jj - 1
+            GxSpV_uvh(ii,jj,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i+1,j,K)) + &
+                                                        (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i+1,j,K-1)))
+          enddo ; enddo ; enddo
+        endif
       endif
-    endif
 
-    do K=nz,2,-1
-      call calculate_density_derivs(T_uvh(:,:,K), S_uvh(:,:,K), pres_uvh(:,:,K), drho_dT(:,:,K), &
-                                  drho_dS(:,:,K), tv%eqn_of_state, EOSdom)
-    enddo
-
-    if (use_stanley) then
-      ! Recalculate T, S, and press at h-points for the second derivative calculation.
-      do concurrent(J=js-1:je, K=2:nz, i=is:ie)
-        pres_uvh(i,J,K) = pres(i,j,K)
-        T_uvh(i,J,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-        S_uvh(i,J,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
-      enddo
-
-      ! The second line below would correspond to arguments
-      !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
-      ! UMW NOTE: changed J bounds from js-1:je to js-1:je+1 to account for extra J access below
-      ! when calculate drdj
-      do J=js-1,je+1 ; do K=nz,2,-1
-        ! UMW TODO: Implement 2d version of this subroutine
-        call calculate_density_second_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), &
-                   scrap, scrap, drho_dT_dT_h(:,J,K), scrap, scrap, &
-                   tv%eqn_of_state, dom=EOSdom_h1)
+      ! Density derivatives at u-points. EOSdom_tile is 1-based so no IsdB offset is needed.
+      do jj=1,jend-jstart+1 ; do K=nz,2,-1
+        call calculate_density_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
+                                      drho_dT(:,jj,K), drho_dS(:,jj,K), &
+                                      tv%eqn_of_state, EOSdom_tile)
       enddo ; enddo
 
-    endif ! end use_stanley
+      if (use_stanley) then
+        ! Refill T_uvh/S_uvh/pres_uvh at h-points for the Stanley second-derivative calculation.
+        ! The fill extends one extra column (ii up to iend-istart+2) because the slope compute
+        ! accesses drho_dT_dT_h(ii,jj,K) and drho_dT_dT_h(ii+1,jj,K) simultaneously.
+        EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 2
+        do concurrent(jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+2)
+          i = istart + ii - 1 ; j = jstart + jj - 1
+          pres_uvh(ii,jj,K) = pres(i,j,K)
+          T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+          S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+        enddo
 
-  ! If not using EOS, gradients are handled inside the do concurrent loop below
-  endif
+        !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
-  do concurrent(J=js-1:je, K=2:nz, i=is:ie) DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB)) &
-                                            DO_LOCALITY(local( hg2A, hg2B, hg2L, hg2R, haA, haB, haL, haR)) &
-                                            DO_LOCALITY(local( dzaL, dzaR, wtA, wtB, wtL, wtR, drdy, drdz)) &
-                                            DO_LOCALITY(local( slope, mag_grad2))
+        do jj=1,jend-jstart+1 ; do K=nz,2,-1
+          call calculate_density_second_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
+                     scrap, scrap, drho_dT_dT_h(:,jj,K), scrap, scrap, &
+                     tv%eqn_of_state, dom=EOSdom_tile_h1)
+        enddo ; enddo
+      endif ! end use_stanley
+
+    endif ! end use_EOS for zonal tile
+
+    ! Push density derivatives to device for the slope compute kernel
+    !$omp target update to(drho_dT, drho_dS, drho_dT_dT_h)
+
+    ! Zonal slope compute over the tile
+    do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &
+        local(drdkL, drdkR, drdiA, drdiB, I, j, i)
+      I = istart + ii - 1  ! global I (u-face)
+      j = jstart + jj - 1  ! global j (h-point)
+      i = I                 ! i = I for C-grid u-faces
+
+      if (use_EOS) then
+        drdiA = drho_dT(ii,jj,K) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
+                drho_dS(ii,jj,K) * (S(i+1,j,k-1)-S(i,j,k-1))
+        drdiB = drho_dT(ii,jj,K) * (T(i+1,j,k)-T(i,j,k)) + &
+                drho_dS(ii,jj,K) * (S(i+1,j,k)-S(i,j,k))
+        drdkL = (drho_dT(ii,jj,K) * (T(i,j,k)-T(i,j,k-1)) + &
+                  drho_dS(ii,jj,K) * (S(i,j,k)-S(i,j,k-1)))
+        drdkR = (drho_dT(ii,jj,K) * (T(i+1,j,k)-T(i+1,j,k-1)) + &
+                  drho_dS(ii,jj,K) * (S(i+1,j,k)-S(i+1,j,k-1)))
+        if (use_stanley) then
+          drdiA = drdiA + 0.5 * ((drho_dT_dT_h(ii+1,jj,K) * tv%varT(i+1,j,K-1)) - &
+                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K-1)) )
+          drdiB = drdiB + 0.5 * ((drho_dT_dT_h(ii+1,jj,K) * tv%varT(i+1,j,K)) - &
+                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K)) )
+        endif
+      else ! .not. use_EOS: layers are constant density
+        drdiA = 0.0 ; drdiB = 0.0
+        drdkL = GV%Rlay(K)-GV%Rlay(K-1) ; drdkR = drdkL
+      endif
+
+      hg2A = h(i,j,k-1)*h(i+1,j,k-1) + h_neglect2
+      hg2B = h(i,j,k)*h(i+1,j,k) + h_neglect2
+      hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
+      hg2R = h(i+1,j,k-1)*h(i+1,j,k) + h_neglect2
+      haA = 0.5*(h(i,j,k-1) + h(i+1,j,k-1)) + h_neglect
+      haB = 0.5*(h(i,j,k) + h(i+1,j,k)) + h_neglect
+      haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
+      haR = 0.5*(h(i+1,j,k-1) + h(i+1,j,k)) + h_neglect
+      if (GV%Boussinesq) then
+        dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
+      else
+        dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
+        dzaR = 0.5*(e(i+1,j,K-1) - e(i+1,j,K+1)) + dz_neglect
+      endif
+      if (present(dzu)) dzu(I,j,K) = 0.5*( dzaL + dzaR )
+      wtA = hg2A*haB ; wtB = hg2B*haA
+      wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
+
+      drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
+      if (present_N2_u) then
+        if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
+          if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
+            drdz = drdkL / dzaL
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+          elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
+            drdz = drdkR / dzaR
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
+          endif
+        endif ; endif
+        N2_u(I,j,K) = GxSpV_uvh(ii,jj,k) * drdz * G%mask2dCu(I,j)
+      endif
+
+      if (use_EOS) then
+        drdx = ((wtA * drdiA + wtB * drdiB) / (wtA + wtB) - &
+                drdz * (e(i,j,K)-e(i+1,j,K))) * G%IdxCu(I,j)
+        mag_grad2 = (US%Z_to_L*drdx)**2 + drdz**2
+        if (mag_grad2 > 0.0) then
+          slope = drdx / sqrt(mag_grad2)
+        else
+          slope = 0.0
+        endif
+      else
+        slope = (e(i+1,j,K)-e(i,j,K)) * G%IdxCu(I,j)
+      endif
+
+      if (local_open_u_BC) then
+        if (OBC%segnum_u(I,j) /= 0) then
+          if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) slope = 0.
+        endif
+        slope = slope * max(G%mask2dT(i,j), G%mask2dT(i+1,j))
+      endif
+
+      slope_x(I,j,K) = slope
+      if (present(dzSxN)) &
+        dzSxN(I,j,K) = sqrt( GxSpV_uvh(ii,jj,k) * max(0., (wtL * ( dzaL * drdkL )) &
+                                                + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) &
+                        * abs(slope) * G%mask2dCu(I,j)
+    enddo ! end zonal tile do concurrent
+  enddo ; enddo ! end zonal outer tile loops
+
+  ! ============================================================
+  ! Meridional tiling loop: compute meridional isopycnal slopes
+  ! ============================================================
+  ! Structure mirrors the zonal loop above, but tiling over (i=is:ie, J=js-1:je).
+  ! The Stanley second-derivative fill extends to jend+1 in J because the slope
+  ! compute accesses drho_dT_dT_h(ii,jj,K) and drho_dT_dT_h(ii,jj+1,K) simultaneously.
+  do jstart=js-1, je, njblock_loc ; do istart=is, ie, niblock_loc
+    iend = min(istart + niblock_loc - 1, ie)
+    jend = min(jstart + njblock_loc - 1, je)
+    EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
+
+    ! Re-initialise GxSpV tile: the zonal pass may have set entries here, so reset to
+    ! G_Rho0 before the meridional fills.
+    do concurrent( jj=1:jend-jstart+1, k=1:nz, ii=1:iend-istart+1 )
+      GxSpV_uvh(ii,jj,k) = G_Rho0
+    enddo
 
     if (use_EOS) then
-      ! Estimate the horizontal density gradients along layers.
-      drdjA = drho_dT(i,J,K) * (T(i,j+1,k-1)-T(i,j,k-1)) + &
-              drho_dS(i,J,K) * (S(i,j+1,k-1)-S(i,j,k-1))
-      drdjB = drho_dT(i,J,K) * (T(i,j+1,k)-T(i,j,k)) + &
-              drho_dS(i,J,K) * (S(i,j+1,k)-S(i,j,k))
+      ! Fill tile T_uvh/S_uvh/pres_uvh at v-points (v-face = average of j and j+1)
+      do concurrent(jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1)
+        i = istart + ii - 1  ! global i (h-point)
+        j = jstart + jj - 1  ! global J (v-face index)
+        pres_uvh(ii,jj,K) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
+        T_uvh(ii,jj,K) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
+        S_uvh(ii,jj,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
+      enddo
 
-      ! Estimate the vertical density gradients times the grid spacing.
-      drdkL = (drho_dT(i,J,K) * (T(i,j,K)-T(i,j,K-1)) + &
-                drho_dS(i,J,K) * (S(i,j,K)-S(i,j,K-1)))
-      drdkR = (drho_dT(i,J,K) * (T(i,j+1,K)-T(i,j+1,K-1)) + &
-                drho_dS(i,J,K) * (S(i,j+1,K)-S(i,j+1,K-1)))
+      !$omp target update from(T_uvh, S_uvh, pres_uvh)
+
+      ! Apply OBC overrides at v-points: north-facing uses interior (j), south-facing uses j+1.
+      if (OBC_friendly) then
+        if (OBC%v_N_OBCs_on_PE) then
+          do j = max(jstart, OBC%Js_v_N_obc), min(jend, OBC%Je_v_N_obc)
+            jj = j - jstart + 1
+            do K = nz, 2, -1
+              do i = max(istart, OBC%is_v_N_obc), min(iend, OBC%ie_v_N_obc)
+                ii = i - istart + 1
+                if (OBC%segnum_v(i,j) > 0) then ! OBC_DIRECTION_N
+                  pres_uvh(ii,jj,K) = pres(i,j,K)
+                  T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+                  S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+                endif
+              enddo
+            enddo
+          enddo
+        endif
+        if (OBC%v_S_OBCs_on_PE) then
+          do j = max(jstart, OBC%Js_v_S_obc), min(jend, OBC%Je_v_S_obc)
+            jj = j - jstart + 1
+            do K = nz, 2, -1
+              do i = max(istart, OBC%is_v_S_obc), min(iend, OBC%ie_v_S_obc)
+                ii = i - istart + 1
+                if (OBC%segnum_v(i,j) < 0) then ! OBC_DIRECTION_S
+                  pres_uvh(ii,jj,K) = pres(i,j+1,K)
+                  T_uvh(ii,jj,K) = 0.5*(T(i,j+1,K) + T(i,j+1,K-1))
+                  S_uvh(ii,jj,K) = 0.5*(S(i,j+1,K) + S(i,j+1,K-1))
+                endif
+              enddo
+            enddo
+          enddo
+        endif
+      endif
+
+      ! Pre-fill GxSpV at v-points.
+      if (present_N2_v .or. present(dzSyN)) then
+        if (allocated(tv%SpV_avg)) then
+          do jj=1, jend-jstart+1 ; do K=2,nz ; do ii=1, iend-istart+1
+            i = istart + ii - 1 ; j = jstart + jj - 1
+            GxSpV_uvh(ii,jj,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i,j+1,K)) + &
+                                                        (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i,j+1,K-1)))
+          enddo ; enddo ; enddo
+        endif
+      endif
+
+      ! Density derivatives at v-points.
+      do jj=1,jend-jstart+1 ; do K=nz,2,-1
+        call calculate_density_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
+                                      drho_dT(:,jj,K), drho_dS(:,jj,K), &
+                                      tv%eqn_of_state, EOSdom_tile)
+      enddo ; enddo
 
       if (use_stanley) then
-        ! Correction to the horizontal density gradient due to nonlinearity in
-        ! the EOS rectifying SGS temperature anomalies
-        ! UMW NOTE: drho_dT_DT replaced with J+1 index in 3d array
-        drdjA = drdjA + 0.5 * ((drho_dT_dT_h(i,J+1,K) * tv%varT(i,j+1,K-1)) - &
-                              (drho_dT_dT_h(i,J,K) * tv%varT(i,j,K-1)) )
-        drdjB = drdjB + 0.5 * ((drho_dT_dT_h(i,J+1,K) * tv%varT(i,j+1,K)) - &
-                              (drho_dT_dT_h(i,J,K) * tv%varT(i,j,K)) )
-      endif
-    else ! .not. use_EOS: layers are constant density
-      drdjA = 0.0 ; drdjB = 0.0
-      drdkL = GV%Rlay(K)-GV%Rlay(K-1) ; drdkR = drdkL
-    endif
+        ! Refill at h-points for Stanley second derivatives. Extend to jend+1 in J because
+        ! the slope compute reads drho_dT_dT_h(ii,jj+1,K) (the J+1 neighbour).
+        EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 1
+        do concurrent(jj=1:jend-jstart+2, K=2:nz, ii=1:iend-istart+1)
+          i = istart + ii - 1 ; j = jstart + jj - 1
+          pres_uvh(ii,jj,K) = pres(i,j,K)
+          T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+          S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+        enddo
 
-    hg2A = h(i,j,k-1)*h(i,j+1,k-1) + h_neglect2
-    hg2B = h(i,j,k)*h(i,j+1,k) + h_neglect2
-    hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
-    hg2R = h(i,j+1,k-1)*h(i,j+1,k) + h_neglect2
-    haA = 0.5*(h(i,j,k-1) + h(i,j+1,k-1)) + h_neglect
-    haB = 0.5*(h(i,j,k) + h(i,j+1,k)) + h_neglect
-    haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
-    haR = 0.5*(h(i,j+1,k-1) + h(i,j+1,k)) + h_neglect
-    if (GV%Boussinesq) then
-      dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
-    else
-      dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
-      dzaR = 0.5*(e(i,j+1,K-1) - e(i,j+1,K+1)) + dz_neglect
-    endif
-    if (present(dzv)) dzv(i,J,K) = 0.5*( dzaL + dzaR )
-    ! Use the harmonic mean thicknesses to weight the horizontal gradients.
-    ! These unnormalized weights have been rearranged to minimize divisions.
-    wtA = hg2A*haB ; wtB = hg2B*haA
-    wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
+        !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
-    drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
-    ! The expression for drdz above is mathematically equivalent to:
-    !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
-    !          ((hg2L/haL) + (hg2R/haR))
-    ! which is an estimate of the gradient of density across geopotentials.
-    if (present_N2_v) then
-      if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
-        ! UMW NOTE: vibe-coded and untested.
-        if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
-          drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
-          if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
-        elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
-          drdz = drdkL / dzaL
-          if (use_EOS .and. allocated(tv%SpV_avg)) &
-            GxSpV_uvh(i,j,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
+        do jj=1,jend-jstart+2 ; do K=nz,2,-1
+          call calculate_density_second_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
+                     scrap, scrap, drho_dT_dT_h(:,jj,K), scrap, scrap, &
+                     tv%eqn_of_state, dom=EOSdom_tile_h1)
+        enddo ; enddo
+      endif ! end use_stanley
+
+    endif ! end use_EOS for meridional tile
+
+    ! Push derivatives to device
+    !$omp target update to(drho_dT, drho_dS, drho_dT_dT_h)
+
+    ! Meridional slope compute over the tile
+    do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &
+        local(drdkL, drdkR, drdjA, drdjB, i, j, J)
+      i = istart + ii - 1  ! global i (h-point)
+      J = jstart + jj - 1  ! global J (v-face)
+      j = J                 ! j = J for C-grid v-faces
+
+      if (use_EOS) then
+        drdjA = drho_dT(ii,jj,K) * (T(i,j+1,k-1)-T(i,j,k-1)) + &
+                drho_dS(ii,jj,K) * (S(i,j+1,k-1)-S(i,j,k-1))
+        drdjB = drho_dT(ii,jj,K) * (T(i,j+1,k)-T(i,j,k)) + &
+                drho_dS(ii,jj,K) * (S(i,j+1,k)-S(i,j,k))
+        drdkL = (drho_dT(ii,jj,K) * (T(i,j,K)-T(i,j,K-1)) + &
+                  drho_dS(ii,jj,K) * (S(i,j,K)-S(i,j,K-1)))
+        drdkR = (drho_dT(ii,jj,K) * (T(i,j+1,K)-T(i,j+1,K-1)) + &
+                  drho_dS(ii,jj,K) * (S(i,j+1,K)-S(i,j+1,K-1)))
+        if (use_stanley) then
+          drdjA = drdjA + 0.5 * ((drho_dT_dT_h(ii,jj+1,K) * tv%varT(i,j+1,K-1)) - &
+                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K-1)) )
+          drdjB = drdjB + 0.5 * ((drho_dT_dT_h(ii,jj+1,K) * tv%varT(i,j+1,K)) - &
+                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K)) )
         endif
-      endif ; endif
-
-      N2_v(i,J,K) = GxSpV_uvh(i,j,k) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
-    endif
-
-    if (use_EOS) then
-      drdy = ((wtA * drdjA + wtB * drdjB) / (wtA + wtB) - &
-              drdz * (e(i,j,K)-e(i,j+1,K))) * G%IdyCv(i,J)
-
-      ! This estimate of slope is accurate for small slopes, but bounded
-      ! to be between -1 and 1.
-      mag_grad2 = (US%Z_to_L*drdy)**2 + drdz**2
-      if (mag_grad2 > 0.0) then
-        slope = drdy / sqrt(mag_grad2)
-      else ! Just in case mag_grad2 = 0 ever.
-        slope = 0.0
+      else
+        drdjA = 0.0 ; drdjB = 0.0
+        drdkL = GV%Rlay(K)-GV%Rlay(K-1) ; drdkR = drdkL
       endif
-    else ! With .not.use_EOS, the layers are constant density.
-      slope = (e(i,j+1,K)-e(i,j,K)) * G%IdyCv(i,J)
-    endif
 
-    if (local_open_v_BC) then
-      if (OBC%segnum_v(i,J) /= 0) then
-        if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
-          slope = 0.
-          ! This and/or the masking code below is to make slopes match inside
-          ! land mask. Might not be necessary except for DEBUG output.
-!           if (OBC%segnum_v(i,J)) > 0) then ! OBC_DIRECTION_N
-!             slope_y(i,J+1,K) = 0.
-!           else
-!             slope_y(i,J-1,K) = 0.
-!           endif
+      hg2A = h(i,j,k-1)*h(i,j+1,k-1) + h_neglect2
+      hg2B = h(i,j,k)*h(i,j+1,k) + h_neglect2
+      hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
+      hg2R = h(i,j+1,k-1)*h(i,j+1,k) + h_neglect2
+      haA = 0.5*(h(i,j,k-1) + h(i,j+1,k-1)) + h_neglect
+      haB = 0.5*(h(i,j,k) + h(i,j+1,k)) + h_neglect
+      haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
+      haR = 0.5*(h(i,j+1,k-1) + h(i,j+1,k)) + h_neglect
+      if (GV%Boussinesq) then
+        dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
+      else
+        dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
+        dzaR = 0.5*(e(i,j+1,K-1) - e(i,j+1,K+1)) + dz_neglect
+      endif
+      if (present(dzv)) dzv(i,J,K) = 0.5*( dzaL + dzaR )
+      wtA = hg2A*haB ; wtB = hg2B*haA
+      wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
+
+      drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
+      if (present_N2_v) then
+        if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
+          if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
+            drdz = drdkL / dzaL
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+          elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
+            drdz = drdkL / dzaL
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
+          endif
+        endif ; endif
+        N2_v(i,J,K) = GxSpV_uvh(ii,jj,k) * drdz * G%mask2dCv(i,J)
+      endif
+
+      if (use_EOS) then
+        drdy = ((wtA * drdjA + wtB * drdjB) / (wtA + wtB) - &
+                drdz * (e(i,j,K)-e(i,j+1,K))) * G%IdyCv(i,J)
+        mag_grad2 = (US%Z_to_L*drdy)**2 + drdz**2
+        if (mag_grad2 > 0.0) then
+          slope = drdy / sqrt(mag_grad2)
+        else
+          slope = 0.0
         endif
+      else
+        slope = (e(i,j+1,K)-e(i,j,K)) * G%IdyCv(i,J)
       endif
-      slope = slope * max(G%mask2dT(i,j), G%mask2dT(i,j+1))
-    endif
-    slope_y(i,J,K) = slope
-    if (present(dzSyN)) &
-      dzSyN(i,J,K) = sqrt( GxSpV_uvh(i,j,k) * max(0., (wtL * ( dzaL * drdkL )) &
-                                              + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
-                      * abs(slope) * G%mask2dCv(i,J) ! x-direction contribution to S^2
 
-  enddo ! end of meridional do concurrent
+      if (local_open_v_BC) then
+        if (OBC%segnum_v(i,J) /= 0) then
+          if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) slope = 0.
+        endif
+        slope = slope * max(G%mask2dT(i,j), G%mask2dT(i,j+1))
+      endif
+      slope_y(i,J,K) = slope
+      if (present(dzSyN)) &
+        dzSyN(i,J,K) = sqrt( GxSpV_uvh(ii,jj,k) * max(0., (wtL * ( dzaL * drdkL )) &
+                                                + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) &
+                        * abs(slope) * G%mask2dCv(i,J)
+    enddo ! end meridional tile do concurrent
+  enddo ; enddo ! end meridional outer tile loops
 
-  ! Delete variables from device
-  !$omp target exit data map(delete: drho_dT, drho_dS, scrap)
-  !$omp target exit data map(delete: drho_dT_dT_h)
-  !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh)
+  ! Delete all tile and field arrays from device
+  !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
+  !$omp   scrap, drho_dT, drho_dS, drho_dT_dT_h)
 
 end subroutine calc_isoneutral_slopes
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -236,6 +236,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     enddo
   enddo
 
+  ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
+  ! non-Boussinesq SpV_avg is available.
+  do concurrent( kk=1:nkblock, jj=1:njblock+1, ii=1:niblock+1 )
+    GxSpV_uvh(ii,jj,kk) = G_Rho0
+  enddo
+
   ! ============================================================
   ! Zonal tiling loop: compute zonal isopycnal slopes
   ! ============================================================
@@ -243,10 +249,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! Within each tile:
   !   1. Fill tile-sized T_uvh/S_uvh/pres_uvh at u-points on device (do concurrent).
   !   2. Apply OBC overrides (CPU, host-side OBC derived types).
-  !   3. Pre-fill GxSpV_uvh at u-points.
-  !   4. Call calculate_density_derivs over tile.
-  !   5. If use_stanley: refill at h-points, call calculate_density_second_derivs.
-  !   6. Compute slopes in do concurrent using tile-local indices.
+  !   3. Call calculate_density_derivs over tile.
+  !   4. If use_stanley: refill at h-points, call calculate_density_second_derivs.
+  !   5. Compute slopes in do concurrent using tile-local indices.
   do jstart=js, je, njblock ; do istart=is-1, ie, niblock ; do kstart=2,nz, nkblock
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + njblock - 1, je)
@@ -254,12 +259,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
     EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
     EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
-
-    ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
-    ! non-Boussinesq SpV_avg is available.
-    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 )
-      GxSpV_uvh(ii,jj,kk) = G_Rho0
-    enddo
 
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at u-points (u-face = average of i and i+1)
@@ -321,13 +320,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! adjacent layers. Individual OBC faces may override this inside the slope loop.
       if (present_N2_u .or. present(dzSxN)) then
         if (allocated(tv%SpV_avg)) then
-          do jj=1, jend-jstart+1 ; do kk=1,kend-kstart+1 ; do ii=1, iend-istart+1
+          do concurrent( kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1 ) &
+              DO_LOCALITY(local(i,j,k))
             i = istart + ii - 1
             j = jstart + jj - 1
             k = kstart + kk - 1
             GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i+1,j,K)) + &
                                                         (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i+1,j,K-1)))
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 
@@ -463,12 +463,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
     EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
 
-    ! Re-initialise GxSpV tile: the zonal pass may have set entries here, so reset to
-    ! G_Rho0 before the meridional fills.
-    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 )
-      GxSpV_uvh(ii,jj,kk) = G_Rho0
-    enddo
-
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at v-points (v-face = average of j and j+1)
       do concurrent(jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1)
@@ -524,13 +518,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! Pre-fill GxSpV at v-points.
       if (present_N2_v .or. present(dzSyN)) then
         if (allocated(tv%SpV_avg)) then
-          do jj=1, jend-jstart+1 ; do kk=1, kend-kstart+1 ; do ii=1, iend-istart+1
+          do concurrent( kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1 ) &
+             DO_LOCALITY(local(i,j,k))
             i = istart + ii - 1
             j = jstart + jj - 1
             k = kstart + kk - 1
             GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i,j+1,K)) + &
                                                         (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i,j+1,K-1)))
-          enddo ; enddo ; enddo
+          enddo
         endif
       endif
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -123,10 +123,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   logical :: local_open_u_BC, local_open_v_BC ! True if u- or v-face OBCs exist anywhere in the global domain.
   logical :: OBC_friendly  ! If true, open boundary conditions are in use and only interior data should
                         ! be used to calculate N2 at OBC faces.
-  integer, dimension(2) :: EOSdom_h1 ! The shifted i-computational domain to use for equation of
-                                     ! state calculations at h points with 1 extra halo point
-  integer, dimension(2) :: EOSdom_tile   !< 1-based EOS domain for the current tile [nondim].
-  integer, dimension(2) :: EOSdom_tile_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
+  integer, dimension(2,2) :: EOSdom_tile    !< 1-based EOS domain for the current tile [nondim].
+  integer, dimension(2)   :: EOSdom_tile_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
   integer :: istart, iend !< First and last global i (or I) indices of the current tile [nondim].
@@ -140,10 +138,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
-    EOSdom_h1(:) = EOS_domain(G%HI, halo=halo+1)
   else
     is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
-    EOSdom_h1(:) = EOS_domain(G%HI, halo=1)
   endif
 
   nz = GV%ke ; IsdB = G%IsdB
@@ -257,7 +253,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + njblock - 1, je)
     kend = min(kstart + nkblock - 1, nz)
-    EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
+    EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
+    EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
 
     ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
     ! non-Boussinesq SpV_avg is available.
@@ -330,11 +327,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
 
       ! Density derivatives at u-points. EOSdom_tile is 1-based so no IsdB offset is needed.
-      do jj=1,jend-jstart+1 ; do kk=1,kend-kstart+1
-        call calculate_density_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
-                                      drho_dT(:,jj,kk), drho_dS(:,jj,kk), &
+      do kk=1,kend-kstart+1
+        call calculate_density_derivs(T_uvh(:,:,kk), S_uvh(:,:,kk), pres_uvh(:,:,kk), &
+                                      drho_dT(:,:,kk), drho_dS(:,:,kk), &
                                       tv%eqn_of_state, EOSdom_tile)
-      enddo ; enddo
+      enddo
 
       if (use_stanley) then
         ! Refill T_uvh/S_uvh/pres_uvh at h-points for the Stanley second-derivative calculation.
@@ -361,7 +358,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     ! Zonal slope compute over the tile
     do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 ) &
-        local(drdkL, drdkR, drdiA, drdiB, I, j)
+        DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB, I, j))
       I = istart + ii - 1  ! global I (u-face)
       j = jstart + jj - 1  ! global j (h-point)
       k = kstart + kk - 1  ! global k
@@ -458,7 +455,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + njblock - 1, je)
     kend = min(kstart + nkblock - 1, nz)
-    EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
+    EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
+    EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
 
     ! Re-initialise GxSpV tile: the zonal pass may have set entries here, so reset to
     ! G_Rho0 before the meridional fills.
@@ -526,17 +524,17 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
 
       ! Density derivatives at v-points.
-      do jj=1,jend-jstart+1 ; do kk=1,kend-kstart+1
-        call calculate_density_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
-                                      drho_dT(:,jj,kk), drho_dS(:,jj,kk), &
+      do kk=1,kend-kstart+1
+        call calculate_density_derivs(T_uvh(:,:,kk), S_uvh(:,:,kk), pres_uvh(:,:,kk), &
+                                      drho_dT(:,:,kk), drho_dS(:,:,kk), &
                                       tv%eqn_of_state, EOSdom_tile)
-      enddo ; enddo
+      enddo
 
       if (use_stanley) then
         ! Refill at h-points for Stanley second derivatives. Extend to jend+1 in J because
         ! the slope compute reads drho_dT_dT_h(ii,jj+1,K) (the J+1 neighbour).
         EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 1
-        do concurrent(jj=1:jend-jstart+2, kk=1:kend-kstart, ii=1:iend-istart+1)
+        do concurrent(jj=1:jend-jstart+2, kk=1:kend-kstart+1, ii=1:iend-istart+1)
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -555,8 +553,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     endif ! end use_EOS for meridional tile
 
     ! Meridional slope compute over the tile
-    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart, ii=1:iend-istart+1 ) &
-        local(drdkL, drdkR, drdjA, drdjB, i, J)
+    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 ) &
+        DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB, i, J))
       i = istart + ii - 1  ! global i (h-point)
       J = jstart + jj - 1  ! global J (v-face)
       K = kstart + kk - 1  ! global k

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -238,7 +238,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
   ! non-Boussinesq SpV_avg is available.
-  do concurrent( kk=1:nkblock, jj=1:njblock+1, ii=1:niblock+1 )
+  do concurrent(kk=1:nkblock, jj=1:njblock+1, ii=1:niblock+1)
     GxSpV_uvh(ii,jj,kk) = G_Rho0
   enddo
 
@@ -252,7 +252,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !   3. Call calculate_density_derivs over tile.
   !   4. If use_stanley: refill at h-points, call calculate_density_second_derivs.
   !   5. Compute slopes in do concurrent using tile-local indices.
-  do jstart=js, je, njblock ; do istart=is-1, ie, niblock ; do kstart=2,nz, nkblock
+  do kstart=2,nz,nkblock ; do jstart=js,je,njblock ; do istart=is-1,ie,niblock
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + njblock - 1, je)
     kend = min(kstart + nkblock - 1, nz)
@@ -262,8 +262,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at u-points (u-face = average of i and i+1)
-      do concurrent(jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1)
-        i = istart + ii - 1  ! global I (u-face index)
+      do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1)
+        I = istart + II - 1  ! global I (u-face index)
         j = jstart + jj - 1  ! global j
         k = kstart + kk - 1  ! global k
         pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
@@ -320,13 +320,13 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! adjacent layers. Individual OBC faces may override this inside the slope loop.
       if (present_N2_u .or. present(dzSxN)) then
         if (allocated(tv%SpV_avg)) then
-          do concurrent( kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1 ) &
-              DO_LOCALITY(local(i,j,k))
-            i = istart + ii - 1
+          do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1) &
+              DO_LOCALITY(local(I,j,k))
+            I = istart + II - 1
             j = jstart + jj - 1
             k = kstart + kk - 1
-            GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i+1,j,K)) + &
-                                                        (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i+1,j,K-1)))
+            GxSpV_uvh(II,jj,kk) = GV%g_Earth * 0.25 * ((tv%SpV_avg(I,j,k) + tv%SpV_avg(I+1,j,k)) + &
+                                                        (tv%SpV_avg(I,j,k-1) + tv%SpV_avg(I+1,j,k-1)))
           enddo
         endif
       endif
@@ -339,18 +339,18 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       if (use_stanley) then
         ! Refill T_uvh/S_uvh/pres_uvh at h-points for the Stanley second-derivative calculation.
         ! The fill extends one extra column (ii up to iend-istart+2) because the slope compute
-        ! accesses drho_dT_dT_h(ii,jj,K) and drho_dT_dT_h(ii+1,jj,K) simultaneously.
+        ! accesses drho_dT_dT_h(ii,jj,kk) and drho_dT_dT_h(ii+1,jj,kk) simultaneously.
         EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 2
-        do concurrent(jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+2)
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+2)
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
-          pres_uvh(ii,jj,kk) = pres(i,j,K)
-          T_uvh(ii,jj,kk) = 0.5*(T(i,j,K) + T(i,j,K-1))
-          S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
+          pres_uvh(ii,jj,KK) = pres(i,j,K)
+          T_uvh(ii,jj,kk) = 0.5*(T(i,j,k) + T(i,j,k-1))
+          S_uvh(ii,jj,kk) = 0.5*(S(i,j,k) + S(i,j,k-1))
         enddo
 
-        do jj=1,jend-jstart+1 ; do kk=1,kend-kstart+1
+        do kk=1,kend-kstart+1 ; do jj=1,jend-jstart+1
           call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
                      scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
                      tv%eqn_of_state, dom=EOSdom_tile_h1)
@@ -360,9 +360,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     endif ! end use_EOS for zonal tile
 
     ! Zonal slope compute over the tile
-    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 ) &
+    do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1) &
         DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB, I, j))
-      I = istart + ii - 1  ! global I (u-face)
+      I = istart + II - 1  ! global I (u-face)
       j = jstart + jj - 1  ! global j (h-point)
       k = kstart + kk - 1  ! global k
 
@@ -411,14 +411,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
             drdz = drdkL / dzaL
             if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+              GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
           elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
             drdz = drdkR / dzaR
             if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
+              GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
           endif
         endif ; endif
-        N2_u(I,j,K) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCu(I,j)
+        N2_u(I,j,k) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCu(I,j)
       endif
 
       if (use_EOS) then
@@ -447,15 +447,15 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                                                 + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) &
                         * abs(slope) * G%mask2dCu(I,j)
     enddo ! end zonal tile do concurrent
-    enddo ; enddo ; enddo ! end zonal outer tile loops
+  enddo ; enddo ; enddo ! end zonal outer tile loops
 
   ! ============================================================
   ! Meridional tiling loop: compute meridional isopycnal slopes
   ! ============================================================
   ! Structure mirrors the zonal loop above, but tiling over (i=is:ie, J=js-1:je).
   ! The Stanley second-derivative fill extends to jend+1 in J because the slope
-  ! compute accesses drho_dT_dT_h(ii,jj,K) and drho_dT_dT_h(ii,jj+1,K) simultaneously.
-  do jstart=js-1, je, njblock ; do istart=is, ie, niblock ; do kstart=2,nz, nkblock
+  ! compute accesses drho_dT_dT_h(ii,jj,kk) and drho_dT_dT_h(ii,jj+1,kk) simultaneously.
+  do kstart=2,nz, nkblock ; do jstart=js-1,je,njblock ; do istart=is,ie,niblock
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + njblock - 1, je)
     kend = min(kstart + nkblock - 1, nz)
@@ -465,7 +465,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at v-points (v-face = average of j and j+1)
-      do concurrent(jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1)
+      do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1)
         i = istart + ii - 1  ! global i (h-point)
         j = jstart + jj - 1  ! global J (v-face index)
         k = kstart + kk - 1  ! global k
@@ -518,7 +518,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! Pre-fill GxSpV at v-points.
       if (present_N2_v .or. present(dzSyN)) then
         if (allocated(tv%SpV_avg)) then
-          do concurrent( kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1 ) &
+          do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1) &
              DO_LOCALITY(local(i,j,k))
             i = istart + ii - 1
             j = jstart + jj - 1
@@ -538,7 +538,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         ! Refill at h-points for Stanley second derivatives. Extend to jend+1 in J because
         ! the slope compute reads drho_dT_dT_h(ii,jj+1,K) (the J+1 neighbour).
         EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 1
-        do concurrent(jj=1:jend-jstart+2, kk=1:kend-kstart+1, ii=1:iend-istart+1)
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+2, ii=1:iend-istart+1)
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -547,7 +547,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
         enddo
 
-        do jj=1,jend-jstart+2 ; do kk=1,kend-kstart+1
+        do kk=1,kend-kstart+1 ; do jj=1,jend-jstart+2
           call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
                      scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
                      tv%eqn_of_state, dom=EOSdom_tile_h1)
@@ -557,7 +557,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     endif ! end use_EOS for meridional tile
 
     ! Meridional slope compute over the tile
-    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 ) &
+    do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1) &
         DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB, i, J))
       i = istart + ii - 1  ! global i (h-point)
       J = jstart + jj - 1  ! global J (v-face)

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -714,7 +714,7 @@ subroutine vert_fill_TS(h, T_in, S_in, kappa_dt, T_f, S_f, G, GV, US, halo_here,
       T_f(i,j,k) = T_in(i,j,k) ; S_f(i,j,k) = S_in(i,j,k)
     enddo
   else
-    !$omp target teams loop private( ent, b1, d1, c1 )
+    !$omp target teams loop private( ent, b1, d1, c1, h_tr )
     do j=js,je
       do concurrent( i=is:ie )
         ent(i,2) = kap_dt_x2 / ((h(i,j,1)+h(i,j,2)) + h0)

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -18,6 +18,7 @@ use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N,
 implicit none ; private
 
 #include <MOM_memory.h>
+#include "do_concurrent_compat.h"
 
 public calc_isoneutral_slopes, vert_fill_TS
 
@@ -81,7 +82,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                   ! [T2 S-1 L-2 ~> kg m-3 ppt-1 Pa-1] and [T2 C-1 L-2 ~> kg m-3 degC-1 Pa-1].
   !UMW Test: Promote to 3d to factor out calculate_density_derivs() calls
   real, dimension(SZIB_(G), SZJB_(G), SZK_(GV)) :: &
-    drho_dT, &      ! The derivative of density with temperature calculated at  
+    drho_dT, &      ! The derivative of density with temperature calculated at
                     ! both u and v points [R C-1 ~> kg m-3 degC-1].
     drho_dS, &      ! The derivative of density with salinity calculated at
                     ! both u and v points [R S-1 ~> kg m-3 ppt-1].
@@ -243,7 +244,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! Calculate density derviatves outside of slope calculation since
   ! deferred EOS subroutines cannot be called on the GPU
   if (use_EOS) then
-    ! Calculate density derivatives using T,S,and P at u points. 
+    ! Calculate density derivatives using T,S,and P at u points.
     do concurrent(j=js:je, K=2:nz, I=is-1:ie)
       pres_uvh(I,j,K) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
       T_uvh(I,j,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
@@ -316,13 +317,13 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                    scrap, scrap, drho_dT_dT_h(:,j,K), scrap, scrap, &
                    tv%eqn_of_state, dom=EOSdom_h1)
       enddo ; enddo
-    
+
     endif ! end use_stanley
 
   ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
 
-  do concurrent( j=js:je , K=2:nz , I=is-1:ie ) local(drdkL, drdkR, drdiA, drdiB)
+  do concurrent( j=js:je , K=2:nz , I=is-1:ie ) DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB))
     ! UMW: Since stanley parameterization requies EOS anyways, putting
     ! the use_stanley loop inside of the use_EOS loop
     if (use_EOS) then
@@ -448,7 +449,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! deferred EOS subroutines cannot be called on the GPU, but this time in the
   ! meridional direciton
   if (use_EOS) then
-    ! Calculate density derivatives using T,S,and P at v points. 
+    ! Calculate density derivatives using T,S,and P at v points.
     do concurrent(J=js-1:je, K=2:nz, i=is:ie)
       pres_uvh(i,J,K) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
       T_uvh(i,J,K) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
@@ -518,19 +519,19 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
       ! UMW NOTE: changed J bounds from js-1:je to js-1:je+1 to account for extra J access below
-      ! when calculate drdj 
+      ! when calculate drdj
       do J=js-1,je+1 ; do K=nz,2,-1
         call calculate_density_second_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), &
                    scrap, scrap, drho_dT_dT_h(:,J,K), scrap, scrap, &
                    tv%eqn_of_state, dom=EOSdom_h1)
       enddo ; enddo
-    
+
     endif ! end use_stanley
 
   ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
 
-  do concurrent(J=js-1:je, K=2:nz, i=is:ie) local(drdkL, drdkR, drdjA, drdjB)
+  do concurrent(J=js-1:je, K=2:nz, i=is:ie) DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB))
 
     if (use_EOS) then
       ! Estimate the horizontal density gradients along layers.

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -79,33 +79,26 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                   ! set there but will be ignored, it is used simultaneously with four different
                   ! inconsistent units of [R S-1 C-1 ~> kg m-3 degC-1 ppt-1], [R S-2 ~> kg m-3 ppt-2],
                   ! [T2 S-1 L-2 ~> kg m-3 ppt-1 Pa-1] and [T2 C-1 L-2 ~> kg m-3 degC-1 Pa-1].
-  real, dimension(SZIB_(G)) :: &
-    drho_dT_u, &  ! The derivative of density with temperature at u points [R C-1 ~> kg m-3 degC-1].
-    drho_dS_u     ! The derivative of density with salinity at u points [R S-1 ~> kg m-3 ppt-1].
-  real, dimension(SZI_(G)) :: &
-    drho_dT_v, &  ! The derivative of density with temperature at v points [R C-1 ~> kg m-3 degC-1].
-    drho_dS_v, &  ! The derivative of density with salinity at v points [R S-1 ~> kg m-3 ppt-1].
-    drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
-    drho_dT_dT_hr ! The second derivative of density with temperature at h (+1) points [R C-2 ~> kg m-3 degC-2]
-  real, dimension(SZIB_(G)) :: &
-    T_u, &        ! Temperature on the interface at the u-point [C ~> degC].
-    S_u, &        ! Salinity on the interface at the u-point [S ~> ppt].
-    GxSpV_u, &    ! Gravitiational acceleration times the specific volume at an interface
+  !UMW Test: Promote to 3d to factor out calculate_density_derivs() calls
+  !UMW TODO: What are the best indices to use for these new 3d arrays?
+  real, dimension(SZIB_(G)) :: GxSpV_u  ! Gravitational acceleration times the specific volume at an interface
                   ! at the u-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
-    pres_u        ! Pressure on the interface at the u-point [R L2 T-2 ~> Pa].
-  real, dimension(SZI_(G)) :: &
-    T_v, &        ! Temperature on the interface at the v-point [C ~> degC].
-    S_v, &        ! Salinity on the interface at the v-point [S ~> ppt].
-    GxSpV_v, &    ! Gravitiational acceleration times the specific volume at an interface
+  real, dimension(SZI_(G)) :: GxSpV_v  ! Gravitational acceleration times the specific volume at an interface
                   ! at the v-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
-    pres_v        ! Pressure on the interface at the v-point [R L2 T-2 ~> Pa].
-  real, dimension(SZI_(G)) :: &
-    T_h, &        ! Temperature on the interface at the h-point [C ~> degC].
-    S_h, &        ! Salinity on the interface at the h-point [S ~> ppt]
-    pres_h, &     ! Pressure on the interface at the h-point [R L2 T-2 ~> Pa].
-    T_hr, &       ! Temperature on the interface at the h (+1) point [C ~> degC].
-    S_hr, &       ! Salinity on the interface at the h (+1) point [S ~> ppt]
-    pres_hr       ! Pressure on the interface at the h (+1) point [R L2 T-2 ~> Pa].
+  real, dimension(SZIB_(G), SZJB_(G), SZK_(GV)) :: &
+    drho_dT, &  ! The derivative of density with temperature calculated at  
+                ! both u and v points [R C-1 ~> kg m-3 degC-1].
+    drho_dS     ! The derivative of density with salinity calculated at
+                ! both u and v points [R S-1 ~> kg m-3 ppt-1].
+  !UMW TODO: Find better name for these variables
+  real, dimension(SZIB_(G), SZJB_(G), SZK_(GV)) :: &
+    drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
+    T_uvh, &        ! Array used to hold temperature at the u,v or h-points for derivative calculations[C ~> degC].
+    S_uvh, &        ! Array used to hold salinity at the u,v or h-points for derivative calculations[S ~> ppt].
+    ! UMW TODO: figure out best way to integrate this array. 
+    ! GxSpV_uvh, &    ! Gravitiational acceleration times the specific volume at an interface
+                  ! at the u-points [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+    pres_uvh        ! Array used to hold pressure on the interface at the u,v or h-points [R L2 T-2 ~> Pa].
   real :: drdiA, drdiB  ! Along layer zonal potential density  gradients in the layers above (A)
                         ! and below (B) the interface times the grid spacing [R ~> kg m-3].
   real :: drdjA, drdjB  ! Along layer meridional potential density  gradients in the layers above (A)
@@ -255,361 +248,319 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   do I=is-1,ie
     GxSpV_u(I) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
-  !$OMP parallel do default(none) shared(nz,is,ie,js,je,IsdB,use_EOS,G,GV,US,pres,T,S,tv,h,e, &
-  !$OMP                                  h_neglect,dz_neglect,h_neglect2, &
-  !$OMP                                  present_N2_u,G_Rho0,N2_u,slope_x,dzSxN,EOSdom_u,EOSdom_h1, &
-  !$OMP                                  local_open_u_BC,dzu,OBC,use_stanley,OBC_friendly) &
-  !$OMP                          private(drdiA,drdiB,drdkL,drdkR,pres_u,T_u,S_u,      &
-  !$OMP                                  drho_dT_u,drho_dS_u,hg2A,hg2B,hg2L,hg2R,haA, &
-  !$OMP                                  drho_dT_dT_h,scrap,pres_h,T_h,S_h, &
-  !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-  !$OMP                                  drdx,mag_grad2,slope) &
-  !$OMP                          firstprivate(GxSpV_u)
-  do j=js,je ; do K=nz,2,-1
-    if (.not.(use_EOS)) then
-      drdiA = 0.0 ; drdiB = 0.0
-      drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
-    endif
 
-    ! Calculate the zonal isopycnal slope.
-    if (use_EOS) then
-      do I=is-1,ie
-        pres_u(I) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
-        T_u(I) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
-        S_u(I) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
-      enddo
-      if (OBC_friendly) then
-        if (OBC%u_E_OBCs_on_PE .and. (j>=OBC%js_u_E_obc) .and. (j<=OBC%je_u_E_obc)) then
-          do I = max(is-1, OBC%Is_u_E_obc), min(ie, OBC%Ie_u_E_obc)
-            if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
-              pres_u(I) = pres(i,j,K)
-              T_u(I) = 0.5*(T(i,j,k) + T(i,j,k-1))
-              S_u(I) = 0.5*(S(i,j,k) + S(i,j,k-1))
-            endif
-          enddo
-        endif
-        if (OBC%u_W_OBCs_on_PE .and. (j>=OBC%js_u_W_obc) .and. (j<=OBC%je_u_W_obc)) then
-          do I = max(is-1, OBC%Is_u_W_obc), min(ie, OBC%Ie_u_W_obc)
-            if (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
-              pres_u(I) = pres(i+1,j,K)
-              T_u(I) = 0.5*(T(i+1,j,k) + T(i+1,j,k-1))
-              S_u(I) = 0.5*(S(i+1,j,k) + S(i+1,j,k-1))
-            endif
-          enddo
-        endif
-      endif
-      call calculate_density_derivs(T_u, S_u, pres_u, drho_dT_u, drho_dS_u, &
-                                    tv%eqn_of_state, EOSdom_u)
-      if (present_N2_u .or. (present(dzSxN))) then
-        if (allocated(tv%SpV_avg)) then
-          do I=is-1,ie
-            GxSpV_u(I) = GV%g_Earth *  0.25* ((tv%SpV_avg(i,j,k) + tv%SpV_avg(i+1,j,k)) + &
-                                              (tv%SpV_avg(i,j,k-1) + tv%SpV_avg(i+1,j,k-1)))
-          enddo
-        endif
-      endif
-    endif
+  ! Calculate density derviatves outside of slope calculation since
+  ! deferred EOS subroutines cannot be called on the GPU
+  if (use_EOS) then
+    ! Calculate density derivatives using T,S,and P at u points. 
+    do j=js,je ; do K=nz,2,-1 ; do I=is-1,ie
+      pres_uvh(I,j,K) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
+      T_uvh(I,j,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
+      S_uvh(I,j,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
+    enddo ; enddo ; enddo
+
+    ! UMW TODO: Add OBC and GxSpV logic
+
+    ! Get density derivatives with i slices of T, S, and P at u points.
+    ! UMW TODO: Does this still have to be over I? 
+    do j=js,je ; do k=nz,2,-1
+      call calculate_density_derivs(T_uvh(:,j,k), S_uvh(:,j,k), pres_uvh(:,j,k), drho_dT(:,j,k), &
+                                  drho_dS(:,j,k), tv%eqn_of_state, EOSdom_u)
+    enddo ; enddo
 
     if (use_stanley) then
-      do i=is-1,ie+1
-        pres_h(i) = pres(i,j,K)
-        T_h(i) = 0.5*(T(i,j,k) + T(i,j,k-1))
-        S_h(i) = 0.5*(S(i,j,k) + S(i,j,k-1))
-      enddo
+      ! Recalculate T, S, and press at h-points for the second derivative calculation.
+      do j=js,je ; do K=nz,2,-1 ; do i=is-1,ie+1
+        pres_uvh(i,j,K) = pres(i,j,K)
+        T_uvh(i,j,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+        S_uvh(i,j,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+      enddo ; enddo ; enddo
+
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
-      call calculate_density_second_derivs(T_h, S_h, pres_h, &
-                   scrap, scrap, drho_dT_dT_h, scrap, scrap, &
+      ! UMW: Currently doing this over i slices, for simplicity - will eventually combine
+      ! with above
+      do j=js,je ; do K=nz,2,-1
+        call calculate_density_second_derivs(T_uvh(:,j,K), S_uvh(:,j,K), pres_uvh(:,j,K), &
+                   scrap, scrap, drho_dT_dT_h(:,j,K), scrap, scrap, &
                    tv%eqn_of_state, dom=EOSdom_h1)
-    endif
+      enddo ; enddo
+    
+    endif ! end use_stanley
 
-    do I=is-1,ie
-      if (use_EOS) then
-        ! Estimate the horizontal density gradients along layers.
-        drdiA = drho_dT_u(I) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
-                drho_dS_u(I) * (S(i+1,j,k-1)-S(i,j,k-1))
-        drdiB = drho_dT_u(I) * (T(i+1,j,k)-T(i,j,k)) + &
-                drho_dS_u(I) * (S(i+1,j,k)-S(i,j,k))
+  ! If not using EOS, just set gradients to zero
+  else
+    drdiA = 0.0 ; drdiB = 0.0
+    drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
+  endif
 
-        ! Estimate the vertical density gradients times the grid spacing.
-        drdkL = (drho_dT_u(I) * (T(i,j,k)-T(i,j,k-1)) + &
-                 drho_dS_u(I) * (S(i,j,k)-S(i,j,k-1)))
-        drdkR = (drho_dT_u(I) * (T(i+1,j,k)-T(i+1,j,k-1)) + &
-                 drho_dS_u(I) * (S(i+1,j,k)-S(i+1,j,k-1)))
-      endif
+  do j=js,je ; do K=nz,2,-1 ; do I=is-1,ie
+    ! UMW: Since stanley parameterization requies EOS anyways, I'm putting
+    ! the use_stanley loop inside of the use_EOS loop for clarity
+    if (use_EOS) then
+      ! Estimate the horizontal density gradients along layers.
+      drdiA = drho_dT(I,j,K) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
+              drho_dS(I,j,K) * (S(i+1,j,k-1)-S(i,j,k-1))
+      drdiB = drho_dT(I,j,K) * (T(i+1,j,k)-T(i,j,k)) + &
+              drho_dS(I,j,K) * (S(i+1,j,k)-S(i,j,k))
+
+      ! Estimate the vertical density gradients times the grid spacing.
+      drdkL = (drho_dT(I,j,K) * (T(i,j,k)-T(i,j,k-1)) + &
+                drho_dS(I,j,K) * (S(i,j,k)-S(i,j,k-1)))
+      drdkR = (drho_dT(I,j,K) * (T(i+1,j,k)-T(i+1,j,k-1)) + &
+                drho_dS(I,j,K) * (S(i+1,j,k)-S(i+1,j,k-1)))
+
       if (use_stanley) then
         ! Correction to the horizontal density gradient due to nonlinearity in
         ! the EOS rectifying SGS temperature anomalies
-        drdiA = drdiA + 0.5 * ((drho_dT_dT_h(i+1) * tv%varT(i+1,j,k-1)) - &
-                              (drho_dT_dT_h(i) * tv%varT(i,j,k-1)) )
-        drdiB = drdiB + 0.5 * ((drho_dT_dT_h(i+1) * tv%varT(i+1,j,k)) - &
-                              (drho_dT_dT_h(i) * tv%varT(i,j,k)) )
+        drdiA = drdiA + 0.5 * ((drho_dT_dT_h(i+1,j,K) * tv%varT(i+1,j,K-1)) - &
+                              (drho_dT_dT_h(i,j,K) * tv%varT(i,j,K-1)) )
+        drdiB = drdiB + 0.5 * ((drho_dT_dT_h(i+1,j,K) * tv%varT(i+1,j,K)) - &
+                              (drho_dT_dT_h(i,j,K) * tv%varT(i,j,K)) )
       endif
+    endif
 
-      hg2A = h(i,j,k-1)*h(i+1,j,k-1) + h_neglect2
-      hg2B = h(i,j,k)*h(i+1,j,k) + h_neglect2
-      hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
-      hg2R = h(i+1,j,k-1)*h(i+1,j,k) + h_neglect2
-      haA = 0.5*(h(i,j,k-1) + h(i+1,j,k-1)) + h_neglect
-      haB = 0.5*(h(i,j,k) + h(i+1,j,k)) + h_neglect
-      haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
-      haR = 0.5*(h(i+1,j,k-1) + h(i+1,j,k)) + h_neglect
-      if (GV%Boussinesq) then
-        dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
-      else
-        dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
-        dzaR = 0.5*(e(i+1,j,K-1) - e(i+1,j,K+1)) + dz_neglect
-      endif
-      if (present(dzu)) dzu(I,j,K) = 0.5*( dzaL + dzaR )
-      ! Use the harmonic mean thicknesses to weight the horizontal gradients.
-      ! These unnormalized weights have been rearranged to minimize divisions.
-      wtA = hg2A*haB ; wtB = hg2B*haA
-      wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
+    hg2A = h(i,j,k-1)*h(i+1,j,k-1) + h_neglect2
+    hg2B = h(i,j,k)*h(i+1,j,k) + h_neglect2
+    hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
+    hg2R = h(i+1,j,k-1)*h(i+1,j,k) + h_neglect2
+    haA = 0.5*(h(i,j,k-1) + h(i+1,j,k-1)) + h_neglect
+    haB = 0.5*(h(i,j,k) + h(i+1,j,k)) + h_neglect
+    haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
+    haR = 0.5*(h(i+1,j,k-1) + h(i+1,j,k)) + h_neglect
+    if (GV%Boussinesq) then
+      dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
+    else
+      dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
+      dzaR = 0.5*(e(i+1,j,K-1) - e(i+1,j,K+1)) + dz_neglect
+    endif
+    if (present(dzu)) dzu(I,j,K) = 0.5*( dzaL + dzaR )
+    ! Use the harmonic mean thicknesses to weight the horizontal gradients.
+    ! These unnormalized weights have been rearranged to minimize divisions.
+    wtA = hg2A*haB ; wtB = hg2B*haA
+    wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
 
-      drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
-      ! The expression for drdz above is mathematically equivalent to:
-      !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
-      !          ((hg2L/haL) + (hg2R/haR))
-      ! which is an estimate of the gradient of density across geopotentials.
-      if (present_N2_u) then
-        if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
-          if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
-            drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
-            if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
-          elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
-            drdz = drdkR / dzaR
-            if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
-          endif
-        endif ; endif
-
-        N2_u(I,j,K) = GxSpV_u(I) * drdz * G%mask2dCu(I,j) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
-      endif
-
-      if (use_EOS) then
-        drdx = ((wtA * drdiA + wtB * drdiB) / (wtA + wtB) - &
-                drdz * (e(i,j,K)-e(i+1,j,K))) * G%IdxCu(I,j)
-
-        ! This estimate of slope is accurate for small slopes, but bounded
-        ! to be between -1 and 1.
-        mag_grad2 = (US%Z_to_L*drdx)**2 + drdz**2
-        if (mag_grad2 > 0.0) then
-          slope = drdx / sqrt(mag_grad2)
-        else ! Just in case mag_grad2 = 0 ever.
-          slope = 0.0
+    drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
+    ! The expression for drdz above is mathematically equivalent to:
+    !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
+    !          ((hg2L/haL) + (hg2R/haR))
+    ! which is an estimate of the gradient of density across geopotentials.
+    if (present_N2_u) then
+      if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
+        if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
+          drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
+          if (use_EOS .and. allocated(tv%SpV_avg)) &
+            GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+        elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
+          drdz = drdkR / dzaR
+          if (use_EOS .and. allocated(tv%SpV_avg)) &
+            GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
         endif
-      else ! With .not.use_EOS, the layers are constant density.
-        slope = (e(i+1,j,K)-e(i,j,K)) * G%IdxCu(I,j)
-      endif
+      endif ; endif
 
-      if (local_open_u_BC) then
-        if (OBC%segnum_u(I,j) /= 0) then
-          if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
-            slope = 0.
-            ! This and/or the masking code below is to make slopes match inside
-            ! land mask. Might not be necessary except for DEBUG output.
+      N2_u(I,j,K) = GxSpV_u(I) * drdz * G%mask2dCu(I,j) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
+    endif
+
+    if (use_EOS) then
+      drdx = ((wtA * drdiA + wtB * drdiB) / (wtA + wtB) - &
+              drdz * (e(i,j,K)-e(i+1,j,K))) * G%IdxCu(I,j)
+
+      ! This estimate of slope is accurate for small slopes, but bounded
+      ! to be between -1 and 1.
+      mag_grad2 = (US%Z_to_L*drdx)**2 + drdz**2
+      if (mag_grad2 > 0.0) then
+        slope = drdx / sqrt(mag_grad2)
+      else ! Just in case mag_grad2 = 0 ever.
+        slope = 0.0
+      endif
+    else ! With .not.use_EOS, the layers are constant density.
+      slope = (e(i+1,j,K)-e(i,j,K)) * G%IdxCu(I,j)
+    endif
+
+    if (local_open_u_BC) then
+      if (OBC%segnum_u(I,j) /= 0) then
+        if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
+          slope = 0.
+          ! This and/or the masking code below is to make slopes match inside
+          ! land mask. Might not be necessary except for DEBUG output.
 !           if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
 !             slope_x(I+1,j,K) = 0.
 !           else
 !             slope_x(I-1,j,K) = 0.
 !           endif
-          endif
         endif
-        slope = slope * max(G%mask2dT(i,j), G%mask2dT(i+1,j))
       endif
+      slope = slope * max(G%mask2dT(i,j), G%mask2dT(i+1,j))
+    endif
 
-      slope_x(I,j,K) = slope
-      if (present(dzSxN)) &
-        dzSxN(I,j,K) = sqrt( GxSpV_u(I) * max(0., (wtL * ( dzaL * drdkL )) &
-                                                + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
-                       * abs(slope) * G%mask2dCu(I,j) ! x-direction contribution to S^2
+    slope_x(I,j,K) = slope
+    if (present(dzSxN)) &
+      dzSxN(I,j,K) = sqrt( GxSpV_u(I) * max(0., (wtL * ( dzaL * drdkL )) &
+                                              + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
+                      * abs(slope) * G%mask2dCu(I,j) ! x-direction contribution to S^2
 
-    enddo ! I
-  enddo ; enddo ! end of j-loop
+  enddo ; enddo ; enddo ! end of j-loop
 
   do i=is,ie
     GxSpV_v(i) = G_Rho0  !This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
   ! Calculate the meridional isopycnal slope.
-  !$OMP parallel do default(none) shared(nz,is,ie,js,je,IsdB,use_EOS,G,GV,US,pres,T,S,tv, &
-  !$OMP                                  h,h_neglect,e,dz_neglect, &
-  !$OMP                                  h_neglect2,present_N2_v,G_Rho0,N2_v,slope_y,dzSyN,EOSdom_v, &
-  !$OMP                                  dzv,local_open_v_BC,OBC,use_stanley,OBC_friendly) &
-  !$OMP                          private(drdjA,drdjB,drdkL,drdkR,pres_v,T_v,S_v,      &
-  !$OMP                                  drho_dT_v,drho_dS_v,hg2A,hg2B,hg2L,hg2R,haA, &
-  !$OMP                                  drho_dT_dT_h,scrap,pres_h,T_h,S_h, &
-  !$OMP                                  drho_dT_dT_hr,pres_hr,T_hr,S_hr,             &
-  !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-  !$OMP                                  drdy,mag_grad2,slope) &
-  !$OMP                          firstprivate(GxSpV_v)
-  do J=js-1,je ; do K=nz,2,-1
-    if (.not.(use_EOS)) then
-      drdjA = 0.0 ; drdjB = 0.0
-      drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
-    endif
 
-    if (use_EOS) then
-      do i=is,ie
-        pres_v(i) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
-        T_v(i) = 0.25*((T(i,j,k) + T(i,j+1,k)) + (T(i,j,k-1) + T(i,j+1,k-1)))
-        S_v(i) = 0.25*((S(i,j,k) + S(i,j+1,k)) + (S(i,j,k-1) + S(i,j+1,k-1)))
-      enddo
-      if (OBC_friendly) then
-        if (OBC%v_N_OBCs_on_PE .and. (J>=OBC%Js_v_N_obc) .and. (J<=OBC%Je_v_N_obc)) then
-          do i = max(is, OBC%is_v_N_obc), min(ie, OBC%ie_v_N_obc)
-            if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
-              pres_v(i) = pres(i,j,K)
-              T_v(i) = 0.5*(T(i,j,k) + T(i,j,k-1))
-              S_v(i) = 0.5*(S(i,j,k) + S(i,j,k-1))
-            endif
-          enddo
-        endif
-        if (OBC%v_S_OBCs_on_PE .and. (J>=OBC%Js_v_S_obc) .and. (J<=OBC%Je_v_S_obc)) then
-          do i = max(is, OBC%is_v_S_obc), min(ie, OBC%ie_v_S_obc)
-            if (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
-              pres_v(i) = pres(i,j+1,K)
-              T_v(i) = 0.5*(T(i,j+1,k) + T(i,j+1,k-1))
-              S_v(i) = 0.5*(S(i,j+1,k) + S(i,j+1,k-1))
-            endif
-          enddo
-        endif
-      endif
-      call calculate_density_derivs(T_v, S_v, pres_v, drho_dT_v, drho_dS_v, &
-                                    tv%eqn_of_state, EOSdom_v)
+  ! As before, calculate density derviatves outside of slope calculation since
+  ! deferred EOS subroutines cannot be called on the GPU, but this time in the
+  ! meridional direciton
+  if (use_EOS) then
+    ! Calculate density derivatives using T,S,and P at v points. 
+    do J=js-1,je ; do K=nz,2,-1 ; do i=is,ie
+      pres_uvh(i,J,K) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
+      T_uvh(i,J,K) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
+      S_uvh(i,J,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
+    enddo ; enddo ; enddo
 
-      if ((present_N2_v) .or. (present(dzSyN))) then
-        if (allocated(tv%SpV_avg)) then
-          do i=is,ie
-            GxSpV_v(i) = GV%g_Earth *  0.25* ((tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j+1,k)) + &
-                                              (tv%SpV_avg(i,j,k-1) + tv%SpV_avg(i,j+1,k-1)))
-          enddo
-        endif
-      endif
-    endif
+    ! UMW TODO: Add OBC and GxSpV logic
+
+    ! Get density derivatives with i slices of T, S, and P at u points.
+    ! UMW TODO: Does this still have to be over I? 
+    do J=js-1,je ; do K=nz,2,-1
+      call calculate_density_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), drho_dT(:,J,K), &
+                                  drho_dS(:,J,K), tv%eqn_of_state, EOSdom_v)
+    enddo ; enddo
 
     if (use_stanley) then
-      do i=is,ie
-        pres_h(i) = pres(i,j,K)
-        T_h(i) = 0.5*(T(i,j,k) + T(i,j,k-1))
-        S_h(i) = 0.5*(S(i,j,k) + S(i,j,k-1))
+      ! Recalculate T, S, and press at h-points for the second derivative calculation.
+      do J=js-1,je ; do K=nz,2,-1 ; do i=is,ie
+        pres_uvh(i,J,K) = pres(i,j,K)
+        T_uvh(i,J,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
+        S_uvh(i,J,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+      enddo ; enddo ; enddo
 
-        pres_hr(i) = pres(i,j+1,K)
-        T_hr(i) = 0.5*(T(i,j+1,k) + T(i,j+1,k-1))
-        S_hr(i) = 0.5*(S(i,j+1,k) + S(i,j+1,k-1))
-      enddo
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
-      call calculate_density_second_derivs(T_h, S_h, pres_h, &
-                   scrap, scrap, drho_dT_dT_h, scrap, scrap, &
-                   tv%eqn_of_state, dom=EOSdom_v)
-      call calculate_density_second_derivs(T_hr, S_hr, pres_hr, &
-                   scrap, scrap, drho_dT_dT_hr, scrap, scrap, &
-                   tv%eqn_of_state, dom=EOSdom_v)
-    endif
-    do i=is,ie
-      if (use_EOS) then
-        ! Estimate the horizontal density gradients along layers.
-        drdjA = drho_dT_v(i) * (T(i,j+1,k-1)-T(i,j,k-1)) + &
-                drho_dS_v(i) * (S(i,j+1,k-1)-S(i,j,k-1))
-        drdjB = drho_dT_v(i) * (T(i,j+1,k)-T(i,j,k)) + &
-                drho_dS_v(i) * (S(i,j+1,k)-S(i,j,k))
+      ! UMW: Currently doing this over i slices, for simplicity - will eventually combine
+      ! with above
+      ! UMW NOTE: changed J bounds to js-1:je+1 to account for extra J acces below
+      ! when calculate drdj 
+      do J=js-1,je+1 ; do K=nz,2,-1
+        call calculate_density_second_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), &
+                   scrap, scrap, drho_dT_dT_h(:,J,K), scrap, scrap, &
+                   tv%eqn_of_state, dom=EOSdom_h1)
+      enddo ; enddo
+    
+    endif ! end use_stanley
 
-        ! Estimate the vertical density gradients times the grid spacing.
-        drdkL = (drho_dT_v(i) * (T(i,j,k)-T(i,j,k-1)) + &
-                 drho_dS_v(i) * (S(i,j,k)-S(i,j,k-1)))
-        drdkR = (drho_dT_v(i) * (T(i,j+1,k)-T(i,j+1,k-1)) + &
-                 drho_dS_v(i) * (S(i,j+1,k)-S(i,j+1,k-1)))
-      endif
+  ! If not using EOS, just set gradients to zero
+  ! UMW TODO: I think I could technically remove this, since 
+  ! they were set above
+  else
+    drdiA = 0.0 ; drdiB = 0.0
+    drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)
+  endif
+
+  do J=js-1,je ; do K=nz,2,-1 ; do i=is,ie
+
+    if (use_EOS) then
+      ! Estimate the horizontal density gradients along layers.
+      drdjA = drho_dT(i,J,K) * (T(i,j+1,k-1)-T(i,j,k-1)) + &
+              drho_dS(i,J,K) * (S(i,j+1,k-1)-S(i,j,k-1))
+      drdjB = drho_dT(i,J,K) * (T(i,j+1,k)-T(i,j,k)) + &
+              drho_dS(i,J,K) * (S(i,j+1,k)-S(i,j,k))
+
+      ! Estimate the vertical density gradients times the grid spacing.
+      drdkL = (drho_dT(i,J,K) * (T(i,j,K)-T(i,j,K-1)) + &
+                drho_dS(i,J,K) * (S(i,j,K)-S(i,j,K-1)))
+      drdkR = (drho_dT(i,J,K) * (T(i,j+1,K)-T(i,j+1,K-1)) + &
+                drho_dS(i,J,K) * (S(i,j+1,K)-S(i,j+1,K-1)))
+
       if (use_stanley) then
         ! Correction to the horizontal density gradient due to nonlinearity in
         ! the EOS rectifying SGS temperature anomalies
-        drdjA = drdjA + 0.5 * ((drho_dT_dT_hr(i) * tv%varT(i,j+1,k-1)) - &
-                              (drho_dT_dT_h(i) * tv%varT(i,j,k-1)) )
-        drdjB = drdjB + 0.5 * ((drho_dT_dT_hr(i) * tv%varT(i,j+1,k)) - &
-                              (drho_dT_dT_h(i) * tv%varT(i,j,k)) )
+        ! UMW NOTE: drho_dT_DT replaced with J+1 index in 3d array
+        drdjA = drdjA + 0.5 * ((drho_dT_dT_h(i,J+1,K) * tv%varT(i,j+1,K-1)) - &
+                              (drho_dT_dT_h(i,J,K) * tv%varT(i,j,K-1)) )
+        drdjB = drdjB + 0.5 * ((drho_dT_dT_h(i,J+1,K) * tv%varT(i,j+1,K)) - &
+                              (drho_dT_dT_h(i,J,K) * tv%varT(i,j,K)) )
       endif
+    endif
 
-      hg2A = h(i,j,k-1)*h(i,j+1,k-1) + h_neglect2
-      hg2B = h(i,j,k)*h(i,j+1,k) + h_neglect2
-      hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
-      hg2R = h(i,j+1,k-1)*h(i,j+1,k) + h_neglect2
-      haA = 0.5*(h(i,j,k-1) + h(i,j+1,k-1)) + h_neglect
-      haB = 0.5*(h(i,j,k) + h(i,j+1,k)) + h_neglect
-      haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
-      haR = 0.5*(h(i,j+1,k-1) + h(i,j+1,k)) + h_neglect
-      if (GV%Boussinesq) then
-        dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
-      else
-        dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
-        dzaR = 0.5*(e(i,j+1,K-1) - e(i,j+1,K+1)) + dz_neglect
-      endif
-      if (present(dzv)) dzv(i,J,K) = 0.5*( dzaL + dzaR )
-      ! Use the harmonic mean thicknesses to weight the horizontal gradients.
-      ! These unnormalized weights have been rearranged to minimize divisions.
-      wtA = hg2A*haB ; wtB = hg2B*haA
-      wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
+    hg2A = h(i,j,k-1)*h(i,j+1,k-1) + h_neglect2
+    hg2B = h(i,j,k)*h(i,j+1,k) + h_neglect2
+    hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
+    hg2R = h(i,j+1,k-1)*h(i,j+1,k) + h_neglect2
+    haA = 0.5*(h(i,j,k-1) + h(i,j+1,k-1)) + h_neglect
+    haB = 0.5*(h(i,j,k) + h(i,j+1,k)) + h_neglect
+    haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
+    haR = 0.5*(h(i,j+1,k-1) + h(i,j+1,k)) + h_neglect
+    if (GV%Boussinesq) then
+      dzaL = haL * GV%H_to_Z ; dzaR = haR * GV%H_to_Z
+    else
+      dzaL = 0.5*(e(i,j,K-1) - e(i,j,K+1)) + dz_neglect
+      dzaR = 0.5*(e(i,j+1,K-1) - e(i,j+1,K+1)) + dz_neglect
+    endif
+    if (present(dzv)) dzv(i,J,K) = 0.5*( dzaL + dzaR )
+    ! Use the harmonic mean thicknesses to weight the horizontal gradients.
+    ! These unnormalized weights have been rearranged to minimize divisions.
+    wtA = hg2A*haB ; wtB = hg2B*haA
+    wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
 
-      drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
-      ! The expression for drdz above is mathematically equivalent to:
-      !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
-      !          ((hg2L/haL) + (hg2R/haR))
-      ! which is an estimate of the gradient of density across geopotentials.
-      if (present_N2_v) then
-        if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
-          if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
-            drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
-            if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
-          elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
-            drdz = drdkL / dzaL
-            if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
-          endif
-        endif ; endif
-
-        N2_v(i,J,K) = GxSpV_v(i) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
-      endif
-
-      if (use_EOS) then
-        drdy = ((wtA * drdjA + wtB * drdjB) / (wtA + wtB) - &
-                drdz * (e(i,j,K)-e(i,j+1,K))) * G%IdyCv(i,J)
-
-        ! This estimate of slope is accurate for small slopes, but bounded
-        ! to be between -1 and 1.
-        mag_grad2 = (US%Z_to_L*drdy)**2 + drdz**2
-        if (mag_grad2 > 0.0) then
-          slope = drdy / sqrt(mag_grad2)
-        else ! Just in case mag_grad2 = 0 ever.
-          slope = 0.0
+    drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
+    ! The expression for drdz above is mathematically equivalent to:
+    !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
+    !          ((hg2L/haL) + (hg2R/haR))
+    ! which is an estimate of the gradient of density across geopotentials.
+    if (present_N2_v) then
+      if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
+        if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
+          drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
+          if (use_EOS .and. allocated(tv%SpV_avg)) &
+            GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+        elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
+          drdz = drdkL / dzaL
+          if (use_EOS .and. allocated(tv%SpV_avg)) &
+            GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
         endif
-      else ! With .not.use_EOS, the layers are constant density.
-        slope = (e(i,j+1,K)-e(i,j,K)) * G%IdyCv(i,J)
-      endif
+      endif ; endif
 
-      if (local_open_v_BC) then
-        if (OBC%segnum_v(i,J) /= 0) then
-          if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
-            slope = 0.
-            ! This and/or the masking code below is to make slopes match inside
-            ! land mask. Might not be necessary except for DEBUG output.
+      N2_v(i,J,K) = GxSpV_v(i) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
+    endif
+
+    if (use_EOS) then
+      drdy = ((wtA * drdjA + wtB * drdjB) / (wtA + wtB) - &
+              drdz * (e(i,j,K)-e(i,j+1,K))) * G%IdyCv(i,J)
+
+      ! This estimate of slope is accurate for small slopes, but bounded
+      ! to be between -1 and 1.
+      mag_grad2 = (US%Z_to_L*drdy)**2 + drdz**2
+      if (mag_grad2 > 0.0) then
+        slope = drdy / sqrt(mag_grad2)
+      else ! Just in case mag_grad2 = 0 ever.
+        slope = 0.0
+      endif
+    else ! With .not.use_EOS, the layers are constant density.
+      slope = (e(i,j+1,K)-e(i,j,K)) * G%IdyCv(i,J)
+    endif
+
+    if (local_open_v_BC) then
+      if (OBC%segnum_v(i,J) /= 0) then
+        if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
+          slope = 0.
+          ! This and/or the masking code below is to make slopes match inside
+          ! land mask. Might not be necessary except for DEBUG output.
 !           if (OBC%segnum_v(i,J)) > 0) then ! OBC_DIRECTION_N
 !             slope_y(i,J+1,K) = 0.
 !           else
 !             slope_y(i,J-1,K) = 0.
 !           endif
-          endif
         endif
-        slope = slope * max(G%mask2dT(i,j), G%mask2dT(i,j+1))
       endif
-      slope_y(i,J,K) = slope
-      if (present(dzSyN)) &
-        dzSyN(i,J,K) = sqrt( GxSpV_v(i) * max(0., (wtL * ( dzaL * drdkL )) &
-                                                + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
-                        * abs(slope) * G%mask2dCv(i,J) ! x-direction contribution to S^2
+      slope = slope * max(G%mask2dT(i,j), G%mask2dT(i,j+1))
+    endif
+    slope_y(i,J,K) = slope
+    if (present(dzSyN)) &
+      dzSyN(i,J,K) = sqrt( GxSpV_v(i) * max(0., (wtL * ( dzaL * drdkL )) &
+                                              + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) & ! dz * N
+                      * abs(slope) * G%mask2dCv(i,J) ! x-direction contribution to S^2
 
-    enddo ! i
-  enddo ; enddo ! end of j-loop
+  enddo ; enddo ; enddo ! end of j-loop
 
 end subroutine calc_isoneutral_slopes
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -227,7 +227,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       pres(i,j,1) = 0.0
     enddo
   endif
-  ! UMW NOTE: K must be serial
+
   do concurrent( j=js-1:je+1 )
     do k=1,nz
       do concurrent( i=is-1:ie+1 )
@@ -242,13 +242,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! Outer loop tiles the (I=is-1:ie, j=js:je) domain into niblock x njblock patches.
   ! Within each tile:
   !   1. Fill tile-sized T_uvh/S_uvh/pres_uvh at u-points on device (do concurrent).
-  !   2. Transfer tile arrays to host (target update from) for CPU-only EOS calls.
-  !   3. Apply OBC overrides (CPU, host-side OBC derived types).
-  !   4. Pre-fill GxSpV_uvh at u-points.
-  !   5. Call calculate_density_derivs over tile.
-  !   6. If use_stanley: refill at h-points, call calculate_density_second_derivs.
-  !   7. Transfer derivatives to device (target update to).
-  !   8. Compute slopes in do concurrent using tile-local indices.
+  !   2. Apply OBC overrides (CPU, host-side OBC derived types).
+  !   3. Pre-fill GxSpV_uvh at u-points.
+  !   4. Call calculate_density_derivs over tile.
+  !   5. If use_stanley: refill at h-points, call calculate_density_second_derivs.
+  !   6. Compute slopes in do concurrent using tile-local indices.
   do jstart=js, je, njblock ; do istart=is-1, ie, niblock ; do kstart=2,nz, nkblock
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + njblock - 1, je)
@@ -273,22 +271,25 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         S_uvh(ii,jj,kk) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
       enddo
 
+      ! UMW NOTE: Vibecoded and untested
       ! Apply OBC overrides: at open boundary faces use only the interior cell's T/S/P
       ! rather than the two-cell average computed above. Runs on CPU because it requires
       ! access to OBC%segnum_u, a derived-type component not mapped to the device.
-      ! UMW TODO: fix the indices in these two loops
       if (OBC_friendly) then
+        !$omp target update from(T_uvh, S_uvh, pres_uvh)
+
         ! East-facing open boundaries: interior cell is at i (=istart+ii-1), use pres/T/S(i,j,K)
         if (OBC%u_E_OBCs_on_PE) then
-          do j = max(jstart, OBC%js_u_E_obc), min(jend, OBC%je_u_E_obc)
-            jj = j - jstart + 1
-            do K = nz, 2, -1
-              do i = max(istart, OBC%Is_u_E_obc), min(iend, OBC%Ie_u_E_obc)
-                ii = i - istart + 1
+          do jj = max(jstart, OBC%js_u_E_obc), min(jend, OBC%je_u_E_obc)
+            j = j - jstart + 1
+            do kk = 1, kend-kstart+1
+              k = kstart + kk - 1
+              do ii = max(istart, OBC%Is_u_E_obc), min(iend, OBC%Ie_u_E_obc)
+                i = i - istart + 1
                 if (OBC%segnum_u(i,j) > 0) then ! OBC_DIRECTION_E
-                  pres_uvh(ii,jj,K) = pres(i,j,K)
-                  T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-                  S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+                  pres_uvh(ii,jj,kk) = pres(i,j,K)
+                  T_uvh(ii,jj,kk) = 0.5*(T(i,j,K) + T(i,j,K-1))
+                  S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
                 endif
               enddo
             enddo
@@ -296,20 +297,23 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         endif
         ! West-facing open boundaries: interior cell is at i+1, use pres/T/S(i+1,j,K)
         if (OBC%u_W_OBCs_on_PE) then
-          do j = max(jstart, OBC%js_u_W_obc), min(jend, OBC%je_u_W_obc)
-            jj = j - jstart + 1
-            do K = nz, 2, -1
-              do i = max(istart, OBC%Is_u_W_obc), min(iend, OBC%Ie_u_W_obc)
-                ii = i - istart + 1
+          do jj = max(jstart, OBC%js_u_W_obc), min(jend, OBC%je_u_W_obc)
+            j = j - jstart + 1
+            do kk = 1, kend-kstart+1
+              k = kstart + kk - 1
+              do ii = max(istart, OBC%Is_u_W_obc), min(iend, OBC%Ie_u_W_obc)
+                i = i - istart + 1
                 if (OBC%segnum_u(i,j) < 0) then ! OBC_DIRECTION_W
-                  pres_uvh(ii,jj,K) = pres(i+1,j,K)
-                  T_uvh(ii,jj,K) = 0.5*(T(i+1,j,K) + T(i+1,j,K-1))
-                  S_uvh(ii,jj,K) = 0.5*(S(i+1,j,K) + S(i+1,j,K-1))
+                  pres_uvh(ii,jj,kk) = pres(i+1,j,K)
+                  T_uvh(ii,jj,kk) = 0.5*(T(i+1,j,K) + T(i+1,j,K-1))
+                  S_uvh(ii,jj,kk) = 0.5*(S(i+1,j,K) + S(i+1,j,K-1))
                 endif
               enddo
             enddo
           enddo
         endif
+
+        !$omp target update to(T_uvh, S_uvh, pres_uvh)
       endif
 
       ! Pre-fill GxSpV at u-points: four-cell SpV average over the u-face and the two
@@ -403,6 +407,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
       drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
       if (present_N2_u) then
+        !UMW NOTE: Vibecoded and untested
         if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
           if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
             drdz = drdkL / dzaL
@@ -475,39 +480,45 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         S_uvh(ii,jj,kk) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
       enddo
 
+      ! UMW NOTE: Vibecoded and untested
       ! Apply OBC overrides at v-points: north-facing uses interior (j), south-facing uses j+1.
-      ! UMW TODO: Fix indices here
       if (OBC_friendly) then
+        !$omp target update from(T_uvh, S_uvh, pres_uvh)
+
         if (OBC%v_N_OBCs_on_PE) then
-          do j = max(jstart, OBC%Js_v_N_obc), min(jend, OBC%Je_v_N_obc)
-            jj = j - jstart + 1
-            do K = nz, 2, -1
-              do i = max(istart, OBC%is_v_N_obc), min(iend, OBC%ie_v_N_obc)
-                ii = i - istart + 1
+          do jj = max(jstart, OBC%Js_v_N_obc), min(jend, OBC%Je_v_N_obc)
+            j = j - jstart + 1
+            do kk = 1, kend-kstart+1
+              k = kstart + kk - 1
+              do ii = max(istart, OBC%is_v_N_obc), min(iend, OBC%ie_v_N_obc)
+                i = i - istart + 1
                 if (OBC%segnum_v(i,j) > 0) then ! OBC_DIRECTION_N
-                  pres_uvh(ii,jj,K) = pres(i,j,K)
-                  T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-                  S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+                  pres_uvh(ii,jj,kk) = pres(i,j,K)
+                  T_uvh(ii,jj,kk) = 0.5*(T(i,j,K) + T(i,j,K-1))
+                  S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
                 endif
               enddo
             enddo
           enddo
         endif
         if (OBC%v_S_OBCs_on_PE) then
-          do j = max(jstart, OBC%Js_v_S_obc), min(jend, OBC%Je_v_S_obc)
-            jj = j - jstart + 1
-            do K = nz, 2, -1
-              do i = max(istart, OBC%is_v_S_obc), min(iend, OBC%ie_v_S_obc)
-                ii = i - istart + 1
+          do jj = max(jstart, OBC%Js_v_S_obc), min(jend, OBC%Je_v_S_obc)
+            j = j - jstart + 1
+            do kk = 1, kend-kstart+1
+              k = kstart + kk - 1
+              do ii = max(istart, OBC%is_v_S_obc), min(iend, OBC%ie_v_S_obc)
+                i = i - istart + 1
                 if (OBC%segnum_v(i,j) < 0) then ! OBC_DIRECTION_S
-                  pres_uvh(ii,jj,K) = pres(i,j+1,K)
-                  T_uvh(ii,jj,K) = 0.5*(T(i,j+1,K) + T(i,j+1,K-1))
-                  S_uvh(ii,jj,K) = 0.5*(S(i,j+1,K) + S(i,j+1,K-1))
+                  pres_uvh(ii,jj,kk) = pres(i,j+1,K)
+                  T_uvh(ii,jj,kk) = 0.5*(T(i,j+1,K) + T(i,j+1,K-1))
+                  S_uvh(ii,jj,kk) = 0.5*(S(i,j+1,K) + S(i,j+1,K-1))
                 endif
               enddo
             enddo
           enddo
         endif
+
+        !$omp target update to(T_uvh, S_uvh, pres_uvh)
       endif
 
       ! Pre-fill GxSpV at v-points.
@@ -599,6 +610,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
       drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
       if (present_N2_v) then
+        ! UMW note: vibecoded and untested
         if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
           if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
             drdz = drdkL / dzaL

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -123,7 +123,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   logical :: local_open_u_BC, local_open_v_BC ! True if u- or v-face OBCs exist anywhere in the global domain.
   logical :: OBC_friendly  ! If true, open boundary conditions are in use and only interior data should
                         ! be used to calculate N2 at OBC faces.
-  integer, dimension(2,2) :: EOSdom_tile    !< 1-based EOS domain for the current tile [nondim].
+  integer, dimension(3,2) :: EOSdom_tile    !< 1-based EOS domain for the current tile [nondim].
   integer, dimension(2)   :: EOSdom_tile_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
@@ -253,6 +253,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     kend = min(kstart + nkblock - 1, nz)
     EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
     EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
+    EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
 
     ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
     ! non-Boussinesq SpV_avg is available.
@@ -331,11 +332,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
 
       ! Density derivatives at u-points. EOSdom_tile is 1-based so no IsdB offset is needed.
-      do kk=1,kend-kstart+1
-        call calculate_density_derivs(T_uvh(:,:,kk), S_uvh(:,:,kk), pres_uvh(:,:,kk), &
-                                      drho_dT(:,:,kk), drho_dS(:,:,kk), &
-                                      tv%eqn_of_state, EOSdom_tile)
-      enddo
+      call calculate_density_derivs(T_uvh, S_uvh, pres_uvh, &
+                                    drho_dT, drho_dS, &
+                                    tv%eqn_of_state, EOSdom_tile)
 
       if (use_stanley) then
         ! Refill T_uvh/S_uvh/pres_uvh at h-points for the Stanley second-derivative calculation.
@@ -462,6 +461,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     kend = min(kstart + nkblock - 1, nz)
     EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
     EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
+    EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
 
     ! Re-initialise GxSpV tile: the zonal pass may have set entries here, so reset to
     ! G_Rho0 before the meridional fills.
@@ -535,11 +535,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
 
       ! Density derivatives at v-points.
-      do kk=1,kend-kstart+1
-        call calculate_density_derivs(T_uvh(:,:,kk), S_uvh(:,:,kk), pres_uvh(:,:,kk), &
-                                      drho_dT(:,:,kk), drho_dS(:,:,kk), &
-                                      tv%eqn_of_state, EOSdom_tile)
-      enddo
+      call calculate_density_derivs(T_uvh, S_uvh, pres_uvh, &
+                                    drho_dT, drho_dS, &
+                                    tv%eqn_of_state, EOSdom_tile)
 
       if (use_stanley) then
         ! Refill at h-points for Stanley second derivatives. Extend to jend+1 in J because

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -81,11 +81,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   real, dimension(SZI_(G), SZJ_(G),SZK_(GV)+1) :: &
     pres          ! The pressure at an interface [R L2 T-2 ~> Pa].
 
-  ! Tiled work arrays. First and second dimensions use niblock+1 / njblock+1 so that
-  ! the Stanley h-point fills (which need one extra column/row beyond the u/v tile extent)
-  ! fit without a separate buffer. drho_dT and drho_dS only ever need niblock x njblock,
-  ! but are dimensioned +1 for alignment with the rest.
-  real, dimension(niblock+1, njblock+1, nkblock) :: &
+  ! Tiled work arrays.
+  real, dimension(niblock, njblock, nkblock) :: &
     drho_dT, &      ! The derivative of density with temperature [R C-1 ~> kg m-3 degC-1].
     drho_dS, &      ! The derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
     drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
@@ -93,7 +90,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     S_uvh, &        ! Salinity at the u, v or h-points for derivative calculations [S ~> ppt].
     GxSpV_uvh, &    ! g * specific volume at u/v-point interfaces [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
     pres_uvh        ! Pressure at the u, v or h-points [R L2 T-2 ~> Pa].
-  real, dimension(niblock+1) :: scrap ! Ignored output from calculate_density_second_derivs()
+  real, dimension(niblock) :: scrap ! Ignored output from calculate_density_second_derivs()
 
   real :: drdiA, drdiB  ! Along layer zonal potential density  gradients in the layers above (A)
                         ! and below (B) the interface times the grid spacing [R ~> kg m-3].
@@ -131,6 +128,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer :: jstart, jend !< First and last global j (or J) indices of the current tile [nondim].
   integer :: kstart, kend !< First and last global K (or K) indices of the current tile [nondim].
   integer :: ii, jj, kk   !< Tile-local 1-based i, j, and k indices [nondim].
+  integer :: delta_i, delta_j
+  integer :: ie_read, je_read        !< Read-only extent of the h-point tile used to supply the
+                                     !! ii+1 (or jj+1) access needed by the Stanley stencil; equal
+                                     !! to ie (or je) plus one column/row when use_stanley is true,
+                                     !! and otherwise equal to ie (or je).
+  integer :: iend_fill, jend_fill    !< Last i (or j) index filled into the Stanley h-point tile,
+                                     !! as opposed to iend/jend, which bound what is actually written
+                                     !! to the output arrays this tile.
 
   ! Allocate locals on device
   !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
@@ -238,22 +243,25 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
   ! non-Boussinesq SpV_avg is available.
-  do concurrent(kk=1:nkblock, jj=1:njblock+1, ii=1:niblock+1)
+  do concurrent(kk=1:nkblock, jj=1:njblock, ii=1:niblock)
     GxSpV_uvh(ii,jj,kk) = G_Rho0
   enddo
 
-  ! ============================================================
-  ! Zonal tiling loop: compute zonal isopycnal slopes
-  ! ============================================================
-  ! Outer loop tiles the (I=is-1:ie, j=js:je) domain into niblock x njblock patches.
-  ! Within each tile:
-  !   1. Fill tile-sized T_uvh/S_uvh/pres_uvh at u-points on device (do concurrent).
-  !   2. Apply OBC overrides (CPU, host-side OBC derived types).
-  !   3. Call calculate_density_derivs over tile.
-  !   4. If use_stanley: refill at h-points, call calculate_density_second_derivs.
-  !   5. Compute slopes in do concurrent using tile-local indices.
-  do kstart=2,nz,nkblock ; do jstart=js,je,njblock ; do istart=is-1,ie,niblock
-    iend = min(istart + niblock - 1, ie)
+  ! Stanley param needs access to h-point element ii+1, so when using stanley param,
+  ! write chunks of size block - 1 instead of chunks of size block to prevent out of
+  ! range writes but read up to ie+1 to include all values needed for slope computation
+  if (use_stanley) then
+    delta_i = niblock - 1
+    ie_read = ie + 1
+  else
+    delta_i = niblock
+    ie_read = ie
+  endif
+
+  ! Tiled zonal loop
+  do kstart=2,nz,nkblock ; do jstart=js,je,njblock ; do istart=is-1,ie,delta_i
+    iend = min(istart + delta_i - 1, ie)
+    iend_fill = min(istart + niblock - 1, ie_read)
     jend = min(jstart + njblock - 1, je)
     kend = min(kstart + nkblock - 1, nz)
     EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
@@ -261,9 +269,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
 
     if (use_EOS) then
-      ! Fill tile T_uvh/S_uvh/pres_uvh at u-points (u-face = average of i and i+1)
+      ! Fill tile T_uvh/S_uvh/pres_uvh at u-points
       do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1)
-        I = istart + II - 1  ! global I (u-face index)
+        I = istart + II - 1  ! global I
         j = jstart + jj - 1  ! global j
         k = kstart + kk - 1  ! global k
         pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
@@ -272,16 +280,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       enddo
 
       ! UMW NOTE: Vibecoded and untested
-      ! Apply OBC overrides: at open boundary faces use only the interior cell's T/S/P
-      ! rather than the two-cell average computed above. Runs on CPU because it requires
-      ! access to OBC%segnum_u, a derived-type component not mapped to the device.
       if (OBC_friendly) then
         !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
-        ! East-facing open boundaries: interior cell is at i (=istart+ii-1), use pres/T/S(i,j,k)
         if (OBC%u_E_OBCs_on_PE) then
           do k = kstart,kend
-              kk = k - kstart + 1
+            kk = k - kstart + 1
             do j = max(jstart, OBC%js_u_E_obc), min(jend, OBC%je_u_E_obc)
               jj = j - jstart + 1
               do i = max(istart, OBC%Is_u_E_obc), min(iend, OBC%Ie_u_E_obc)
@@ -295,7 +299,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
             enddo
           enddo
         endif
-        ! West-facing open boundaries: interior cell is at i+1, use pres/T/S(i+1,j,k)
         if (OBC%u_W_OBCs_on_PE) then
           do k = kstart, kend
             kk = k - kstart + 1
@@ -331,17 +334,16 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         endif
       endif
 
-      ! Density derivatives at u-points. EOSdom_tile is 1-based so no IsdB offset is needed.
       call calculate_density_derivs(T_uvh, S_uvh, pres_uvh, &
                                     drho_dT, drho_dS, &
                                     tv%eqn_of_state, EOSdom_tile)
 
       if (use_stanley) then
         ! Refill T_uvh/S_uvh/pres_uvh at h-points for the Stanley second-derivative calculation.
-        ! The fill extends one extra column (ii up to iend-istart+2) because the slope compute
-        ! accesses drho_dT_dT_h(ii,jj,kk) and drho_dT_dT_h(ii+1,jj,kk) simultaneously.
-        EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 2
-        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+2)
+        ! This tile is filled one column beyond the write range (out to iend_fill = iend+1) to
+        ! supply the ii+1 access used by the compute loop below.
+        EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend_fill - istart + 1
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend_fill-istart+1)
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -350,6 +352,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           S_uvh(ii,jj,kk) = 0.5*(S(i,j,k) + S(i,j,k-1))
         enddo
 
+        ! UMW TODO: Make 3d version of this
         do kk=1,kend-kstart+1 ; do jj=1,jend-jstart+1
           call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
                      scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
@@ -362,8 +365,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ! Zonal slope compute over the tile
     do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1) &
         DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB, I, j))
-      I = istart + II - 1  ! global I (u-face)
-      j = jstart + jj - 1  ! global j (h-point)
+      I = istart + II - 1  ! global I
+      j = jstart + jj - 1  ! global j
       k = kstart + kk - 1  ! global k
 
       if (use_EOS) then
@@ -449,25 +452,29 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     enddo ! end zonal tile do concurrent
   enddo ; enddo ; enddo ! end zonal outer tile loops
 
-  ! ============================================================
-  ! Meridional tiling loop: compute meridional isopycnal slopes
-  ! ============================================================
-  ! Structure mirrors the zonal loop above, but tiling over (i=is:ie, J=js-1:je).
-  ! The Stanley second-derivative fill extends to jend+1 in J because the slope
-  ! compute accesses drho_dT_dT_h(ii,jj,kk) and drho_dT_dT_h(ii,jj+1,kk) simultaneously.
-  do kstart=2,nz, nkblock ; do jstart=js-1,je,njblock ; do istart=is,ie,niblock
+  if (use_stanley) then
+    delta_j = njblock - 1
+    je_read = je + 1
+  else
+    delta_j = njblock
+    je_read = je
+  endif
+
+  ! Tiled meridional loop
+  do kstart=2,nz, nkblock ; do jstart=js-1,je,delta_j ; do istart=is,ie,niblock
     iend = min(istart + niblock - 1, ie)
-    jend = min(jstart + njblock - 1, je)
+    jend = min(jstart + delta_j - 1, je)
+    jend_fill = min(jstart + njblock - 1, je_read)
     kend = min(kstart + nkblock - 1, nz)
     EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
     EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
     EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
 
     if (use_EOS) then
-      ! Fill tile T_uvh/S_uvh/pres_uvh at v-points (v-face = average of j and j+1)
+      ! Fill tile T_uvh/S_uvh/pres_uvh at v-points
       do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1)
-        i = istart + ii - 1  ! global i (h-point)
-        j = jstart + jj - 1  ! global J (v-face index)
+        i = istart + ii - 1  ! global i
+        j = jstart + jj - 1  ! global J
         k = kstart + kk - 1  ! global k
         pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
         T_uvh(ii,jj,kk) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
@@ -475,7 +482,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       enddo
 
       ! UMW NOTE: Vibecoded and untested
-      ! Apply OBC overrides at v-points: north-facing uses interior (j), south-facing uses j+1.
       if (OBC_friendly) then
         !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
@@ -515,7 +521,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         !$omp target update to(T_uvh, S_uvh, pres_uvh)
       endif
 
-      ! Pre-fill GxSpV at v-points.
       if (present_N2_v .or. present(dzSyN)) then
         if (allocated(tv%SpV_avg)) then
           do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1) &
@@ -529,16 +534,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         endif
       endif
 
-      ! Density derivatives at v-points.
       call calculate_density_derivs(T_uvh, S_uvh, pres_uvh, &
                                     drho_dT, drho_dS, &
                                     tv%eqn_of_state, EOSdom_tile)
 
       if (use_stanley) then
-        ! Refill at h-points for Stanley second derivatives. Extend to jend+1 in J because
-        ! the slope compute reads drho_dT_dT_h(ii,jj+1,K) (the J+1 neighbour).
+        ! Refill at h-points for Stanley second derivatives.
         EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 1
-        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+2, ii=1:iend-istart+1)
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend_fill-jstart+1, ii=1:iend-istart+1)
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -547,7 +550,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
         enddo
 
-        do kk=1,kend-kstart+1 ; do jj=1,jend-jstart+2
+        ! UMW TODO: Make 3d versions of this
+        do kk=1,kend-kstart+1 ; do jj=1,jend_fill-jstart+1
           call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
                      scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
                      tv%eqn_of_state, dom=EOSdom_tile_h1)

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -252,7 +252,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   do concurrent( j=js-1:je+1 )
     do k=1,nz
       do concurrent( i=is-1:ie+1 )
-      pres(i,j,K+1) = pres(i,j,K) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
+        pres(i,j,K+1) = pres(i,j,K) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
       enddo
     enddo
   enddo

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -119,12 +119,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   logical :: local_open_u_BC, local_open_v_BC ! True if u- or v-face OBCs exist anywhere in the global domain.
   logical :: OBC_friendly  ! If true, open boundary conditions are in use and only interior data should
                         ! be used to calculate N2 at OBC faces.
-  integer, dimension(2) :: EOSdom_u  ! The shifted I-computational domain to use for equation of
-                                     ! state calculations at u-points.
-  integer, dimension(2) :: EOSdom_v  ! The shifted i-computational domain to use for equation of
-                                     ! state calculations at v-points.
   integer, dimension(2) :: EOSdom_h1 ! The shifted i-computational domain to use for equation of
                                      ! state calculations at h points with 1 extra halo point
+  integer, dimension(2,2) :: EOSdom  ! The shifted i- and j-computational domains to use for equation
+                                     ! of state calculations at u and v points
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
 
@@ -139,8 +137,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
     EOSdom_h1(:) = EOS_domain(G%HI, halo=1)
   endif
-  EOSdom_u(1) = is-1 - (G%IsdB-1) ; EOSdom_u(2) = ie - (G%IsdB-1)
-  EOSdom_v(:) = EOS_domain(G%HI, halo=halo)
+  ! For zonal loop: u-points for i, tracer points for j
+  EOSdom(1,1) = is-1 - (G%IsdB-1) ; EOSdom(1,2) = ie - (G%IsdB-1)
+  EOSdom(2,1) = js - (G%Jsdb-1) ; EOSdom(2,2) = je - (G%Jsdb-1)
 
   nz = GV%ke ; IsdB = G%IsdB
 
@@ -297,10 +296,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
     endif
 
-    do j=js,je ; do k=nz,2,-1
-      call calculate_density_derivs(T_uvh(:,j,k), S_uvh(:,j,k), pres_uvh(:,j,k), drho_dT(:,j,k), &
-                                  drho_dS(:,j,k), tv%eqn_of_state, EOSdom_u)
-    enddo ; enddo
+    do k=nz,2,-1
+      call calculate_density_derivs(T_uvh(:,:,k), S_uvh(:,:,k), pres_uvh(:,:,k), drho_dT(:,:,k), &
+                                  drho_dS(:,:,k), tv%eqn_of_state, EOSdom)
+    enddo
 
     if (use_stanley) then
       ! Recalculate T, S, and press at h-points for the second derivative calculation.
@@ -438,7 +437,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   do concurrent( I=is-1:ie, J=js-1:je, k=1:nz )
     GxSpV_uvh(I,J,k) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
+
   ! Calculate the meridional isopycnal slope.
+  ! For meridional loop: v-points for j, tracer points for i
+  EOSdom(1,1) = is - (G%IsdB-1) ; EOSdom(1,2) = ie - (G%IsdB-1)
+  EOSdom(2,1) = js-1 - (G%Jsdb-1) ; EOSdom(2,2) = je - (G%Jsdb-1)
+
 
   ! As before, calculate density derviatves outside of slope calculation since
   ! deferred EOS subroutines cannot be called on the GPU, but this time in the
@@ -498,10 +502,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
     endif
 
-    do J=js-1,je ; do K=nz,2,-1
-      call calculate_density_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), drho_dT(:,J,K), &
-                                  drho_dS(:,J,K), tv%eqn_of_state, EOSdom_v)
-    enddo ; enddo
+    do K=nz,2,-1
+      call calculate_density_derivs(T_uvh(:,:,K), S_uvh(:,:,K), pres_uvh(:,:,K), drho_dT(:,:,K), &
+                                  drho_dS(:,:,K), tv%eqn_of_state, EOSdom)
+    enddo
 
     if (use_stanley) then
       ! Recalculate T, S, and press at h-points for the second derivative calculation.

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -120,20 +120,20 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   logical :: local_open_u_BC, local_open_v_BC ! True if u- or v-face OBCs exist anywhere in the global domain.
   logical :: OBC_friendly  ! If true, open boundary conditions are in use and only interior data should
                         ! be used to calculate N2 at OBC faces.
-  integer, dimension(3,2) :: EOSdom_tile    !< 1-based EOS domain for the current tile [nondim].
-  integer, dimension(2)   :: EOSdom_tile_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
+  integer, dimension(3,2) :: EOSdom_block    !< 1-based EOS domain for the current tile [nondim].
+  integer, dimension(2)   :: EOSdom_block_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
-  integer :: istart, iend !< First and last global i (or I) indices of the current tile [nondim].
-  integer :: jstart, jend !< First and last global j (or J) indices of the current tile [nondim].
-  integer :: kstart, kend !< First and last global K (or K) indices of the current tile [nondim].
-  integer :: ii, jj, kk   !< Tile-local 1-based i, j, and k indices [nondim].
+  integer :: istart, iend !< First and last global i (or I) indices of the current tile.
+  integer :: jstart, jend !< First and last global j (or J) indices of the current tile.
+  integer :: kstart, kend !< First and last global K (or K) indices of the current tile.
+  integer :: ii, jj, kk   !< Tile-local 1-based i, j, and k indices.
   integer :: delta_i, delta_j
   integer :: ie_read, je_read        !< Read-only extent of the h-point tile used to supply the
                                      !! ii+1 (or jj+1) access needed by the Stanley stencil; equal
                                      !! to ie (or je) plus one column/row when use_stanley is true,
                                      !! and otherwise equal to ie (or je).
-  integer :: iend_fill, jend_fill    !< Last i (or j) index filled into the Stanley h-point tile,
+  integer :: iend_stanley, jend_stanley    !< Last i (or j) index filled into the Stanley h-point tile,
                                      !! as opposed to iend/jend, which bound what is actually written
                                      !! to the output arrays this tile.
 
@@ -241,15 +241,13 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     enddo
   enddo
 
-  ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
-  ! non-Boussinesq SpV_avg is available.
   do concurrent(kk=1:nkblock, jj=1:njblock, ii=1:niblock)
-    GxSpV_uvh(ii,jj,kk) = G_Rho0
+    GxSpV_uvh(ii,jj,kk) = G_Rho0 ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
 
   ! Stanley param needs access to h-point element ii+1, so when using stanley param,
-  ! write chunks of size block - 1 instead of chunks of size block to prevent out of
-  ! range writes but read up to ie+1 to include all values needed for slope computation
+  ! iterate in chunks of size block - 1 but read chunks of size block to ensure blocks
+  ! always included needed elements. Allow access to element ie+1 so element ie is filled
   if (use_stanley) then
     delta_i = niblock - 1
     ie_read = ie + 1
@@ -258,28 +256,27 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ie_read = ie
   endif
 
-  ! Tiled zonal loop
+  ! Calculate the zonal isopycnal slope.
   do kstart=2,nz,nkblock ; do jstart=js,je,njblock ; do istart=is-1,ie,delta_i
     iend = min(istart + delta_i - 1, ie)
-    iend_fill = min(istart + niblock - 1, ie_read)
+    iend_stanley = min(istart + niblock - 1, ie_read)
     jend = min(jstart + njblock - 1, je)
     kend = min(kstart + nkblock - 1, nz)
-    EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
-    EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
-    EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
+    EOSdom_block(1,1) = 1 ; EOSdom_block(1,2) = iend - istart + 1
+    EOSdom_block(2,1) = 1 ; EOSdom_block(2,2) = jend - jstart + 1
+    EOSdom_block(3,1) = 1 ; EOSdom_block(3,2) = kend - kstart + 1
 
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at u-points
       do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1)
-        I = istart + II - 1  ! global I
-        j = jstart + jj - 1  ! global j
-        k = kstart + kk - 1  ! global k
+        I = istart + II - 1
+        j = jstart + jj - 1
+        k = kstart + kk - 1
         pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
         T_uvh(ii,jj,kk) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
         S_uvh(ii,jj,kk) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
       enddo
 
-      ! UMW NOTE: Vibecoded and untested
       if (OBC_friendly) then
         !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
@@ -336,14 +333,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
       call calculate_density_derivs(T_uvh, S_uvh, pres_uvh, &
                                     drho_dT, drho_dS, &
-                                    tv%eqn_of_state, EOSdom_tile)
+                                    tv%eqn_of_state, EOSdom_block)
 
       if (use_stanley) then
-        ! Refill T_uvh/S_uvh/pres_uvh at h-points for the Stanley second-derivative calculation.
-        ! This tile is filled one column beyond the write range (out to iend_fill = iend+1) to
-        ! supply the ii+1 access used by the compute loop below.
-        EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend_fill - istart + 1
-        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend_fill-istart+1)
+        ! Reset T_uvh/S_uvh/pres_uvh at h-points for the Stanley second-derivative calculation.
+        ! This loop fills all niblock elements of the _uvh arrays and can access index ie+1 of T
+        ! and S to ensure there always exists an ii+1 element for the compute loop below.
+        EOSdom_block_h1(1) = 1 ; EOSdom_block_h1(2) = iend_stanley - istart + 1
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend_stanley-istart+1)
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -352,11 +349,13 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           S_uvh(ii,jj,kk) = 0.5*(S(i,j,k) + S(i,j,k-1))
         enddo
 
-        ! UMW TODO: Make 3d version of this
+        ! TODO: Make 3D version of this
         do kk=1,kend-kstart+1 ; do jj=1,jend-jstart+1
+          ! The second line below would correspond to arguments
+          !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
           call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
                      scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
-                     tv%eqn_of_state, dom=EOSdom_tile_h1)
+                     tv%eqn_of_state, dom=EOSdom_block_h1)
         enddo ; enddo
       endif ! end use_stanley
 
@@ -365,26 +364,31 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ! Zonal slope compute over the tile
     do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1) &
         DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB, I, j))
-      I = istart + II - 1  ! global I
-      j = jstart + jj - 1  ! global j
-      k = kstart + kk - 1  ! global k
+      I = istart + II - 1
+      j = jstart + jj - 1
+      k = kstart + kk - 1
 
       if (use_EOS) then
+        ! Estimate the horizontal density gradients along layers.
         drdiA = drho_dT(ii,jj,kk) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
                 drho_dS(ii,jj,kk) * (S(i+1,j,k-1)-S(i,j,k-1))
         drdiB = drho_dT(ii,jj,kk) * (T(i+1,j,k)-T(i,j,k)) + &
                 drho_dS(ii,jj,kk) * (S(i+1,j,k)-S(i,j,k))
+
+        ! Estimate the vertical density gradients times the grid spacing.
         drdkL = (drho_dT(ii,jj,kk) * (T(i,j,k)-T(i,j,k-1)) + &
                   drho_dS(ii,jj,kk) * (S(i,j,k)-S(i,j,k-1)))
         drdkR = (drho_dT(ii,jj,kk) * (T(i+1,j,k)-T(i+1,j,k-1)) + &
                   drho_dS(ii,jj,kk) * (S(i+1,j,k)-S(i+1,j,k-1)))
         if (use_stanley) then
+          ! Correction to the horizontal density gradient due to nonlinearity in
+          ! the EOS rectifying SGS temperature anomalies
           drdiA = drdiA + 0.5 * ((drho_dT_dT_h(ii+1,jj,kk) * tv%varT(i+1,j,K-1)) - &
                                 (drho_dT_dT_h(ii,jj,kk) * tv%varT(i,j,K-1)) )
           drdiB = drdiB + 0.5 * ((drho_dT_dT_h(ii+1,jj,kk) * tv%varT(i+1,j,K)) - &
                                 (drho_dT_dT_h(ii,jj,kk) * tv%varT(i,j,K)) )
         endif
-      else ! .not. use_EOS: layers are constant density
+      else
         drdiA = 0.0 ; drdiB = 0.0
         drdkL = GV%Rlay(K)-GV%Rlay(K-1) ; drdkR = drdkL
       endif
@@ -404,15 +408,20 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         dzaR = 0.5*(e(i+1,j,K-1) - e(i+1,j,K+1)) + dz_neglect
       endif
       if (present(dzu)) dzu(I,j,K) = 0.5*( dzaL + dzaR )
+      ! Use the harmonic mean thicknesses to weight the horizontal gradients.
+      ! These unnormalized weights have been rearranged to minimize divisions.
       wtA = hg2A*haB ; wtB = hg2B*haA
       wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
 
       drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
+      ! The expression for drdz above is mathematically equivalent to:
+      !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
+      !          ((hg2L/haL) + (hg2R/haR))
+      ! which is an estimate of the gradient of density across geopotentials.
       if (present_N2_u) then
-        !UMW NOTE: Vibecoded and untested
         if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
           if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
-            drdz = drdkL / dzaL
+            drdz = drdkL / dzaL ! Note that drdz is not used for slopes at OBC faces.
             if (use_EOS .and. allocated(tv%SpV_avg)) &
               GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
           elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
@@ -421,25 +430,37 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
               GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
           endif
         endif ; endif
-        N2_u(I,j,k) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCu(I,j)
+        N2_u(I,j,k) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCu(I,j) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
       endif
 
       if (use_EOS) then
         drdx = ((wtA * drdiA + wtB * drdiB) / (wtA + wtB) - &
                 drdz * (e(i,j,K)-e(i+1,j,K))) * G%IdxCu(I,j)
+
+        ! This estimate of slope is accurate for small slopes, but bounded
+        ! to be between -1 and 1.
         mag_grad2 = (US%Z_to_L*drdx)**2 + drdz**2
         if (mag_grad2 > 0.0) then
           slope = drdx / sqrt(mag_grad2)
-        else
+        else ! Just in case mag_grad2 = 0 ever.
           slope = 0.0
         endif
-      else
+      else ! With .not.use_EOS, the layers are constant density.
         slope = (e(i+1,j,K)-e(i,j,K)) * G%IdxCu(I,j)
       endif
 
       if (local_open_u_BC) then
         if (OBC%segnum_u(I,j) /= 0) then
-          if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) slope = 0.
+          if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
+            slope = 0.
+            ! This and/or the masking code below is to make slopes match inside
+            ! land mask. Might not be necessary except for DEBUG output.
+!           if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
+!             slope_x(I+1,j,K) = 0.
+!           else
+!             slope_x(I-1,j,K) = 0.
+!           endif
+          endif
         endif
         slope = slope * max(G%mask2dT(i,j), G%mask2dT(i+1,j))
       endif
@@ -464,24 +485,23 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   do kstart=2,nz, nkblock ; do jstart=js-1,je,delta_j ; do istart=is,ie,niblock
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + delta_j - 1, je)
-    jend_fill = min(jstart + njblock - 1, je_read)
+    jend_stanley = min(jstart + njblock - 1, je_read)
     kend = min(kstart + nkblock - 1, nz)
-    EOSdom_tile(1,1) = 1 ; EOSdom_tile(1,2) = iend - istart + 1
-    EOSdom_tile(2,1) = 1 ; EOSdom_tile(2,2) = jend - jstart + 1
-    EOSdom_tile(3,1) = 1 ; EOSdom_tile(3,2) = kend - kstart + 1
+    EOSdom_block(1,1) = 1 ; EOSdom_block(1,2) = iend - istart + 1
+    EOSdom_block(2,1) = 1 ; EOSdom_block(2,2) = jend - jstart + 1
+    EOSdom_block(3,1) = 1 ; EOSdom_block(3,2) = kend - kstart + 1
 
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at v-points
       do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1)
-        i = istart + ii - 1  ! global i
-        j = jstart + jj - 1  ! global J
-        k = kstart + kk - 1  ! global k
+        i = istart + ii - 1
+        j = jstart + jj - 1
+        k = kstart + kk - 1
         pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
         T_uvh(ii,jj,kk) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
         S_uvh(ii,jj,kk) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
       enddo
 
-      ! UMW NOTE: Vibecoded and untested
       if (OBC_friendly) then
         !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
@@ -536,12 +556,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
       call calculate_density_derivs(T_uvh, S_uvh, pres_uvh, &
                                     drho_dT, drho_dS, &
-                                    tv%eqn_of_state, EOSdom_tile)
+                                    tv%eqn_of_state, EOSdom_block)
 
       if (use_stanley) then
-        ! Refill at h-points for Stanley second derivatives.
-        EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 1
-        do concurrent(kk=1:kend-kstart+1, jj=1:jend_fill-jstart+1, ii=1:iend-istart+1)
+        ! Reset at h-points for Stanley second derivatives.
+        EOSdom_block_h1(1) = 1 ; EOSdom_block_h1(2) = iend - istart + 1
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend_stanley-jstart+1, ii=1:iend-istart+1)
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -550,11 +570,13 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
         enddo
 
-        ! UMW TODO: Make 3d versions of this
-        do kk=1,kend-kstart+1 ; do jj=1,jend_fill-jstart+1
+        ! TODO: Make 3D version of this
+        do kk=1,kend-kstart+1 ; do jj=1,jend_stanley-jstart+1
+          ! The second line below would correspond to arguments
+          !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
           call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
                      scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
-                     tv%eqn_of_state, dom=EOSdom_tile_h1)
+                     tv%eqn_of_state, dom=EOSdom_block_h1)
         enddo ; enddo
       endif ! end use_stanley
 
@@ -563,20 +585,25 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     ! Meridional slope compute over the tile
     do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1) &
         DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB, i, J))
-      i = istart + ii - 1  ! global i (h-point)
-      J = jstart + jj - 1  ! global J (v-face)
-      K = kstart + kk - 1  ! global k
+      i = istart + ii - 1
+      J = jstart + jj - 1
+      K = kstart + kk - 1
 
       if (use_EOS) then
+        ! Estimate the horizontal density gradients along layers.
         drdjA = drho_dT(ii,jj,kk) * (T(i,j+1,k-1)-T(i,j,k-1)) + &
                 drho_dS(ii,jj,kk) * (S(i,j+1,k-1)-S(i,j,k-1))
         drdjB = drho_dT(ii,jj,kk) * (T(i,j+1,k)-T(i,j,k)) + &
                 drho_dS(ii,jj,kk) * (S(i,j+1,k)-S(i,j,k))
+
+        ! Estimate the vertical density gradients times the grid spacing.
         drdkL = (drho_dT(ii,jj,kk) * (T(i,j,K)-T(i,j,K-1)) + &
                   drho_dS(ii,jj,kk) * (S(i,j,K)-S(i,j,K-1)))
         drdkR = (drho_dT(ii,jj,kk) * (T(i,j+1,K)-T(i,j+1,K-1)) + &
                   drho_dS(ii,jj,kk) * (S(i,j+1,K)-S(i,j+1,K-1)))
         if (use_stanley) then
+          ! Correction to the horizontal density gradient due to nonlinearity in
+          ! the EOS rectifying SGS temperature anomalies
           drdjA = drdjA + 0.5 * ((drho_dT_dT_h(ii,jj+1,kk) * tv%varT(i,j+1,K-1)) - &
                                 (drho_dT_dT_h(ii,jj,kk) * tv%varT(i,j,K-1)) )
           drdjB = drdjB + 0.5 * ((drho_dT_dT_h(ii,jj+1,kk) * tv%varT(i,j+1,K)) - &
@@ -602,15 +629,20 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         dzaR = 0.5*(e(i,j+1,K-1) - e(i,j+1,K+1)) + dz_neglect
       endif
       if (present(dzv)) dzv(i,J,K) = 0.5*( dzaL + dzaR )
+      ! Use the harmonic mean thicknesses to weight the horizontal gradients.
+      ! These unnormalized weights have been rearranged to minimize divisions.
       wtA = hg2A*haB ; wtB = hg2B*haA
       wtL = hg2L*(haR*dzaR) ; wtR = hg2R*(haL*dzaL)
 
       drdz = ((wtL * drdkL) + (wtR * drdkR)) / ((dzaL*wtL) + (dzaR*wtR))
+      ! The expression for drdz above is mathematically equivalent to:
+      !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
+      !          ((hg2L/haL) + (hg2R/haR))
+      ! which is an estimate of the gradient of density across geopotentials.
       if (present_N2_v) then
-        ! UMW note: vibecoded and untested
         if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
           if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
-            drdz = drdkL / dzaL
+            drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
             if (use_EOS .and. allocated(tv%SpV_avg)) &
               GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
           elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
@@ -619,25 +651,37 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
               GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
           endif
         endif ; endif
-        N2_v(i,J,K) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCv(i,J)
+        N2_v(i,J,K) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
       endif
 
       if (use_EOS) then
         drdy = ((wtA * drdjA + wtB * drdjB) / (wtA + wtB) - &
                 drdz * (e(i,j,K)-e(i,j+1,K))) * G%IdyCv(i,J)
+
+        ! This estimate of slope is accurate for small slopes, but bounded
+        ! to be between -1 and 1.
         mag_grad2 = (US%Z_to_L*drdy)**2 + drdz**2
         if (mag_grad2 > 0.0) then
           slope = drdy / sqrt(mag_grad2)
-        else
+        else ! Just in case mag_grad2 = 0 ever.
           slope = 0.0
         endif
-      else
+      else ! With .not.use_EOS, the layers are constant density.
         slope = (e(i,j+1,K)-e(i,j,K)) * G%IdyCv(i,J)
       endif
 
       if (local_open_v_BC) then
         if (OBC%segnum_v(i,J) /= 0) then
-          if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) slope = 0.
+          if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
+            slope = 0.
+            ! This and/or the masking code below is to make slopes match inside
+            ! land mask. Might not be necessary except for DEBUG output.
+!           if (OBC%segnum_v(i,J)) > 0) then ! OBC_DIRECTION_N
+!             slope_y(i,J+1,K) = 0.
+!           else
+!             slope_y(i,J-1,K) = 0.
+!           endif
+          endif
         endif
         slope = slope * max(G%mask2dT(i,j), G%mask2dT(i,j+1))
       endif

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -228,9 +228,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     enddo
   endif
 
-  do concurrent( j=js-1:je+1 )
+  do concurrent (j=js-1:je+1)
     do k=1,nz
-      do concurrent( i=is-1:ie+1 )
+      do concurrent (i=is-1:ie+1)
         pres(i,j,K+1) = pres(i,j,K) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
       enddo
     enddo
@@ -278,35 +278,35 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       if (OBC_friendly) then
         !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
-        ! East-facing open boundaries: interior cell is at i (=istart+ii-1), use pres/T/S(i,j,K)
+        ! East-facing open boundaries: interior cell is at i (=istart+ii-1), use pres/T/S(i,j,k)
         if (OBC%u_E_OBCs_on_PE) then
-          do jj = max(jstart, OBC%js_u_E_obc), min(jend, OBC%je_u_E_obc)
-            j = j - jstart + 1
-            do kk = 1, kend-kstart+1
-              k = kstart + kk - 1
-              do ii = max(istart, OBC%Is_u_E_obc), min(iend, OBC%Ie_u_E_obc)
-                i = i - istart + 1
+          do k = kstart,kend
+              kk = k - kstart + 1
+            do j = max(jstart, OBC%js_u_E_obc), min(jend, OBC%je_u_E_obc)
+              jj = j - jstart + 1
+              do i = max(istart, OBC%Is_u_E_obc), min(iend, OBC%Ie_u_E_obc)
+                ii = i - istart + 1
                 if (OBC%segnum_u(i,j) > 0) then ! OBC_DIRECTION_E
-                  pres_uvh(ii,jj,kk) = pres(i,j,K)
-                  T_uvh(ii,jj,kk) = 0.5*(T(i,j,K) + T(i,j,K-1))
-                  S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
+                  pres_uvh(ii,jj,kk) = pres(i,j,k)
+                  T_uvh(ii,jj,kk) = 0.5*(T(i,j,k) + T(i,j,k-1))
+                  S_uvh(ii,jj,kk) = 0.5*(S(i,j,k) + S(i,j,k-1))
                 endif
               enddo
             enddo
           enddo
         endif
-        ! West-facing open boundaries: interior cell is at i+1, use pres/T/S(i+1,j,K)
+        ! West-facing open boundaries: interior cell is at i+1, use pres/T/S(i+1,j,k)
         if (OBC%u_W_OBCs_on_PE) then
-          do jj = max(jstart, OBC%js_u_W_obc), min(jend, OBC%je_u_W_obc)
-            j = j - jstart + 1
-            do kk = 1, kend-kstart+1
-              k = kstart + kk - 1
-              do ii = max(istart, OBC%Is_u_W_obc), min(iend, OBC%Ie_u_W_obc)
-                i = i - istart + 1
+          do k = kstart, kend
+            kk = k - kstart + 1
+            do j = max(jstart, OBC%js_u_W_obc), min(jend, OBC%je_u_W_obc)
+              jj = j - jstart + 1
+              do i = max(istart, OBC%Is_u_W_obc), min(iend, OBC%Ie_u_W_obc)
+                ii = i - istart + 1
                 if (OBC%segnum_u(i,j) < 0) then ! OBC_DIRECTION_W
-                  pres_uvh(ii,jj,kk) = pres(i+1,j,K)
-                  T_uvh(ii,jj,kk) = 0.5*(T(i+1,j,K) + T(i+1,j,K-1))
-                  S_uvh(ii,jj,kk) = 0.5*(S(i+1,j,K) + S(i+1,j,K-1))
+                  pres_uvh(ii,jj,kk) = pres(i+1,j,k)
+                  T_uvh(ii,jj,kk) = 0.5*(T(i+1,j,k) + T(i+1,j,k-1))
+                  S_uvh(ii,jj,kk) = 0.5*(S(i+1,j,k) + S(i+1,j,k-1))
                 endif
               enddo
             enddo
@@ -480,12 +480,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
         if (OBC%v_N_OBCs_on_PE) then
-          do jj = max(jstart, OBC%Js_v_N_obc), min(jend, OBC%Je_v_N_obc)
-            j = j - jstart + 1
-            do kk = 1, kend-kstart+1
-              k = kstart + kk - 1
-              do ii = max(istart, OBC%is_v_N_obc), min(iend, OBC%ie_v_N_obc)
-                i = i - istart + 1
+          do k = kstart, kend
+              kk = k - kstart + 1
+            do j = max(jstart, OBC%Js_v_N_obc), min(jend, OBC%Je_v_N_obc)
+              jj = j - jstart + 1
+              do i = max(istart, OBC%is_v_N_obc), min(iend, OBC%ie_v_N_obc)
+                ii = i - istart + 1
                 if (OBC%segnum_v(i,j) > 0) then ! OBC_DIRECTION_N
                   pres_uvh(ii,jj,kk) = pres(i,j,K)
                   T_uvh(ii,jj,kk) = 0.5*(T(i,j,K) + T(i,j,K-1))
@@ -496,12 +496,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           enddo
         endif
         if (OBC%v_S_OBCs_on_PE) then
-          do jj = max(jstart, OBC%Js_v_S_obc), min(jend, OBC%Je_v_S_obc)
-            j = j - jstart + 1
-            do kk = 1, kend-kstart+1
-              k = kstart + kk - 1
-              do ii = max(istart, OBC%is_v_S_obc), min(iend, OBC%ie_v_S_obc)
-                i = i - istart + 1
+          do k = kstart, kend
+            kk = k - kstart + 1
+            do j = max(jstart, OBC%Js_v_S_obc), min(jend, OBC%Je_v_S_obc)
+              jj = j - jstart + 1
+              do i = max(istart, OBC%is_v_S_obc), min(iend, OBC%ie_v_S_obc)
+                ii = i - istart + 1
                 if (OBC%segnum_v(i,j) < 0) then ! OBC_DIRECTION_S
                   pres_uvh(ii,jj,kk) = pres(i,j+1,K)
                   T_uvh(ii,jj,kk) = 0.5*(T(i,j+1,K) + T(i,j+1,K-1))

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -313,6 +313,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! The second line below would correspond to arguments
       !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
       do j=js,je ; do K=nz,2,-1
+        ! UMW TODO: Implement 2d version of this subroutine
         call calculate_density_second_derivs(T_uvh(:,j,K), S_uvh(:,j,K), pres_uvh(:,j,K), &
                    scrap, scrap, drho_dT_dT_h(:,j,K), scrap, scrap, &
                    tv%eqn_of_state, dom=EOSdom_h1)
@@ -323,7 +324,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
 
-  do concurrent( j=js:je , K=2:nz , I=is-1:ie ) DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB))
+  do concurrent( j=js:je , K=2:nz , I=is-1:ie ) DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB)) &
+                                                DO_LOCALITY(local(hg2A, hg2B, hg2L, hg2R, haA, haB, haL, haR)) &
+                                                DO_LOCALITY(local(dzaL, dzaR, wtA, wtB, wtL, wtR, drdx, drdz)) &
+                                                DO_LOCALITY(local(slope, mag_grad2))
     ! UMW: Since stanley parameterization requies EOS anyways, putting
     ! the use_stanley loop inside of the use_EOS loop
     if (use_EOS) then
@@ -521,6 +525,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! UMW NOTE: changed J bounds from js-1:je to js-1:je+1 to account for extra J access below
       ! when calculate drdj
       do J=js-1,je+1 ; do K=nz,2,-1
+        ! UMW TODO: Implement 2d version of this subroutine
         call calculate_density_second_derivs(T_uvh(:,J,K), S_uvh(:,J,K), pres_uvh(:,J,K), &
                    scrap, scrap, drho_dT_dT_h(:,J,K), scrap, scrap, &
                    tv%eqn_of_state, dom=EOSdom_h1)
@@ -531,7 +536,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! If not using EOS, gradients are handled inside the do concurrent loop below
   endif
 
-  do concurrent(J=js-1:je, K=2:nz, i=is:ie) DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB))
+  do concurrent(J=js-1:je, K=2:nz, i=is:ie) DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB)) &
+                                            DO_LOCALITY(local( hg2A, hg2B, hg2L, hg2R, haA, haB, haL, haR)) &
+                                            DO_LOCALITY(local( dzaL, dzaR, wtA, wtB, wtL, wtR, drdy, drdz)) &
+                                            DO_LOCALITY(local( slope, mag_grad2))
 
     if (use_EOS) then
       ! Estimate the horizontal density gradients along layers.

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -25,8 +25,9 @@ public calc_isoneutral_slopes, vert_fill_TS
 ! Default tile sizes for loop blocking. For CPU runs these small values improve cache reuse
 ! by working over small sub-domains at a time. For GPU runs, calc_isoneutral_slopes overrides
 ! these to cover the full computational domain in a single tile (see niblock/njblock below).
-integer, parameter :: default_niblock = 32 !< Default i-direction loop-tile size [nondim].
-integer, parameter :: default_njblock = 4  !< Default j-direction loop-tile size [nondim].
+integer, parameter :: default_niblock = 64 !< Default i-direction loop-tile size [nondim].
+integer, parameter :: default_njblock = 1  !< Default j-direction loop-tile size [nondim].
+integer, parameter :: default_nkblock = 1  !< Default k-direction loop-tile size [nondim].
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -87,7 +88,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! the Stanley h-point fills (which need one extra column/row beyond the u/v tile extent)
   ! fit without a separate buffer. drho_dT and drho_dS only ever need niblock x njblock,
   ! but are dimensioned +1 for alignment with the rest.
-  real, dimension(default_niblock+1, default_njblock+1, SZK_(GV)) :: &
+  real, dimension(default_niblock+1, default_njblock+1, default_nkblock) :: &
     drho_dT, &      ! The derivative of density with temperature [R C-1 ~> kg m-3 degC-1].
     drho_dS, &      ! The derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
     drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
@@ -133,9 +134,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer :: i, j, k
   integer :: niblock_loc  !< i-direction tile size for the current subroutine call [nondim].
   integer :: njblock_loc  !< j-direction tile size for the current subroutine call [nondim].
+  integer :: nkblock_loc  !< k-direction tile size for the current subroutine call [nondim].
   integer :: istart, iend !< First and last global i (or I) indices of the current tile [nondim].
   integer :: jstart, jend !< First and last global j (or J) indices of the current tile [nondim].
-  integer :: ii, jj       !< Tile-local 1-based i and j indices [nondim].
+  integer :: kstart, kend !< First and last global K (or K) indices of the current tile [nondim].
+  integer :: ii, jj,kk       !< Tile-local 1-based i, j, and k indices [nondim].
 
   ! Allocate locals on device
   !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
@@ -148,9 +151,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
     EOSdom_h1(:) = EOS_domain(G%HI, halo=1)
   endif
-  ! For zonal loop: u-points for i, tracer points for j
-  EOSdom(1,1) = is-1 - (G%IsdB-1) ; EOSdom(1,2) = ie - (G%IsdB-1)
-  EOSdom(2,1) = js - (G%Jsdb-1) ; EOSdom(2,2) = je - (G%Jsdb-1)
+  !! For zonal loop: u-points for i, tracer points for j
+  !EOSdom(1,1) = is-1 - (G%IsdB-1) ; EOSdom(1,2) = ie - (G%IsdB-1)
+  !EOSdom(2,1) = js - (G%Jsdb-1) ; EOSdom(2,2) = je - (G%Jsdb-1)
 
   nz = GV%ke ; IsdB = G%IsdB
 
@@ -159,7 +162,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! in a single tile, maximising parallelism. The zonal pass uses I=is-1:ie (extent
   ! ie-is+2) and the meridional pass uses J=js-1:je (extent je-js+2); using these as
   ! niblock_loc/njblock_loc ensures a single tile covers each pass on the GPU.
-  niblock_loc = default_niblock ; njblock_loc = default_njblock
+  niblock_loc = default_niblock ; njblock_loc = default_njblock ; nkblock_loc = default_nkblock
   !$ if (omp_get_num_devices() > 0) then
   !$   niblock_loc = ie - is + 2  ! = (ie) - (is-1) + 1: covers I=is-1:ie in one tile
   !$   njblock_loc = je - js + 2  ! = (je) - (js-1) + 1: covers J=js-1:je in one tile
@@ -270,30 +273,33 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !   6. If use_stanley: refill at h-points, call calculate_density_second_derivs.
   !   7. Transfer derivatives to device (target update to).
   !   8. Compute slopes in do concurrent using tile-local indices.
-  do jstart=js, je, njblock_loc ; do istart=is-1, ie, niblock_loc
+  do jstart=js, je, njblock_loc ; do istart=is-1, ie, niblock_loc ; do kstart=2,nz, nkblock_loc
     iend = min(istart + niblock_loc - 1, ie)
     jend = min(jstart + njblock_loc - 1, je)
+    kend = min(kstart + nkblock_loc - 1, nz)
     EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
 
     ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
     ! non-Boussinesq SpV_avg is available.
-    do concurrent( jj=1:jend-jstart+1, k=1:nz, ii=1:iend-istart+1 )
-      GxSpV_uvh(ii,jj,k) = G_Rho0
+    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 )
+      GxSpV_uvh(ii,jj,kk) = G_Rho0
     enddo
 
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at u-points (u-face = average of i and i+1)
-      do concurrent(jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1)
+      do concurrent(jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1)
         i = istart + ii - 1  ! global I (u-face index)
         j = jstart + jj - 1  ! global j
-        pres_uvh(ii,jj,K) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
-        T_uvh(ii,jj,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
-        S_uvh(ii,jj,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
+        k = kstart + kk - 1  ! global k
+        pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
+        T_uvh(ii,jj,kk) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
+        S_uvh(ii,jj,kk) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
       enddo
 
       ! Apply OBC overrides: at open boundary faces use only the interior cell's T/S/P
       ! rather than the two-cell average computed above. Runs on CPU because it requires
       ! access to OBC%segnum_u, a derived-type component not mapped to the device.
+      ! UMW TODO: fix the indices in these two loops
       if (OBC_friendly) then
         ! East-facing open boundaries: interior cell is at i (=istart+ii-1), use pres/T/S(i,j,K)
         if (OBC%u_E_OBCs_on_PE) then
@@ -333,18 +339,20 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! adjacent layers. Individual OBC faces may override this inside the slope loop.
       if (present_N2_u .or. present(dzSxN)) then
         if (allocated(tv%SpV_avg)) then
-          do jj=1, jend-jstart+1 ; do K=2,nz ; do ii=1, iend-istart+1
-            i = istart + ii - 1 ; j = jstart + jj - 1
-            GxSpV_uvh(ii,jj,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i+1,j,K)) + &
+          do jj=1, jend-jstart+1 ; do kk=1,kend-kstart+1 ; do ii=1, iend-istart+1
+            i = istart + ii - 1
+            j = jstart + jj - 1
+            k = kstart + kk - 1
+            GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i+1,j,K)) + &
                                                         (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i+1,j,K-1)))
           enddo ; enddo ; enddo
         endif
       endif
 
       ! Density derivatives at u-points. EOSdom_tile is 1-based so no IsdB offset is needed.
-      do jj=1,jend-jstart+1 ; do K=nz,2,-1
-        call calculate_density_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
-                                      drho_dT(:,jj,K), drho_dS(:,jj,K), &
+      do jj=1,jend-jstart+1 ; do kk=1,kend-kstart+1
+        call calculate_density_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
+                                      drho_dT(:,jj,kk), drho_dS(:,jj,kk), &
                                       tv%eqn_of_state, EOSdom_tile)
       enddo ; enddo
 
@@ -353,16 +361,18 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         ! The fill extends one extra column (ii up to iend-istart+2) because the slope compute
         ! accesses drho_dT_dT_h(ii,jj,K) and drho_dT_dT_h(ii+1,jj,K) simultaneously.
         EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 2
-        do concurrent(jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+2)
-          i = istart + ii - 1 ; j = jstart + jj - 1
-          pres_uvh(ii,jj,K) = pres(i,j,K)
-          T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-          S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+        do concurrent(jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+2)
+          i = istart + ii - 1
+          j = jstart + jj - 1
+          k = kstart + kk - 1
+          pres_uvh(ii,jj,kk) = pres(i,j,K)
+          T_uvh(ii,jj,kk) = 0.5*(T(i,j,K) + T(i,j,K-1))
+          S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
         enddo
 
-        do jj=1,jend-jstart+1 ; do K=nz,2,-1
-          call calculate_density_second_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
-                     scrap, scrap, drho_dT_dT_h(:,jj,K), scrap, scrap, &
+        do jj=1,jend-jstart+1 ; do kk=1,kend-kstart+1
+          call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
+                     scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
                      tv%eqn_of_state, dom=EOSdom_tile_h1)
         enddo ; enddo
       endif ! end use_stanley
@@ -370,26 +380,26 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     endif ! end use_EOS for zonal tile
 
     ! Zonal slope compute over the tile
-    do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &
+    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 ) &
         local(drdkL, drdkR, drdiA, drdiB, I, j)
       I = istart + ii - 1  ! global I (u-face)
       j = jstart + jj - 1  ! global j (h-point)
-      i = I                 ! i = I for C-grid u-faces
+      k = kstart + kk - 1  ! global k
 
       if (use_EOS) then
-        drdiA = drho_dT(ii,jj,K) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
-                drho_dS(ii,jj,K) * (S(i+1,j,k-1)-S(i,j,k-1))
-        drdiB = drho_dT(ii,jj,K) * (T(i+1,j,k)-T(i,j,k)) + &
-                drho_dS(ii,jj,K) * (S(i+1,j,k)-S(i,j,k))
-        drdkL = (drho_dT(ii,jj,K) * (T(i,j,k)-T(i,j,k-1)) + &
-                  drho_dS(ii,jj,K) * (S(i,j,k)-S(i,j,k-1)))
-        drdkR = (drho_dT(ii,jj,K) * (T(i+1,j,k)-T(i+1,j,k-1)) + &
-                  drho_dS(ii,jj,K) * (S(i+1,j,k)-S(i+1,j,k-1)))
+        drdiA = drho_dT(ii,jj,kk) * (T(i+1,j,k-1)-T(i,j,k-1)) + &
+                drho_dS(ii,jj,kk) * (S(i+1,j,k-1)-S(i,j,k-1))
+        drdiB = drho_dT(ii,jj,kk) * (T(i+1,j,k)-T(i,j,k)) + &
+                drho_dS(ii,jj,kk) * (S(i+1,j,k)-S(i,j,k))
+        drdkL = (drho_dT(ii,jj,kk) * (T(i,j,k)-T(i,j,k-1)) + &
+                  drho_dS(ii,jj,kk) * (S(i,j,k)-S(i,j,k-1)))
+        drdkR = (drho_dT(ii,jj,kk) * (T(i+1,j,k)-T(i+1,j,k-1)) + &
+                  drho_dS(ii,jj,kk) * (S(i+1,j,k)-S(i+1,j,k-1)))
         if (use_stanley) then
-          drdiA = drdiA + 0.5 * ((drho_dT_dT_h(ii+1,jj,K) * tv%varT(i+1,j,K-1)) - &
-                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K-1)) )
-          drdiB = drdiB + 0.5 * ((drho_dT_dT_h(ii+1,jj,K) * tv%varT(i+1,j,K)) - &
-                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K)) )
+          drdiA = drdiA + 0.5 * ((drho_dT_dT_h(ii+1,jj,kk) * tv%varT(i+1,j,K-1)) - &
+                                (drho_dT_dT_h(ii,jj,kk) * tv%varT(i,j,K-1)) )
+          drdiB = drdiB + 0.5 * ((drho_dT_dT_h(ii+1,jj,kk) * tv%varT(i+1,j,K)) - &
+                                (drho_dT_dT_h(ii,jj,kk) * tv%varT(i,j,K)) )
         endif
       else ! .not. use_EOS: layers are constant density
         drdiA = 0.0 ; drdiB = 0.0
@@ -427,7 +437,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
               GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
           endif
         endif ; endif
-        N2_u(I,j,K) = GxSpV_uvh(ii,jj,k) * drdz * G%mask2dCu(I,j)
+        N2_u(I,j,K) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCu(I,j)
       endif
 
       if (use_EOS) then
@@ -452,11 +462,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
       slope_x(I,j,K) = slope
       if (present(dzSxN)) &
-        dzSxN(I,j,K) = sqrt( GxSpV_uvh(ii,jj,k) * max(0., (wtL * ( dzaL * drdkL )) &
+        dzSxN(I,j,K) = sqrt( GxSpV_uvh(ii,jj,kk) * max(0., (wtL * ( dzaL * drdkL )) &
                                                 + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) &
                         * abs(slope) * G%mask2dCu(I,j)
     enddo ! end zonal tile do concurrent
-  enddo ; enddo ! end zonal outer tile loops
+    enddo ; enddo ; enddo ! end zonal outer tile loops
 
   ! ============================================================
   ! Meridional tiling loop: compute meridional isopycnal slopes
@@ -464,28 +474,31 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! Structure mirrors the zonal loop above, but tiling over (i=is:ie, J=js-1:je).
   ! The Stanley second-derivative fill extends to jend+1 in J because the slope
   ! compute accesses drho_dT_dT_h(ii,jj,K) and drho_dT_dT_h(ii,jj+1,K) simultaneously.
-  do jstart=js-1, je, njblock_loc ; do istart=is, ie, niblock_loc
+  do jstart=js-1, je, njblock_loc ; do istart=is, ie, niblock_loc ; do kstart=2,nz, nkblock_loc
     iend = min(istart + niblock_loc - 1, ie)
     jend = min(jstart + njblock_loc - 1, je)
+    kend = min(kstart + nkblock_loc - 1, nz)
     EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
 
     ! Re-initialise GxSpV tile: the zonal pass may have set entries here, so reset to
     ! G_Rho0 before the meridional fills.
-    do concurrent( jj=1:jend-jstart+1, k=1:nz, ii=1:iend-istart+1 )
-      GxSpV_uvh(ii,jj,k) = G_Rho0
+    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1 )
+      GxSpV_uvh(ii,jj,kk) = G_Rho0
     enddo
 
     if (use_EOS) then
       ! Fill tile T_uvh/S_uvh/pres_uvh at v-points (v-face = average of j and j+1)
-      do concurrent(jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1)
+      do concurrent(jj=1:jend-jstart+1, kk=1:kend-kstart+1, ii=1:iend-istart+1)
         i = istart + ii - 1  ! global i (h-point)
         j = jstart + jj - 1  ! global J (v-face index)
-        pres_uvh(ii,jj,K) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
-        T_uvh(ii,jj,K) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
-        S_uvh(ii,jj,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
+        k = kstart + kk - 1  ! global k
+        pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i,j+1,K))
+        T_uvh(ii,jj,kk) = 0.25*((T(i,j,K) + T(i,j+1,K)) + (T(i,j,K-1) + T(i,j+1,K-1)))
+        S_uvh(ii,jj,kk) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
       enddo
 
       ! Apply OBC overrides at v-points: north-facing uses interior (j), south-facing uses j+1.
+      ! UMW TODO: Fix indices here
       if (OBC_friendly) then
         if (OBC%v_N_OBCs_on_PE) then
           do j = max(jstart, OBC%Js_v_N_obc), min(jend, OBC%Je_v_N_obc)
@@ -522,18 +535,20 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! Pre-fill GxSpV at v-points.
       if (present_N2_v .or. present(dzSyN)) then
         if (allocated(tv%SpV_avg)) then
-          do jj=1, jend-jstart+1 ; do K=2,nz ; do ii=1, iend-istart+1
-            i = istart + ii - 1 ; j = jstart + jj - 1
-            GxSpV_uvh(ii,jj,K) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i,j+1,K)) + &
+          do jj=1, jend-jstart+1 ; do kk=1, kend-kstart+1 ; do ii=1, iend-istart+1
+            i = istart + ii - 1
+            j = jstart + jj - 1
+            k = kstart + kk - 1
+            GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.25 * ((tv%SpV_avg(i,j,K) + tv%SpV_avg(i,j+1,K)) + &
                                                         (tv%SpV_avg(i,j,K-1) + tv%SpV_avg(i,j+1,K-1)))
           enddo ; enddo ; enddo
         endif
       endif
 
       ! Density derivatives at v-points.
-      do jj=1,jend-jstart+1 ; do K=nz,2,-1
-        call calculate_density_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
-                                      drho_dT(:,jj,K), drho_dS(:,jj,K), &
+      do jj=1,jend-jstart+1 ; do kk=1,kend-kstart+1
+        call calculate_density_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
+                                      drho_dT(:,jj,kk), drho_dS(:,jj,kk), &
                                       tv%eqn_of_state, EOSdom_tile)
       enddo ; enddo
 
@@ -541,16 +556,18 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         ! Refill at h-points for Stanley second derivatives. Extend to jend+1 in J because
         ! the slope compute reads drho_dT_dT_h(ii,jj+1,K) (the J+1 neighbour).
         EOSdom_tile_h1(1) = 1 ; EOSdom_tile_h1(2) = iend - istart + 1
-        do concurrent(jj=1:jend-jstart+2, K=2:nz, ii=1:iend-istart+1)
-          i = istart + ii - 1 ; j = jstart + jj - 1
-          pres_uvh(ii,jj,K) = pres(i,j,K)
-          T_uvh(ii,jj,K) = 0.5*(T(i,j,K) + T(i,j,K-1))
-          S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
+        do concurrent(jj=1:jend-jstart+2, kk=1:kend-kstart, ii=1:iend-istart+1)
+          i = istart + ii - 1
+          j = jstart + jj - 1
+          k = kstart + kk - 1
+          pres_uvh(ii,jj,kk) = pres(i,j,K)
+          T_uvh(ii,jj,kk) = 0.5*(T(i,j,K) + T(i,j,K-1))
+          S_uvh(ii,jj,kk) = 0.5*(S(i,j,K) + S(i,j,K-1))
         enddo
 
-        do jj=1,jend-jstart+2 ; do K=nz,2,-1
-          call calculate_density_second_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
-                     scrap, scrap, drho_dT_dT_h(:,jj,K), scrap, scrap, &
+        do jj=1,jend-jstart+2 ; do kk=1,kend-kstart+1
+          call calculate_density_second_derivs(T_uvh(:,jj,kk), S_uvh(:,jj,kk), pres_uvh(:,jj,kk), &
+                     scrap, scrap, drho_dT_dT_h(:,jj,kk), scrap, scrap, &
                      tv%eqn_of_state, dom=EOSdom_tile_h1)
         enddo ; enddo
       endif ! end use_stanley
@@ -558,26 +575,26 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     endif ! end use_EOS for meridional tile
 
     ! Meridional slope compute over the tile
-    do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &
+    do concurrent( jj=1:jend-jstart+1, kk=1:kend-kstart, ii=1:iend-istart+1 ) &
         local(drdkL, drdkR, drdjA, drdjB, i, J)
       i = istart + ii - 1  ! global i (h-point)
       J = jstart + jj - 1  ! global J (v-face)
-      j = J                 ! j = J for C-grid v-faces
+      K = kstart + kk - 1  ! global k
 
       if (use_EOS) then
-        drdjA = drho_dT(ii,jj,K) * (T(i,j+1,k-1)-T(i,j,k-1)) + &
-                drho_dS(ii,jj,K) * (S(i,j+1,k-1)-S(i,j,k-1))
-        drdjB = drho_dT(ii,jj,K) * (T(i,j+1,k)-T(i,j,k)) + &
-                drho_dS(ii,jj,K) * (S(i,j+1,k)-S(i,j,k))
-        drdkL = (drho_dT(ii,jj,K) * (T(i,j,K)-T(i,j,K-1)) + &
-                  drho_dS(ii,jj,K) * (S(i,j,K)-S(i,j,K-1)))
-        drdkR = (drho_dT(ii,jj,K) * (T(i,j+1,K)-T(i,j+1,K-1)) + &
-                  drho_dS(ii,jj,K) * (S(i,j+1,K)-S(i,j+1,K-1)))
+        drdjA = drho_dT(ii,jj,kk) * (T(i,j+1,k-1)-T(i,j,k-1)) + &
+                drho_dS(ii,jj,kk) * (S(i,j+1,k-1)-S(i,j,k-1))
+        drdjB = drho_dT(ii,jj,kk) * (T(i,j+1,k)-T(i,j,k)) + &
+                drho_dS(ii,jj,kk) * (S(i,j+1,k)-S(i,j,k))
+        drdkL = (drho_dT(ii,jj,kk) * (T(i,j,K)-T(i,j,K-1)) + &
+                  drho_dS(ii,jj,kk) * (S(i,j,K)-S(i,j,K-1)))
+        drdkR = (drho_dT(ii,jj,kk) * (T(i,j+1,K)-T(i,j+1,K-1)) + &
+                  drho_dS(ii,jj,kk) * (S(i,j+1,K)-S(i,j+1,K-1)))
         if (use_stanley) then
-          drdjA = drdjA + 0.5 * ((drho_dT_dT_h(ii,jj+1,K) * tv%varT(i,j+1,K-1)) - &
-                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K-1)) )
-          drdjB = drdjB + 0.5 * ((drho_dT_dT_h(ii,jj+1,K) * tv%varT(i,j+1,K)) - &
-                                (drho_dT_dT_h(ii,jj,K) * tv%varT(i,j,K)) )
+          drdjA = drdjA + 0.5 * ((drho_dT_dT_h(ii,jj+1,kk) * tv%varT(i,j+1,K-1)) - &
+                                (drho_dT_dT_h(ii,jj,kk) * tv%varT(i,j,K-1)) )
+          drdjB = drdjB + 0.5 * ((drho_dT_dT_h(ii,jj+1,kk) * tv%varT(i,j+1,K)) - &
+                                (drho_dT_dT_h(ii,jj,kk) * tv%varT(i,j,K)) )
         endif
       else
         drdjA = 0.0 ; drdjB = 0.0
@@ -608,14 +625,14 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
             drdz = drdkL / dzaL
             if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+              GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
           elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
             drdz = drdkL / dzaL
             if (use_EOS .and. allocated(tv%SpV_avg)) &
-              GxSpV_uvh(ii,jj,k) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
+              GxSpV_uvh(ii,jj,kk) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
           endif
         endif ; endif
-        N2_v(i,J,K) = GxSpV_uvh(ii,jj,k) * drdz * G%mask2dCv(i,J)
+        N2_v(i,J,K) = GxSpV_uvh(ii,jj,kk) * drdz * G%mask2dCv(i,J)
       endif
 
       if (use_EOS) then
@@ -639,11 +656,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
       slope_y(i,J,K) = slope
       if (present(dzSyN)) &
-        dzSyN(i,J,K) = sqrt( GxSpV_uvh(ii,jj,k) * max(0., (wtL * ( dzaL * drdkL )) &
+        dzSyN(i,J,K) = sqrt( GxSpV_uvh(ii,jj,kk) * max(0., (wtL * ( dzaL * drdkL )) &
                                                 + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) &
                         * abs(slope) * G%mask2dCv(i,J)
     enddo ! end meridional tile do concurrent
-  enddo ; enddo ! end meridional outer tile loops
+  enddo ; enddo ; enddo! end meridional outer tile loops
 
   ! Delete all tile and field arrays from device
   !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -211,11 +211,15 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   endif
 
   if (use_EOS) then
+    !$omp target enter data map(to: h, tv%T, tv%S)
+    !$omp target enter data map(alloc: T, S)
     if (present(halo)) then
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, halo+1)
     else
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, 1)
     endif
+    !$omp target exit data map(from: T, S)
+    !$omp target exit data map(release: h, tv%T, tv%S)
   endif
 
   if ((use_EOS .and. allocated(tv%SpV_avg) .and. (tv%valid_SpV_halo < 1)) .and. &
@@ -660,15 +664,16 @@ subroutine vert_fill_TS(h, T_in, S_in, kappa_dt, T_f, S_f, G, GV, US, halo_here,
     if (larger_h_denom) h0 = 1.0e-16*sqrt(0.5*kap_dt_x2)
   endif
 
+  !$omp target enter data map(alloc: ent, b1, d1, c1)
+
   if (kap_dt_x2 <= 0.0) then
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=js,je ; do i=is,ie
+    do concurrent (k=1:nz , j=js:je , i=is:ie)
       T_f(i,j,k) = T_in(i,j,k) ; S_f(i,j,k) = S_in(i,j,k)
-    enddo ; enddo ; enddo
+    enddo
   else
-    !$OMP parallel do default(shared) private(ent,b1,d1,c1,h_tr)
+    !$omp target teams distribute parallel do private( ent, b1, d1, c1 )
     do j=js,je
-      do i=is,ie
+      do concurrent( i=is:ie )
         ent(i,2) = kap_dt_x2 / ((h(i,j,1)+h(i,j,2)) + h0)
         h_tr = h(i,j,1) + h_neglect
         b1(i) = 1.0 / (h_tr + ent(i,2))
@@ -676,7 +681,7 @@ subroutine vert_fill_TS(h, T_in, S_in, kappa_dt, T_f, S_f, G, GV, US, halo_here,
         T_f(i,j,1) = (b1(i)*h_tr)*T_in(i,j,1)
         S_f(i,j,1) = (b1(i)*h_tr)*S_in(i,j,1)
       enddo
-      do k=2,nz-1 ; do i=is,ie
+      do k=2,nz-1 ; do concurrent( i=is:ie )
         ent(i,K+1) = kap_dt_x2 / ((h(i,j,k)+h(i,j,k+1)) + h0)
         h_tr = h(i,j,k) + h_neglect
         c1(i,k) = ent(i,K) * b1(i)
@@ -685,19 +690,21 @@ subroutine vert_fill_TS(h, T_in, S_in, kappa_dt, T_f, S_f, G, GV, US, halo_here,
         T_f(i,j,k) = b1(i) * (h_tr*T_in(i,j,k) + ent(i,K)*T_f(i,j,k-1))
         S_f(i,j,k) = b1(i) * (h_tr*S_in(i,j,k) + ent(i,K)*S_f(i,j,k-1))
       enddo ; enddo
-      do i=is,ie
+      do concurrent( i=is:ie )
         c1(i,nz) = ent(i,nz) * b1(i)
         h_tr = h(i,j,nz) + h_neglect
         b1(i) = 1.0 / (h_tr + d1(i)*ent(i,nz))
         T_f(i,j,nz) = b1(i) * (h_tr*T_in(i,j,nz) + ent(i,nz)*T_f(i,j,nz-1))
         S_f(i,j,nz) = b1(i) * (h_tr*S_in(i,j,nz) + ent(i,nz)*S_f(i,j,nz-1))
       enddo
-      do k=nz-1,1,-1 ; do i=is,ie
+      do k=nz-1,1,-1 ; do concurrent( i=is:ie )
         T_f(i,j,k) = T_f(i,j,k) + c1(i,k+1)*T_f(i,j,k+1)
         S_f(i,j,k) = S_f(i,j,k) + c1(i,k+1)*S_f(i,j,k+1)
       enddo ; enddo
     enddo
   endif
+
+  !$omp target exit data map(delete: ent, b1, d1, c1)
 
 end subroutine vert_fill_TS
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -81,7 +81,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   real, dimension(SZI_(G), SZJ_(G),SZK_(GV)+1) :: &
     pres          ! The pressure at an interface [R L2 T-2 ~> Pa].
 
-  ! Tiled work arrays.
+  ! Blocked work arrays.
   real, dimension(niblock, njblock, nkblock) :: &
     drho_dT, &      ! The derivative of density with temperature [R C-1 ~> kg m-3 degC-1].
     drho_dS, &      ! The derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
@@ -120,22 +120,22 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   logical :: local_open_u_BC, local_open_v_BC ! True if u- or v-face OBCs exist anywhere in the global domain.
   logical :: OBC_friendly  ! If true, open boundary conditions are in use and only interior data should
                         ! be used to calculate N2 at OBC faces.
-  integer, dimension(3,2) :: EOSdom_block    !< 1-based EOS domain for the current tile [nondim].
+  integer, dimension(3,2) :: EOSdom_block    !< 1-based EOS domain for the current block [nondim].
   integer, dimension(2)   :: EOSdom_block_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
-  integer :: istart, iend !< First and last global i (or I) indices of the current tile.
-  integer :: jstart, jend !< First and last global j (or J) indices of the current tile.
-  integer :: kstart, kend !< First and last global K (or K) indices of the current tile.
-  integer :: ii, jj, kk   !< Tile-local 1-based i, j, and k indices.
+  integer :: istart, iend !< First and last global i (or I) indices of the current block.
+  integer :: jstart, jend !< First and last global j (or J) indices of the current block.
+  integer :: kstart, kend !< First and last global K (or K) indices of the current block.
+  integer :: ii, jj, kk   !< Block-local 1-based i, j, and k indices.
   integer :: delta_i, delta_j
-  integer :: ie_read, je_read        !< Read-only extent of the h-point tile used to supply the
+  integer :: ie_read, je_read        !< Read-only extent of the h-point block used to supply the
                                      !! ii+1 (or jj+1) access needed by the Stanley stencil; equal
                                      !! to ie (or je) plus one column/row when use_stanley is true,
                                      !! and otherwise equal to ie (or je).
-  integer :: iend_stanley, jend_stanley    !< Last i (or j) index filled into the Stanley h-point tile,
+  integer :: iend_stanley, jend_stanley    !< Last i (or j) index filled into the Stanley h-point block,
                                      !! as opposed to iend/jend, which bound what is actually written
-                                     !! to the output arrays this tile.
+                                     !! to the output arrays this block.
 
   ! Allocate locals on device
   !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
@@ -248,6 +248,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! Stanley param needs access to h-point element ii+1, so when using stanley param,
   ! iterate in chunks of size block - 1 but read chunks of size block to ensure blocks
   ! always included needed elements. Allow access to element ie+1 so element ie is filled
+  ! Block sizes are validated to be > 0 and not equal to 1 if use_stanley at initialization
   if (use_stanley) then
     delta_i = niblock - 1
     ie_read = ie + 1
@@ -267,9 +268,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     EOSdom_block(3,1) = 1 ; EOSdom_block(3,2) = kend - kstart + 1
 
     if (use_EOS) then
-      ! Fill tile T_uvh/S_uvh/pres_uvh at u-points
-      do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1)
-        I = istart + II - 1
+      ! Fill block T_uvh/S_uvh/pres_uvh at u-points
+      do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1) &
+          DO_LOCALITY(local(i,j,k))
+        i = istart + ii - 1
         j = jstart + jj - 1
         k = kstart + kk - 1
         pres_uvh(ii,jj,kk) = 0.5*(pres(i,j,K) + pres(i+1,j,K))
@@ -340,7 +342,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         ! This loop fills all niblock elements of the _uvh arrays and can access index ie+1 of T
         ! and S to ensure there always exists an ii+1 element for the compute loop below.
         EOSdom_block_h1(1) = 1 ; EOSdom_block_h1(2) = iend_stanley - istart + 1
-        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend_stanley-istart+1)
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend_stanley-istart+1) &
+            DO_LOCALITY(local(i,j,k))
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -359,9 +362,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         enddo ; enddo
       endif ! end use_stanley
 
-    endif ! end use_EOS for zonal tile
+    endif ! end use_EOS for zonal block
 
-    ! Zonal slope compute over the tile
+    ! Zonal slope compute over the block
     do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, II=1:iend-istart+1) &
         DO_LOCALITY(local(drdkL, drdkR, drdiA, drdiB, I, j))
       I = istart + II - 1
@@ -470,8 +473,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         dzSxN(I,j,K) = sqrt( GxSpV_uvh(ii,jj,kk) * max(0., (wtL * ( dzaL * drdkL )) &
                                                 + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) &
                         * abs(slope) * G%mask2dCu(I,j)
-    enddo ! end zonal tile do concurrent
-  enddo ; enddo ; enddo ! end zonal outer tile loops
+    enddo ! end zonal block do concurrent
+  enddo ; enddo ; enddo ! end zonal outer block loops
 
   if (use_stanley) then
     delta_j = njblock - 1
@@ -481,7 +484,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     je_read = je
   endif
 
-  ! Tiled meridional loop
+  ! Blocked meridional loop
   do kstart=2,nz, nkblock ; do jstart=js-1,je,delta_j ; do istart=is,ie,niblock
     iend = min(istart + niblock - 1, ie)
     jend = min(jstart + delta_j - 1, je)
@@ -492,8 +495,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     EOSdom_block(3,1) = 1 ; EOSdom_block(3,2) = kend - kstart + 1
 
     if (use_EOS) then
-      ! Fill tile T_uvh/S_uvh/pres_uvh at v-points
-      do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1)
+      ! Fill block T_uvh/S_uvh/pres_uvh at v-points
+      do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1) &
+          DO_LOCALITY(local(i,j,k))
         i = istart + ii - 1
         j = jstart + jj - 1
         k = kstart + kk - 1
@@ -561,7 +565,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       if (use_stanley) then
         ! Reset at h-points for Stanley second derivatives.
         EOSdom_block_h1(1) = 1 ; EOSdom_block_h1(2) = iend - istart + 1
-        do concurrent(kk=1:kend-kstart+1, jj=1:jend_stanley-jstart+1, ii=1:iend-istart+1)
+        do concurrent(kk=1:kend-kstart+1, jj=1:jend_stanley-jstart+1, ii=1:iend-istart+1) &
+            DO_LOCALITY(local(i,j,k))
           i = istart + ii - 1
           j = jstart + jj - 1
           k = kstart + kk - 1
@@ -580,9 +585,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         enddo ; enddo
       endif ! end use_stanley
 
-    endif ! end use_EOS for meridional tile
+    endif ! end use_EOS for meridional block
 
-    ! Meridional slope compute over the tile
+    ! Meridional slope compute over the block
     do concurrent(kk=1:kend-kstart+1, jj=1:jend-jstart+1, ii=1:iend-istart+1) &
         DO_LOCALITY(local(drdkL, drdkR, drdjA, drdjB, i, J))
       i = istart + ii - 1
@@ -690,10 +695,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         dzSyN(i,J,K) = sqrt( GxSpV_uvh(ii,jj,kk) * max(0., (wtL * ( dzaL * drdkL )) &
                                                 + (wtR * ( dzaR * drdkR ))) / (wtL + wtR) ) &
                         * abs(slope) * G%mask2dCv(i,J)
-    enddo ! end meridional tile do concurrent
-  enddo ; enddo ; enddo! end meridional outer tile loops
+    enddo ! end meridional block do concurrent
+  enddo ; enddo ; enddo ! end meridional outer block loops
 
-  ! Delete all tile and field arrays from device
+  ! Delete all block and field arrays from device
   !$omp target exit data map(delete: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
   !$omp   scrap, drho_dT, drho_dS, drho_dT_dT_h)
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -22,13 +22,6 @@ implicit none ; private
 
 public calc_isoneutral_slopes, vert_fill_TS
 
-! Default tile sizes for loop blocking. For CPU runs these small values improve cache reuse
-! by working over small sub-domains at a time. For GPU runs, calc_isoneutral_slopes overrides
-! these to cover the full computational domain in a single tile (see niblock/njblock below).
-integer, parameter :: default_niblock = 64 !< Default i-direction loop-tile size [nondim].
-integer, parameter :: default_njblock = 1  !< Default j-direction loop-tile size [nondim].
-integer, parameter :: default_nkblock = 1  !< Default k-direction loop-tile size [nondim].
-
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
 ! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
@@ -39,7 +32,11 @@ contains
 !> Calculate isopycnal slopes, and optionally return other stratification dependent functions such as N^2
 !! and dz*S^2*g-prime used, or calculable from factors used, during the calculation.
 subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stanley, slope_x, slope_y, &
-                                  N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, halo, OBC, OBC_N2)
+                                  niblock, njblock, nkblock, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, halo, &
+                                  OBC, OBC_N2)
+  integer,                                     intent(in)    :: niblock !< Blocksize in i direction
+  integer,                                     intent(in)    :: njblock !< Blocksize in j direction
+  integer,                                     intent(in)    :: nkblock !< Blocksize in k direction
   type(ocean_grid_type),                       intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                     intent(in)    :: GV   !< The ocean's vertical grid structure
   type(unit_scale_type),                       intent(in)    :: US   !< A dimensional unit scaling type
@@ -88,7 +85,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! the Stanley h-point fills (which need one extra column/row beyond the u/v tile extent)
   ! fit without a separate buffer. drho_dT and drho_dS only ever need niblock x njblock,
   ! but are dimensioned +1 for alignment with the rest.
-  real, dimension(default_niblock+1, default_njblock+1, default_nkblock) :: &
+  real, dimension(niblock+1, njblock+1, nkblock) :: &
     drho_dT, &      ! The derivative of density with temperature [R C-1 ~> kg m-3 degC-1].
     drho_dS, &      ! The derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
     drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
@@ -96,7 +93,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     S_uvh, &        ! Salinity at the u, v or h-points for derivative calculations [S ~> ppt].
     GxSpV_uvh, &    ! g * specific volume at u/v-point interfaces [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
     pres_uvh        ! Pressure at the u, v or h-points [R L2 T-2 ~> Pa].
-  real, dimension(default_niblock+1) :: scrap ! Ignored output from calculate_density_second_derivs()
+  real, dimension(niblock+1) :: scrap ! Ignored output from calculate_density_second_derivs()
 
   real :: drdiA, drdiB  ! Along layer zonal potential density  gradients in the layers above (A)
                         ! and below (B) the interface times the grid spacing [R ~> kg m-3].
@@ -132,13 +129,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   integer, dimension(2) :: EOSdom_tile_h1 !< 1-based EOS domain for h-point fills (one extra column) [nondim].
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
-  integer :: niblock_loc  !< i-direction tile size for the current subroutine call [nondim].
-  integer :: njblock_loc  !< j-direction tile size for the current subroutine call [nondim].
-  integer :: nkblock_loc  !< k-direction tile size for the current subroutine call [nondim].
   integer :: istart, iend !< First and last global i (or I) indices of the current tile [nondim].
   integer :: jstart, jend !< First and last global j (or J) indices of the current tile [nondim].
   integer :: kstart, kend !< First and last global K (or K) indices of the current tile [nondim].
-  integer :: ii, jj,kk       !< Tile-local 1-based i, j, and k indices [nondim].
+  integer :: ii, jj, kk   !< Tile-local 1-based i, j, and k indices [nondim].
 
   ! Allocate locals on device
   !$omp target enter data map(alloc: T, S, pres, T_uvh, S_uvh, pres_uvh, GxSpV_uvh, &
@@ -151,22 +145,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
     EOSdom_h1(:) = EOS_domain(G%HI, halo=1)
   endif
-  !! For zonal loop: u-points for i, tracer points for j
-  !EOSdom(1,1) = is-1 - (G%IsdB-1) ; EOSdom(1,2) = ie - (G%IsdB-1)
-  !EOSdom(2,1) = js - (G%Jsdb-1) ; EOSdom(2,2) = je - (G%Jsdb-1)
 
   nz = GV%ke ; IsdB = G%IsdB
-
-  ! Set tile sizes. On CPU, use the module defaults (small tiles for cache locality).
-  ! On GPU, override to the full computational domain so the entire domain is processed
-  ! in a single tile, maximising parallelism. The zonal pass uses I=is-1:ie (extent
-  ! ie-is+2) and the meridional pass uses J=js-1:je (extent je-js+2); using these as
-  ! niblock_loc/njblock_loc ensures a single tile covers each pass on the GPU.
-  niblock_loc = default_niblock ; njblock_loc = default_njblock ; nkblock_loc = default_nkblock
-  !$ if (omp_get_num_devices() > 0) then
-  !$   niblock_loc = ie - is + 2  ! = (ie) - (is-1) + 1: covers I=is-1:ie in one tile
-  !$   njblock_loc = je - js + 2  ! = (je) - (js-1) + 1: covers J=js-1:je in one tile
-  !$ endif
 
   h_neglect = GV%H_subroundoff ; h_neglect2 = h_neglect**2
   dz_neglect = GV%dZ_subroundoff
@@ -263,7 +243,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! ============================================================
   ! Zonal tiling loop: compute zonal isopycnal slopes
   ! ============================================================
-  ! Outer loop tiles the (I=is-1:ie, j=js:je) domain into niblock_loc x njblock_loc patches.
+  ! Outer loop tiles the (I=is-1:ie, j=js:je) domain into niblock x njblock patches.
   ! Within each tile:
   !   1. Fill tile-sized T_uvh/S_uvh/pres_uvh at u-points on device (do concurrent).
   !   2. Transfer tile arrays to host (target update from) for CPU-only EOS calls.
@@ -273,10 +253,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !   6. If use_stanley: refill at h-points, call calculate_density_second_derivs.
   !   7. Transfer derivatives to device (target update to).
   !   8. Compute slopes in do concurrent using tile-local indices.
-  do jstart=js, je, njblock_loc ; do istart=is-1, ie, niblock_loc ; do kstart=2,nz, nkblock_loc
-    iend = min(istart + niblock_loc - 1, ie)
-    jend = min(jstart + njblock_loc - 1, je)
-    kend = min(kstart + nkblock_loc - 1, nz)
+  do jstart=js, je, njblock ; do istart=is-1, ie, niblock ; do kstart=2,nz, nkblock
+    iend = min(istart + niblock - 1, ie)
+    jend = min(jstart + njblock - 1, je)
+    kend = min(kstart + nkblock - 1, nz)
     EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
 
     ! Initialise GxSpV tile to the Boussinesq default G/rho0; overwritten below if
@@ -474,10 +454,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! Structure mirrors the zonal loop above, but tiling over (i=is:ie, J=js-1:je).
   ! The Stanley second-derivative fill extends to jend+1 in J because the slope
   ! compute accesses drho_dT_dT_h(ii,jj,K) and drho_dT_dT_h(ii,jj+1,K) simultaneously.
-  do jstart=js-1, je, njblock_loc ; do istart=is, ie, niblock_loc ; do kstart=2,nz, nkblock_loc
-    iend = min(istart + niblock_loc - 1, ie)
-    jend = min(jstart + njblock_loc - 1, je)
-    kend = min(kstart + nkblock_loc - 1, nz)
+  do jstart=js-1, je, njblock ; do istart=is, ie, niblock ; do kstart=2,nz, nkblock
+    iend = min(istart + niblock - 1, ie)
+    jend = min(jstart + njblock - 1, je)
+    kend = min(kstart + nkblock - 1, nz)
     EOSdom_tile(1) = 1 ; EOSdom_tile(2) = iend - istart + 1
 
     ! Re-initialise GxSpV tile: the zonal pass may have set entries here, so reset to

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -228,9 +228,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     enddo
   endif
   ! UMW NOTE: K must be serial
-  do concurrent( j=js-1:je+1, i=is-1:ie+1 )
+  do concurrent( j=js-1:je+1 )
     do k=1,nz
+      do concurrent( i=is-1:ie+1 )
       pres(i,j,K+1) = pres(i,j,K) + GV%g_Earth * GV%H_to_RZ * h(i,j,k)
+      enddo
     enddo
   enddo
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -225,11 +225,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     else
       call vert_fill_TS(h, tv%T, tv%S, dt_kappa_smooth, T, S, G, GV, US, 1)
     endif
-#ifdef DEBUG
-    !$omp target update from(T, S)
-    call hchksum(T, "calc_isoneutral_slopes: T after vert_fill", G%HI)
-    call hchksum(S, "calc_isoneutral_slopes: S after vert_fill", G%HI)
-#endif
   endif
 
   if ((use_EOS .and. allocated(tv%SpV_avg) .and. (tv%valid_SpV_halo < 1)) .and. &
@@ -295,9 +290,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         T_uvh(ii,jj,K) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
         S_uvh(ii,jj,K) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
       enddo
-
-      ! Transfer tile arrays from device to host for CPU-only EOS and OBC operations
-      !$omp target update from(T_uvh, S_uvh, pres_uvh)
 
       ! Apply OBC overrides: at open boundary faces use only the interior cell's T/S/P
       ! rather than the two-cell average computed above. Runs on CPU because it requires
@@ -368,8 +360,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
         enddo
 
-        !$omp target update from(T_uvh, S_uvh, pres_uvh)
-
         do jj=1,jend-jstart+1 ; do K=nz,2,-1
           call calculate_density_second_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
                      scrap, scrap, drho_dT_dT_h(:,jj,K), scrap, scrap, &
@@ -378,9 +368,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif ! end use_stanley
 
     endif ! end use_EOS for zonal tile
-
-    ! Push density derivatives to device for the slope compute kernel
-    !$omp target update to(drho_dT, drho_dS, drho_dT_dT_h)
 
     ! Zonal slope compute over the tile
     do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &
@@ -498,8 +485,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         S_uvh(ii,jj,K) = 0.25*((S(i,j,K) + S(i,j+1,K)) + (S(i,j,K-1) + S(i,j+1,K-1)))
       enddo
 
-      !$omp target update from(T_uvh, S_uvh, pres_uvh)
-
       ! Apply OBC overrides at v-points: north-facing uses interior (j), south-facing uses j+1.
       if (OBC_friendly) then
         if (OBC%v_N_OBCs_on_PE) then
@@ -563,8 +548,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           S_uvh(ii,jj,K) = 0.5*(S(i,j,K) + S(i,j,K-1))
         enddo
 
-        !$omp target update from(T_uvh, S_uvh, pres_uvh)
-
         do jj=1,jend-jstart+2 ; do K=nz,2,-1
           call calculate_density_second_derivs(T_uvh(:,jj,K), S_uvh(:,jj,K), pres_uvh(:,jj,K), &
                      scrap, scrap, drho_dT_dT_h(:,jj,K), scrap, scrap, &
@@ -573,9 +556,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif ! end use_stanley
 
     endif ! end use_EOS for meridional tile
-
-    ! Push derivatives to device
-    !$omp target update to(drho_dT, drho_dS, drho_dT_dT_h)
 
     ! Meridional slope compute over the tile
     do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -87,7 +87,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   ! the Stanley h-point fills (which need one extra column/row beyond the u/v tile extent)
   ! fit without a separate buffer. drho_dT and drho_dS only ever need niblock x njblock,
   ! but are dimensioned +1 for alignment with the rest.
-  real, dimension(niblock+1, njblock+1, SZK_(GV)) :: &
+  real, dimension(default_niblock+1, default_njblock+1, SZK_(GV)) :: &
     drho_dT, &      ! The derivative of density with temperature [R C-1 ~> kg m-3 degC-1].
     drho_dS, &      ! The derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
     drho_dT_dT_h, & ! The second derivative of density with temperature at h points [R C-2 ~> kg m-3 degC-2]
@@ -95,7 +95,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
     S_uvh, &        ! Salinity at the u, v or h-points for derivative calculations [S ~> ppt].
     GxSpV_uvh, &    ! g * specific volume at u/v-point interfaces [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
     pres_uvh        ! Pressure at the u, v or h-points [R L2 T-2 ~> Pa].
-  real, dimension(niblock+1) :: scrap ! Ignored output from calculate_density_second_derivs()
+  real, dimension(default_niblock+1) :: scrap ! Ignored output from calculate_density_second_derivs()
 
   real :: drdiA, drdiB  ! Along layer zonal potential density  gradients in the layers above (A)
                         ! and below (B) the interface times the grid spacing [R ~> kg m-3].
@@ -384,7 +384,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     ! Zonal slope compute over the tile
     do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &
-        local(drdkL, drdkR, drdiA, drdiB, I, j, i)
+        local(drdkL, drdkR, drdiA, drdiB, I, j)
       I = istart + ii - 1  ! global I (u-face)
       j = jstart + jj - 1  ! global j (h-point)
       i = I                 ! i = I for C-grid u-faces
@@ -579,7 +579,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
     ! Meridional slope compute over the tile
     do concurrent( jj=1:jend-jstart+1, K=2:nz, ii=1:iend-istart+1 ) &
-        local(drdkL, drdkR, drdjA, drdjB, i, j, J)
+        local(drdkL, drdkR, drdjA, drdjB, i, J)
       i = istart + ii - 1  ! global i (h-point)
       J = jstart + jj - 1  ! global J (v-face)
       j = J                 ! j = J for C-grid v-faces

--- a/src/core/MOM_stoch_eos.F90
+++ b/src/core/MOM_stoch_eos.F90
@@ -224,7 +224,11 @@ subroutine MOM_calc_varT(G, GV, US, h, tv, CS, dt)
   ! extreme gradients along layers which are vanished against topography. It is
   ! still a poor approximation in the interior when coordinates are strongly tilted.
   if (.not. associated(tv%varT)) allocate(tv%varT(G%isd:G%ied, G%jsd:G%jed, GV%ke), source=0.0)
+  !$omp target enter data map(to: h, tv%T, tv%S)
+  !$omp target enter data map(alloc: T, S)
   call vert_fill_TS(h, tv%T, tv%S, CS%kappa_smooth*dt, T, S, G, GV, US, halo_here=1, larger_h_denom=.true.)
+  !$omp target exit data map(from: T, S)
+  !$omp target exit data map(release: h, tv%T, tv%S)
 
   do k=1,G%ke
     do j=G%jsc,G%jec

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1878,9 +1878,12 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=2)
-  !$omp target exit data map(from: e)
   ! Note the hard-coded dimenisional constant in the following line.
+  !$omp target enter data map(to: tv%T, tv%S)
+  !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y)
+  !$omp target exit data map(release: tv%T, tv%S, e)
+  !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   call pass_vector(slope_x, slope_y, G%Domain)
   do j=js-1,je+1 ; do i=is-1,ie+1
     slope_x_vert_avg(I,j) = vertical_average_interface(slope_x(i,j,:), h_u(i,j,:), GV%H_subroundoff)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -35,6 +35,7 @@ use MOM_variables,         only : vertvisc_type, thermo_var_ptrs
 use MOM_verticalGrid,      only : verticalGrid_type
 use MOM_MEKE_types,        only : MEKE_type
 
+!$ use omp_lib, only: omp_get_num_devices
 
 implicit none ; private
 
@@ -167,6 +168,11 @@ type, public :: MEKE_CS ; private
   integer :: id_slope_x = -1 !< Diagnostic id for isopycnal slope in the x-direction
   integer :: id_slope_y = -1 !< Diagnostic id for isopycnal slope in the y-direction
   integer :: id_rv      = -1 !< Diagnostic id for surface relative vorticity
+
+  ! Isoneutral blocking parameters
+  integer :: niblock         !< The i block size used in calc_isoneutral_slopes [nondim].
+  integer :: njblock         !< The j block size used in calc_isoneutral_slopes [nondim].
+  integer :: nkblock         !< The k block size used in calc_isoneutral_slopes [nondim].
 
 end type MEKE_CS
 
@@ -1825,6 +1831,23 @@ subroutine ML_MEKE_init(diag, G, US, Time, param_file, dbcomms_CS, CS)
   CS%id_rv = register_diag_field('ocean_model', 'MEKE_RV', diag%axesT1, Time, &
      'Surface relative vorticity used in MEKE', 's-1', conversion=US%s_to_T)
 
+  ! Isoneutral blocking parameters
+  call get_param(param_file, mdl, "ISOPYCNAL_NIBLOCK", CS%niblock, &
+                 "The i-direction block size used to calculate isopycnal slopes. "//&
+                 "If 0, defaults to 64, except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain width is used.", default=64)
+  call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
+                 "The j-direction block size used in the continuity solver. "//&
+                 "If 0, defaults to 1, except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain height is used.", default=1)
+  call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
+                 "The j-direction block size used in the continuity solver. "//&
+                 "If 0, defaults to 1 , except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain height is used.", default=1)
+
 end subroutine ML_MEKE_init
 
 !> Calculate the various features used for the machine learning prediction
@@ -1865,6 +1888,7 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   real :: sum_area  ! A sum of adjacent cell areas [L2 ~> m2]
 
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+  integer :: niblock, njblock, nkblock
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -1875,6 +1899,16 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
     h_u(I,j,k) = 0.5*(h(i,j,k)*G%mask2dT(i,j) + h(i+1,j,k)*G%mask2dT(i+1,j)) + GV%Angstrom_H
     h_v(i,J,k) = 0.5*(h(i,j,k)*G%mask2dT(i,j) + h(i,j+1,k)*G%mask2dT(i,j+1)) + GV%Angstrom_H
   enddo ; enddo ; enddo
+
+  niblock = CS%niblock
+  njblock = CS%njblock
+  nkblock = CS%nkblock
+  !$ if (omp_get_num_devices() > 0) then
+  !$   niblock = ie - is + 1
+  !$   njblock = je - js + 1
+  !$   nkblock = nz
+  !$ endif
+
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=2)
@@ -1883,7 +1917,8 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
-  call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y)
+  call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y, &
+                              niblock, njblock, nkblock )
   !$omp target exit data map(release: tv, tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1882,11 +1882,11 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   ! UMW: Below is untested
   !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
-  !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+  !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y)
   !$omp target exit data map(release: tv, tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
-  !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+  !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
   !$omp target exit data map(from: slope_x, slope_y)
   call pass_vector(slope_x, slope_y, G%Domain)
   do j=js-1,je+1 ; do i=is-1,ie+1

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -35,8 +35,6 @@ use MOM_variables,         only : vertvisc_type, thermo_var_ptrs
 use MOM_verticalGrid,      only : verticalGrid_type
 use MOM_MEKE_types,        only : MEKE_type
 
-!$ use omp_lib, only: omp_get_num_devices
-
 implicit none ; private
 
 #include <MOM_memory.h>
@@ -1769,6 +1767,15 @@ subroutine ML_MEKE_init(diag, G, US, Time, param_file, dbcomms_CS, CS)
   character(len=200)  :: inputdir, backend, model_filename
   integer :: db_return_code, batch_size
   character(len=40) :: mdl = "MOM_ML_MEKE"
+  #ifdef __NVCOMPILER_OPENMP_GPU
+  integer, parameter :: default_niblock = 0
+  integer, parameter :: default_njblock = 0
+  integer, parameter :: default_nkblock = 0
+  #else
+  integer, parameter :: default_niblock = 0
+  integer, parameter :: default_njblock = 1
+  integer, parameter :: default_nkblock = 1
+  #endif
 
   ! Store pointers in control structure
   write(CS%key_suffix, '(A,I6.6)') '_', PE_here()
@@ -1836,17 +1843,17 @@ subroutine ML_MEKE_init(diag, G, US, Time, param_file, dbcomms_CS, CS)
                  "The i-direction block size used to calculate isopycnal slopes. "//&
                  "If 0, defaults to 64, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=64)
+                 "domain width is used.", default=default_niblock)
   call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=1)
+                 "domain height is used.", default=default_njblock)
   call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1 , except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=1)
+                 "domain height is used.", default=default_nkblock)
 
 end subroutine ML_MEKE_init
 
@@ -1890,6 +1897,10 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: niblock, njblock, nkblock
 
+  niblock = CS%niblock
+  njblock = CS%njblock
+  nkblock = CS%nkblock
+
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
@@ -1900,14 +1911,9 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
     h_v(i,J,k) = 0.5*(h(i,j,k)*G%mask2dT(i,j) + h(i,j+1,k)*G%mask2dT(i,j+1)) + GV%Angstrom_H
   enddo ; enddo ; enddo
 
-  niblock = CS%niblock
-  njblock = CS%njblock
-  nkblock = CS%nkblock
-  !$ if (omp_get_num_devices() > 0) then
-  !$   niblock = ie - is + 1
-  !$   njblock = je - js + 1
-  !$   nkblock = nz
-  !$ endif
+  if (niblock == 0) niblock = ie - is + 1
+  if (njblock == 0) njblock = je - js + 1
+  if (nkblock == 0) nkblock = nz
 
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -144,7 +144,6 @@ type, public :: MEKE_CS ; private
   type(external_field) :: eke_handle   !< Handle for reading in EKE from a file
   ! Infrastructure
   integer :: id_clock_pass !< Clock for group pass calls
-  integer :: id_clock_isoneutral_slopes !< Clock for calc_isoneutral_slopes calls
   type(group_pass_type) :: pass_MEKE !< Group halo pass handle for MEKE%MEKE and maybe MEKE%Kh_diff
   type(group_pass_type) :: pass_Kh   !< Group halo pass handle for MEKE%Kh, MEKE%Ku, and/or MEKE%Au
 
@@ -1716,7 +1715,6 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
   endif
 
   CS%id_clock_pass = cpu_clock_id('(Ocean continuity halo updates)', grain=CLOCK_ROUTINE)
-  CS%id_clock_isoneutral_slopes = cpu_clock_id('(Calc_isoneutral_slopes)', grain=CLOCK_ROUTINE)
 
 
   ! Detect whether this instance of MEKE_init() is at the beginning of a run
@@ -1881,7 +1879,6 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=2)
   ! Note the hard-coded dimenisional constant in the following line.
-  call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
   ! UMW: Below is untested
   !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
@@ -1891,7 +1888,6 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
   !$omp target exit data map(from: slope_x, slope_y)
-  call cpu_clock_end(CS%id_clock_isoneutral_slopes)
   call pass_vector(slope_x, slope_y, G%Domain)
   do j=js-1,je+1 ; do i=is-1,ie+1
     slope_x_vert_avg(I,j) = vertical_average_interface(slope_x(i,j,:), h_u(i,j,:), GV%H_subroundoff)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1716,7 +1716,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
   endif
 
   CS%id_clock_pass = cpu_clock_id('(Ocean continuity halo updates)', grain=CLOCK_ROUTINE)
-  CS%id_clock_isoneutral_slopes = cpu_clock_id('(MEKE isoneutral slopes)', grain=CLOCK_ROUTINE)
+  CS%id_clock_isoneutral_slopes = cpu_clock_id('(Calc_isoneutral_slopes)', grain=CLOCK_ROUTINE)
 
 
   ! Detect whether this instance of MEKE_init() is at the beginning of a run

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1885,9 +1885,11 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   ! UMW: Below is untested
   !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e))
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
+  !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y)
   !$omp target exit data map(release: tv, tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+  !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
   !$omp target exit data map(from: slope_x, slope_y)
   call cpu_clock_end(CS%id_clock_isoneutral_slopes)
   call pass_vector(slope_x, slope_y, G%Domain)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1883,7 +1883,7 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   ! Note the hard-coded dimenisional constant in the following line.
   call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
   ! UMW: Below is untested
-  !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e))
+  !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1841,19 +1841,32 @@ subroutine ML_MEKE_init(diag, G, US, Time, param_file, dbcomms_CS, CS)
   ! Isoneutral blocking parameters
   call get_param(param_file, mdl, "ISOPYCNAL_NIBLOCK", CS%niblock, &
                  "The i-direction block size used to calculate isopycnal slopes. "//&
-                 "If 0, defaults to 64, except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=default_niblock, layoutParam=.true.)
+                 "If 0, or when running with OpenMP offload, "//&
+                 "the full computational domain width is used. "//&
+                 "If USE_STANLEY_ISO is true, ISOPYCNAL_NIBLOCK cannot equal 1.", &
+                 default=default_niblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
-                 "The j-direction block size used in the continuity solver. "//&
+                 "The j-direction block size used to calculate isopycnal slopes. "//&
+                 "If 0, defaults to 1, except when running with OpenMP offload, "//&
+                 "in which case the full computational domain height is used. " //&
+                 "If USE_STANLEY_ISO is true, ISOPYCNAL_NJBLOCK cannot equal 1.", &
+                 default=default_njblock, layoutParam=.true.)
+  call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
+                 "The k-direction block size used to calculate isopycnal slopes. "//&
                  "If 0, defaults to 1, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_njblock, layoutParam=.true.)
-  call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
-                 "The j-direction block size used in the continuity solver. "//&
-                 "If 0, defaults to 1 , except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_nkblock, layoutParam=.true.)
+                 "domain depth is used.", default=default_nkblock, layoutParam=.true.)
+
+  if (CS%niblock < 0) &
+    call MOM_error(FATAL, "ISOPYCNAL_NIBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%njblock < 0) &
+    call MOM_error(FATAL, "ISOPYCNAL_NJBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%nkblock < 0) &
+    call MOM_error(FATAL, "ISOPYCNAL_NKBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+
 
 end subroutine ML_MEKE_init
 
@@ -1920,12 +1933,13 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   call find_eta(h, tv, G, GV, US, e, halo_size=2)
   ! Note the hard-coded dimenisional constant in the following line.
   ! UMW: Below is untested
-  !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e)
+  !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y, &
                               niblock, njblock, nkblock )
-  !$omp target exit data map(release: tv, tv%T, tv%S, e)
+  !$omp target exit data map(release: tv, tv%T, tv%S)
+  !$omp target exit data map(delete: e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
   !$omp target exit data map(from: slope_x, slope_y)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -144,6 +144,7 @@ type, public :: MEKE_CS ; private
   type(external_field) :: eke_handle   !< Handle for reading in EKE from a file
   ! Infrastructure
   integer :: id_clock_pass !< Clock for group pass calls
+  integer :: id_clock_isoneutral_slopes !< Clock for calc_isoneutral_slopes calls
   type(group_pass_type) :: pass_MEKE !< Group halo pass handle for MEKE%MEKE and maybe MEKE%Kh_diff
   type(group_pass_type) :: pass_Kh   !< Group halo pass handle for MEKE%Kh, MEKE%Ku, and/or MEKE%Au
 
@@ -1715,6 +1716,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
   endif
 
   CS%id_clock_pass = cpu_clock_id('(Ocean continuity halo updates)', grain=CLOCK_ROUTINE)
+  CS%id_clock_isoneutral_slopes = cpu_clock_id('(MEKE isoneutral slopes)', grain=CLOCK_ROUTINE)
 
 
   ! Detect whether this instance of MEKE_init() is at the beginning of a run
@@ -1879,11 +1881,15 @@ subroutine ML_MEKE_calculate_features(G, GV, US, CS, Rd_dx_h, u, v, tv, h, dt, f
   !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=2)
   ! Note the hard-coded dimenisional constant in the following line.
-  !$omp target enter data map(to: tv%T, tv%S)
+  call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
+  ! UMW: Below is untested
+  !$omp target enter data map(to: tv, tv%T, tv%S, slope_x, slope_y, e))
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*1.e-7*GV%m2_s_to_HZ_T, .false., slope_x, slope_y)
-  !$omp target exit data map(release: tv%T, tv%S, e)
+  !$omp target exit data map(release: tv, tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+  !$omp target exit data map(from: slope_x, slope_y)
+  call cpu_clock_end(CS%id_clock_isoneutral_slopes)
   call pass_vector(slope_x, slope_y, G%Domain)
   do j=js-1,je+1 ; do i=is-1,ie+1
     slope_x_vert_avg(I,j) = vertical_average_interface(slope_x(i,j,:), h_u(i,j,:), GV%H_subroundoff)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1767,15 +1767,15 @@ subroutine ML_MEKE_init(diag, G, US, Time, param_file, dbcomms_CS, CS)
   character(len=200)  :: inputdir, backend, model_filename
   integer :: db_return_code, batch_size
   character(len=40) :: mdl = "MOM_ML_MEKE"
-  #ifdef __NVCOMPILER_OPENMP_GPU
+#ifdef __NVCOMPILER_OPENMP_GPU
   integer, parameter :: default_niblock = 0
   integer, parameter :: default_njblock = 0
   integer, parameter :: default_nkblock = 0
-  #else
+#else
   integer, parameter :: default_niblock = 0
   integer, parameter :: default_njblock = 1
   integer, parameter :: default_nkblock = 1
-  #endif
+#endif
 
   ! Store pointers in control structure
   write(CS%key_suffix, '(A,I6.6)') '_', PE_here()
@@ -1843,17 +1843,17 @@ subroutine ML_MEKE_init(diag, G, US, Time, param_file, dbcomms_CS, CS)
                  "The i-direction block size used to calculate isopycnal slopes. "//&
                  "If 0, defaults to 64, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=default_niblock)
+                 "domain width is used.", default=default_niblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_njblock)
+                 "domain height is used.", default=default_njblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1 , except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_nkblock)
+                 "domain height is used.", default=default_nkblock, layoutParam=.true.)
 
 end subroutine ML_MEKE_init
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -688,9 +688,10 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       !$omp target enter data map(alloc: e)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
       call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
-      !$omp target enter data map(to: tv, tv%T, tv%S, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
+      !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
@@ -796,10 +797,10 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     !$omp target enter data map(alloc: e)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
     call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
-    !$omp target enter data map(to: tv, tv%T, tv%S, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, &
-    !$omp & CS%slope_x, CS%slope_y)
+    !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
     !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
     !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+    !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
     if (CS%use_simpler_Eady_growth_rate) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
@@ -816,10 +817,11 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
       !$omp target exit data map(from: e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
-    !$omp target exit data map(release: tv, tv%T, tv%S, e, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, &
+    !$omp target exit data map(release: tv, tv%T, tv%S,  &
     !$omp & CS%slope_x, CS%slope_y)
     !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
     !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+    !$omp target exit data map(delete: e, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
     call cpu_clock_end(CS%id_clock_isoneutral_slopes)
   endif
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -690,11 +690,13 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
       !$omp target enter data map(to: tv, tv%T, tv%S, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
+      !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(release: tv%T, tv%S, e)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+      !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
       !$omp target exit data map(from: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       do k=2,nz ; do j=js,je ; do i=is,ie
@@ -797,6 +799,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     !$omp target enter data map(to: tv, tv%T, tv%S, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, &
     !$omp & CS%slope_x, CS%slope_y)
     !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
+    !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
     if (CS%use_simpler_Eady_growth_rate) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
@@ -816,6 +819,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     !$omp target exit data map(release: tv, tv%T, tv%S, e, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, &
     !$omp & CS%slope_x, CS%slope_y)
     !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+    !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
     call cpu_clock_end(CS%id_clock_isoneutral_slopes)
   endif
 
@@ -1398,10 +1402,12 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
   !$omp target enter data map(to: tv%T, tv%S)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
+  !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                               slope_x, slope_y, halo=2, OBC=OBC, OBC_N2=CS%OBC_friendly)
   !$omp target exit data map(release: tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+  !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
   call cpu_clock_end(CS%id_clock_isoneutral_slopes)
 
 end subroutine calc_QG_slopes

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -662,6 +662,10 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
   integer :: i, j, k, is, ie, js, je, nz
   integer :: niblock, njblock, nkblock
 
+  niblock = CS%niblock
+  njblock = CS%njblock
+  nkblock = CS%nkblock
+
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   f_subround = 1.0e-40 * US%s_to_T
 
@@ -695,14 +699,9 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       !$omp target enter data map(alloc: e)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
 
-      niblock = CS%niblock
-      njblock = CS%njblock
-      nkblock = CS%nkblock
-      !$ if (omp_get_num_devices() > 0) then
-      !$   niblock = ie - is + 1
-      !$   njblock = je - js + 1
-      !$   nkblock = nz
-      !$ endif
+      if (niblock == 0) niblock = ie - is + 1
+      if (njblock == 0) njblock = je - js + 1
+      if (nkblock == 0) nkblock = nz
 
       !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
@@ -812,11 +811,10 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
   niblock = CS%niblock
   njblock = CS%njblock
   nkblock = CS%nkblock
-  !$ if (omp_get_num_devices() > 0) then
-  !$   niblock = G%iec - G%isc + 1
-  !$   njblock = G%jec - G%jsc + 1
-  !$   nkblock = GV%ke
-  !$ endif
+
+  if (niblock == 0) niblock = G%iec - G%isc + 1
+  if (njblock == 0) njblock = G%jec - G%jsc + 1
+  if (nkblock == 0) nkblock = GV%ke
 
   if (CS%calculate_Eady_growth_rate) then
     !$omp target update to(h)
@@ -1436,11 +1434,10 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   niblock = CS%niblock
   njblock = CS%njblock
   nkblock = CS%nkblock
-  !$ if (omp_get_num_devices() > 0) then
-  !$   niblock = G%iec - G%isc + 1
-  !$   njblock = G%jec - G%jsc + 1
-  !$   nkblock = GV%ke
-  !$ endif
+
+  if (niblock == 0) niblock = G%iec - G%isc + 1
+  if (njblock == 0) njblock = G%jec - G%jsc + 1
+  if (nkblock == 0) nkblock = GV%ke
 
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)
@@ -1654,6 +1651,16 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   integer :: number_of_OBC_segments
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+  #ifdef __NVCOMPILER_OPENMP_GPU
+  integer, parameter :: default_niblock = 0
+  integer, parameter :: default_njblock = 0
+  integer, parameter :: default_nkblock = 0
+  #else
+  integer, parameter :: default_niblock = 0
+  integer, parameter :: default_njblock = 1
+  integer, parameter :: default_nkblock = 1
+  #endif
+
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -2173,17 +2180,17 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "The i-direction block size used to calculate isopycnal slopes. "//&
                  "If 0, defaults to 64, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=64)
+                 "domain width is used.", default=default_niblock)
   call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=1)
+                 "domain height is used.", default=default_njblock)
   call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1 , except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=1)
+                 "domain height is used.", default=default_nkblock)
 
   ! Leith parameters
   call get_param(param_file, mdl, "USE_QG_LEITH_GM", CS%use_QG_Leith_GM, &

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -796,39 +796,44 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     !$omp target update to(h)
     !$omp target enter data map(alloc: e)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
-    call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
-    !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
-    !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
-    !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
-    !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
-    call cpu_clock_end(CS%id_clock_isoneutral_slopes)
+
     if (CS%use_simpler_Eady_growth_rate) then
       call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
+      !$omp target enter data map(to: tv, tv%T, tv%S)
+      !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
+      !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: e, dzu, dzv, dzSxN, dzSyN)
       call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
+      !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+      !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target exit data map(delete: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
     elseif (CS%use_stored_slopes) then
       call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
+      !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
+      !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target enter data map(alloc: N2_u, N2_v)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, halo=1, OBC=OBC, &
                                   OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
       call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
+      !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target exit data map(delete: N2_u, N2_v )
     else
       !$omp target exit data map(from: e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
-    call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
-    !$omp target exit data map(release: tv, tv%T, tv%S,  &
-    !$omp & CS%slope_x, CS%slope_y)
-    !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
-    !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
-    !$omp target exit data map(delete: e, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
-    call cpu_clock_end(CS%id_clock_isoneutral_slopes)
+    !$omp target exit data map(delete: e)
   endif
 
   if (query_averaging_enabled(CS%diag)) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -25,6 +25,8 @@ use MOM_open_boundary,     only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary,     only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_MEKE_types,        only : MEKE_type
 
+!$ use omp_lib, only: omp_get_num_devices
+
 implicit none ; private
 
 #include <MOM_memory.h>
@@ -176,6 +178,11 @@ type, public :: VarMix_CS
   ! Leith parameters
   logical :: use_QG_Leith_GM      !< If true, uses the QG Leith viscosity as the GM coefficient
   logical :: use_beta_in_QG_Leith !< If true, includes the beta term in the QG Leith GM coefficient
+
+  ! Isoneutral blocking parameters
+  integer :: niblock         !< The i block size used in calc_isoneutral_slopes [nondim].
+  integer :: njblock         !< The j block size used in calc_isoneutral_slopes [nondim].
+  integer :: nkblock         !< The k block size used in calc_isoneutral_slopes [nondim].
 
   ! Diagnostics
   !>@{
@@ -653,6 +660,7 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
   real :: dz_int        ! Average of thicknesses around an interface in height units [Z ~> m]
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, nz
+  integer :: niblock, njblock, nkblock
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   f_subround = 1.0e-40 * US%s_to_T
@@ -686,13 +694,24 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       !$omp target update to(h)
       !$omp target enter data map(alloc: e)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
+
+      niblock = CS%niblock
+      njblock = CS%njblock
+      nkblock = CS%nkblock
+      !$ if (omp_get_num_devices() > 0) then
+      !$   niblock = ie - is + 1
+      !$   njblock = je - js + 1
+      !$   nkblock = nz
+      !$ endif
+
       !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
-                                  CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
-                                  dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
+                                  CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
+                                  N2_v=N2_v, dzu=dzu, dzv=dzv, dzSxN=dzSxN, dzSyN=dzSyN, halo=1, &
+                                  OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(release: tv%T, tv%S, e)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
@@ -785,9 +804,19 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: dzv  ! Z-thickness at v-points [Z ~> m]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: dzSxN ! |Sx| N times dz at u-points [Z T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: dzSyN ! |Sy| N times dz at v-points [Z T-1 ~> m s-1]
+  integer :: niblock, njblock, nkblock
 
   if (.not. CS%initialized) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_slope_functions: "//&
          "Module must be initialized before it is used.")
+
+  niblock = CS%niblock
+  njblock = CS%njblock
+  nkblock = CS%nkblock
+  !$ if (omp_get_num_devices() > 0) then
+  !$   niblock = G%iec - G%isc + 1
+  !$   njblock = G%jec - G%jsc + 1
+  !$   nkblock = GV%ke
+  !$ endif
 
   if (CS%calculate_Eady_growth_rate) then
     !$omp target update to(h)
@@ -800,8 +829,9 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
       !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
-                                  CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
-                                  dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
+                                  CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
+                                  N2_v=N2_v, dzu=dzu, dzv=dzv, dzSxN=dzSxN, dzSyN=dzSyN, halo=1, &
+                                  OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: e, dzu, dzv, dzSxN, dzSyN)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
@@ -814,8 +844,8 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
       !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
-                                  CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, halo=1, OBC=OBC, &
-                                  OBC_N2=CS%OBC_friendly)
+                                  CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
+                                  N2_v=N2_v, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
       !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
@@ -1398,9 +1428,19 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   type(ocean_OBC_type),                         pointer       :: OBC !< Open boundaries control structure
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1)  :: e    ! The interface heights relative to mean sea level [Z ~> m]
+  integer :: niblock, njblock, nkblock
 
   if (.not. CS%initialized) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_QG_slopes: "//&
          "Module must be initialized before it is used.")
+
+  niblock = CS%niblock
+  njblock = CS%njblock
+  nkblock = CS%nkblock
+  !$ if (omp_get_num_devices() > 0) then
+  !$   niblock = G%iec - G%isc + 1
+  !$   njblock = G%jec - G%jsc + 1
+  !$   nkblock = GV%ke
+  !$ endif
 
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)
@@ -1409,7 +1449,8 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
-                              slope_x, slope_y, halo=2, OBC=OBC, OBC_N2=CS%OBC_friendly)
+                              slope_x, slope_y, niblock, njblock, nkblock, halo=2, OBC=OBC, &
+                              OBC_N2=CS%OBC_friendly)
   !$omp target exit data map(release: tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
@@ -2126,6 +2167,23 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                          better_speed_est=better_speed_est, min_speed=wave_speed_min, &
                          om4_remap_via_sub_cells=om4_remap_via_sub_cells, wave_speed_tol=wave_speed_tol)
   endif
+
+  ! Isoneutral blocking parameters
+  call get_param(param_file, mdl, "ISOPYCNAL_NIBLOCK", CS%niblock, &
+                 "The i-direction block size used to calculate isopycnal slopes. "//&
+                 "If 0, defaults to 64, except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain width is used.", default=64)
+  call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
+                 "The j-direction block size used in the continuity solver. "//&
+                 "If 0, defaults to 1, except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain height is used.", default=1)
+  call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
+                 "The j-direction block size used in the continuity solver. "//&
+                 "If 0, defaults to 1 , except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain height is used.", default=1)
 
   ! Leith parameters
   call get_param(param_file, mdl, "USE_QG_LEITH_GM", CS%use_QG_Leith_GM, &

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -193,7 +193,6 @@ type, public :: VarMix_CS
   type(wave_speed_CS) :: wave_speed !< Wave speed control structure
   type(group_pass_type) :: pass_cg1 !< For group halo pass
   logical :: debug      !< If true, write out checksums of data for debugging
-  integer :: id_clock_isoneutral_slopes !< Clock for calc_isoneutral_slopes calls
 end type VarMix_CS
 
 public VarMix_init, VarMix_end, calc_slope_functions, calc_resoln_function
@@ -687,7 +686,6 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       !$omp target update to(h)
       !$omp target enter data map(alloc: e)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
-      call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
       !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
@@ -699,7 +697,6 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
       !$omp target exit data map(from: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
-      call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       do k=2,nz ; do j=js,je ; do i=is,ie
         N2 = max(0.25 * ((N2_u(I-1,j,K) + N2_u(I,j,K)) + (N2_v(i,J-1,K) + N2_v(i,J,K))), 0.0)
         dzc = 0.25 * ((dzu(I-1,j,K) + dzu(I,j,K)) + (dzv(i,J-1,K) + dzv(i,J,K)))
@@ -798,7 +795,6 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
 
     if (CS%use_simpler_Eady_growth_rate) then
-      call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
       !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
@@ -807,14 +803,12 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: e, dzu, dzv, dzSxN, dzSyN)
-      call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
       !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target exit data map(delete: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
     elseif (CS%use_stored_slopes) then
-      call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
       !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
@@ -823,7 +817,6 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, halo=1, OBC=OBC, &
                                   OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
-      call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
       !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
@@ -1412,7 +1405,6 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=3)
-  call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
   !$omp target enter data map(to: tv%T, tv%S)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
@@ -1421,7 +1413,6 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   !$omp target exit data map(release: tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
-  call cpu_clock_end(CS%id_clock_isoneutral_slopes)
 
 end subroutine calc_QG_slopes
 
@@ -2182,7 +2173,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   ! Re-enable variable mixing if one of the schemes was enabled
   CS%use_variable_mixing = in_use .or. CS%use_variable_mixing
 
-  CS%id_clock_isoneutral_slopes = cpu_clock_id('(Calc_isoneutral_slopes)', grain=CLOCK_ROUTINE)
 end subroutine VarMix_init
 
 !> Destructor for VarMix control structure

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -5,6 +5,7 @@
 !> Variable mixing coefficients
 module MOM_lateral_mixing_coeffs
 
+use MOM_cpu_clock,         only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
 use MOM_debugging,         only : hchksum, uvchksum
 use MOM_error_handler,     only : MOM_error, FATAL, WARNING, MOM_mesg
 use MOM_diag_mediator,     only : register_diag_field, safe_alloc_ptr, post_data
@@ -192,6 +193,7 @@ type, public :: VarMix_CS
   type(wave_speed_CS) :: wave_speed !< Wave speed control structure
   type(group_pass_type) :: pass_cg1 !< For group halo pass
   logical :: debug      !< If true, write out checksums of data for debugging
+  integer :: id_clock_isoneutral_slopes !< Clock for calc_isoneutral_slopes calls
 end type VarMix_CS
 
 public VarMix_init, VarMix_end, calc_slope_functions, calc_resoln_function
@@ -685,13 +687,16 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       !$omp target update to(h)
       !$omp target enter data map(alloc: e)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
-      !$omp target enter data map(to: tv%T, tv%S)
+      call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
+      !$omp target enter data map(to: tv, tv%T, tv%S, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(release: tv%T, tv%S, e)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+      !$omp target exit data map(from: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
+      call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       do k=2,nz ; do j=js,je ; do i=is,ie
         N2 = max(0.25 * ((N2_u(I-1,j,K) + N2_u(I,j,K)) + (N2_v(i,J-1,K) + N2_v(i,J,K))), 0.0)
         dzc = 0.25 * ((dzu(I-1,j,K) + dzu(I,j,K)) + (dzv(i,J-1,K) + dzv(i,J,K)))
@@ -788,27 +793,30 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     !$omp target update to(h)
     !$omp target enter data map(alloc: e)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
-    ! UMW TODO: Transfer other vars as well
-    !$omp target enter data map(to: tv%T, tv%S)
+    call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
+    !$omp target enter data map(to: tv, tv%T, tv%S, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, &
+    !$omp & CS%slope_x, CS%slope_y)
     !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
     if (CS%use_simpler_Eady_growth_rate) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
-      !$omp target exit data map(from: e)
+      !$omp target exit data map(from: e, dzu, dzv, dzSxN, dzSyN)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
     elseif (CS%use_stored_slopes) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, halo=1, OBC=OBC, &
                                   OBC_N2=CS%OBC_friendly)
-      !$omp target exit data map(from: e)
+      !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
     else
       !$omp target exit data map(from: e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
-    !$omp target exit data map(release: tv%T, tv%S, e)
+    !$omp target exit data map(release: tv, tv%T, tv%S, e, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, &
+    !$omp & CS%slope_x, CS%slope_y)
     !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+    call cpu_clock_end(CS%id_clock_isoneutral_slopes)
   endif
 
   if (query_averaging_enabled(CS%diag)) then
@@ -1387,12 +1395,14 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=3)
+  call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
   !$omp target enter data map(to: tv%T, tv%S)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                               slope_x, slope_y, halo=2, OBC=OBC, OBC_N2=CS%OBC_friendly)
   !$omp target exit data map(release: tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
+  call cpu_clock_end(CS%id_clock_isoneutral_slopes)
 
 end subroutine calc_QG_slopes
 
@@ -2152,6 +2162,8 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
 
   ! Re-enable variable mixing if one of the schemes was enabled
   CS%use_variable_mixing = in_use .or. CS%use_variable_mixing
+
+  CS%id_clock_isoneutral_slopes = cpu_clock_id('(VarMix isoneutral slopes)', grain=CLOCK_ROUTINE)
 end subroutine VarMix_init
 
 !> Destructor for VarMix control structure

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1657,7 +1657,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   integer, parameter :: default_nkblock = 0
 #else
   integer, parameter :: default_niblock = 0
-  integer, parameter :: default_njblock = 1
+  integer, parameter :: default_njblock = 2
   integer, parameter :: default_nkblock = 1
 #endif
 
@@ -1776,6 +1776,32 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
 
+  ! Isopycnal blocking parameters
+  call get_param(param_file, mdl, "ISOPYCNAL_NIBLOCK", CS%niblock, &
+                 "The i-direction block size used to calculate isopycnal slopes. "//&
+                 "If 0, defaults to 64, except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain width is used.", default=default_niblock, layoutParam=.true.)
+  call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
+                 "The j-direction block size used to calculate isopycnal slopes. "//&
+                 "If 0, defaults to 1, except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain height is used.", default=default_njblock, layoutParam=.true.)
+  call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
+                 "The j-direction block size used to calculate isopycnal slopes. "//&
+                 "If 0, defaults to 1 , except when "//&
+                 "running with OpenMP offload, in which case the full computational "//&
+                 "domain height is used.", default=default_nkblock, layoutParam=.true.)
+  if (CS%niblock < 0) &
+    call MOM_error(FATAL, "ISOPYCNAL_NIBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%njblock < 0) &
+    call MOM_error(FATAL, "ISOPYCNAL_NJBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%nkblock < 0) &
+    call MOM_error(FATAL, "ISOPYCNAL_NKBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+
   call get_param(param_file, mdl, "USE_STANLEY_ISO", CS%use_stanley_iso, &
                  "If true, turn on Stanley SGS T variance parameterization "// &
                  "in isopycnal slope code.", default=.false.)
@@ -1785,6 +1811,16 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  units="nondim", default=-1.0, do_not_log=.true.)
     if (Stanley_coeff < 0.0) call MOM_error(FATAL, &
                  "STANLEY_COEFF must be set >= 0 if USE_STANLEY_ISO is true.")
+    if (CS%njblock == 1) then
+      call MOM_error(WARNING, "ISOPYCNAL_NJBLOCK must be >= 2 or 0 if USE_STANLEY_ISO is true."//&
+                    " Changing block size from 1 to 2 for this run.")
+      CS%njblock = 2
+    endif
+    if (CS%niblock == 1) then
+      call MOM_error(WARNING, "ISOPYCNAL_NIBLOCK must be >= 2 or 0 if USE_STANLEY_ISO is true."//&
+                    " Changing block size from 1 to 2 for this run.")
+      CS%niblock = 2
+    endif
   endif
   call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", number_of_OBC_segments, &
                  default=0, do_not_log=.true.)
@@ -2174,23 +2210,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                          better_speed_est=better_speed_est, min_speed=wave_speed_min, &
                          om4_remap_via_sub_cells=om4_remap_via_sub_cells, wave_speed_tol=wave_speed_tol)
   endif
-
-  ! Isoneutral blocking parameters
-  call get_param(param_file, mdl, "ISOPYCNAL_NIBLOCK", CS%niblock, &
-                 "The i-direction block size used to calculate isopycnal slopes. "//&
-                 "If 0, defaults to 64, except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=default_niblock, layoutParam=.true.)
-  call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
-                 "The j-direction block size used in the continuity solver. "//&
-                 "If 0, defaults to 1, except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_njblock, layoutParam=.true.)
-  call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
-                 "The j-direction block size used in the continuity solver. "//&
-                 "If 0, defaults to 1 , except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_nkblock, layoutParam=.true.)
 
   ! Leith parameters
   call get_param(param_file, mdl, "USE_QG_LEITH_GM", CS%use_QG_Leith_GM, &

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1651,15 +1651,15 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   integer :: number_of_OBC_segments
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  #ifdef __NVCOMPILER_OPENMP_GPU
+#ifdef __NVCOMPILER_OPENMP_GPU
   integer, parameter :: default_niblock = 0
   integer, parameter :: default_njblock = 0
   integer, parameter :: default_nkblock = 0
-  #else
+#else
   integer, parameter :: default_niblock = 0
   integer, parameter :: default_njblock = 1
   integer, parameter :: default_nkblock = 1
-  #endif
+#endif
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -2180,17 +2180,17 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "The i-direction block size used to calculate isopycnal slopes. "//&
                  "If 0, defaults to 64, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=default_niblock)
+                 "domain width is used.", default=default_niblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_njblock)
+                 "domain height is used.", default=default_njblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
                  "The j-direction block size used in the continuity solver. "//&
                  "If 0, defaults to 1 , except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_nkblock)
+                 "domain height is used.", default=default_nkblock, layoutParam=.true.)
 
   ! Leith parameters
   call get_param(param_file, mdl, "USE_QG_LEITH_GM", CS%use_QG_Leith_GM, &

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -801,22 +801,28 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
     !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
     !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
+    call cpu_clock_end(CS%id_clock_isoneutral_slopes)
     if (CS%use_simpler_Eady_growth_rate) then
+      call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: e, dzu, dzv, dzSxN, dzSyN)
+      call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
     elseif (CS%use_stored_slopes) then
+      call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, halo=1, OBC=OBC, &
                                   OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
+      call cpu_clock_end(CS%id_clock_isoneutral_slopes)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
     else
       !$omp target exit data map(from: e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
+    call cpu_clock_begin(CS%id_clock_isoneutral_slopes)
     !$omp target exit data map(release: tv, tv%T, tv%S,  &
     !$omp & CS%slope_x, CS%slope_y)
     !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
@@ -2171,7 +2177,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   ! Re-enable variable mixing if one of the schemes was enabled
   CS%use_variable_mixing = in_use .or. CS%use_variable_mixing
 
-  CS%id_clock_isoneutral_slopes = cpu_clock_id('(VarMix isoneutral slopes)', grain=CLOCK_ROUTINE)
+  CS%id_clock_isoneutral_slopes = cpu_clock_id('(Calc_isoneutral_slopes)', grain=CLOCK_ROUTINE)
 end subroutine VarMix_init
 
 !> Destructor for VarMix control structure

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1657,7 +1657,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   integer, parameter :: default_nkblock = 0
 #else
   integer, parameter :: default_niblock = 0
-  integer, parameter :: default_njblock = 2
+  integer, parameter :: default_njblock = 1
   integer, parameter :: default_nkblock = 1
 #endif
 
@@ -1779,14 +1779,16 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   ! Isopycnal blocking parameters
   call get_param(param_file, mdl, "ISOPYCNAL_NIBLOCK", CS%niblock, &
                  "The i-direction block size used to calculate isopycnal slopes. "//&
-                 "If 0, defaults to 64, except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain width is used.", default=default_niblock, layoutParam=.true.)
+                 "If 0, or when running with OpenMP offload, "//&
+                 "the full computational domain width is used. "//&
+                 "If USE_STANLEY_ISO is true, ISOPYCNAL_NIBLOCK cannot equal 1.", &
+                 default=default_niblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NJBLOCK", CS%njblock, &
                  "The j-direction block size used to calculate isopycnal slopes. "//&
-                 "If 0, defaults to 1, except when "//&
-                 "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_njblock, layoutParam=.true.)
+                 "If 0, defaults to 1, except when running with OpenMP offload, "//&
+                 "in which case the full computational domain height is used. " //&
+                 "If USE_STANLEY_ISO is true, ISOPYCNAL_NJBLOCK cannot equal 1.", &
+                 default=default_njblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
                  "The j-direction block size used to calculate isopycnal slopes. "//&
                  "If 0, defaults to 1 , except when "//&

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -5,7 +5,6 @@
 !> Variable mixing coefficients
 module MOM_lateral_mixing_coeffs
 
-use MOM_cpu_clock,         only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
 use MOM_debugging,         only : hchksum, uvchksum
 use MOM_error_handler,     only : MOM_error, FATAL, WARNING, MOM_mesg
 use MOM_diag_mediator,     only : register_diag_field, safe_alloc_ptr, post_data
@@ -711,7 +710,8 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
                                   CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
                                   N2_v=N2_v, dzu=dzu, dzv=dzv, dzSxN=dzSxN, dzSyN=dzSyN, halo=1, &
                                   OBC=OBC, OBC_N2=CS%OBC_friendly)
-      !$omp target exit data map(release: tv%T, tv%S, e)
+      !$omp target exit data map(release: tv%T, tv%S, tv)
+      !$omp target exit data map(delete: e)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
       !$omp target exit data map(from: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
@@ -822,7 +822,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
 
     if (CS%use_simpler_Eady_growth_rate) then
-      !$omp target enter data map(to: tv, tv%T, tv%S)
+      !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
@@ -830,7 +830,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
                                   CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
                                   N2_v=N2_v, dzu=dzu, dzv=dzv, dzSxN=dzSxN, dzSyN=dzSyN, halo=1, &
                                   OBC=OBC, OBC_N2=CS%OBC_friendly)
-      !$omp target exit data map(from: e, dzu, dzv, dzSxN, dzSyN)
+      !$omp target update from(e, dzu, dzv, dzSxN, dzSyN)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
@@ -846,12 +846,11 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
                                   N2_v=N2_v, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
-      !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target exit data map(release: tv%T, tv%S, tv, CS%slope_x, CS%slope_y)
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
-      !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target exit data map(delete: N2_u, N2_v )
     else
-      !$omp target exit data map(from: e)
+      !$omp target update from(e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
     !$omp target exit data map(delete: e)
@@ -1448,7 +1447,8 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                               slope_x, slope_y, niblock, njblock, nkblock, halo=2, OBC=OBC, &
                               OBC_N2=CS%OBC_friendly)
-  !$omp target exit data map(release: tv%T, tv%S, e)
+  !$omp target exit data map(release: tv%T, tv%S)
+  !$omp target exit data map(delete: e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
 
@@ -1790,10 +1790,10 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "If USE_STANLEY_ISO is true, ISOPYCNAL_NJBLOCK cannot equal 1.", &
                  default=default_njblock, layoutParam=.true.)
   call get_param(param_file, mdl, "ISOPYCNAL_NKBLOCK", CS%nkblock, &
-                 "The j-direction block size used to calculate isopycnal slopes. "//&
-                 "If 0, defaults to 1 , except when "//&
+                 "The k-direction block size used to calculate isopycnal slopes. "//&
+                 "If 0, defaults to 1, except when "//&
                  "running with OpenMP offload, in which case the full computational "//&
-                 "domain height is used.", default=default_nkblock, layoutParam=.true.)
+                 "domain depth is used.", default=default_nkblock, layoutParam=.true.)
   if (CS%niblock < 0) &
     call MOM_error(FATAL, "ISOPYCNAL_NIBLOCK must be nonnegative; "//&
                           "use 0 to select the default block size.")

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -685,10 +685,13 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       !$omp target update to(h)
       !$omp target enter data map(alloc: e)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
-      !$omp target exit data map(from: e)
+      !$omp target enter data map(to: tv%T, tv%S)
+      !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
+      !$omp target exit data map(release: tv%T, tv%S, e)
+      !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       do k=2,nz ; do j=js,je ; do i=is,ie
         N2 = max(0.25 * ((N2_u(I-1,j,K) + N2_u(I,j,K)) + (N2_v(i,J-1,K) + N2_v(i,J,K))), 0.0)
         dzc = 0.25 * ((dzu(I-1,j,K) + dzu(I,j,K)) + (dzv(i,J-1,K) + dzv(i,J,K)))
@@ -785,20 +788,27 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     !$omp target update to(h)
     !$omp target enter data map(alloc: e)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
-    !$omp target exit data map(from: e)
+    ! UMW TODO: Transfer other vars as well
+    !$omp target enter data map(to: tv%T, tv%S)
+    !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
     if (CS%use_simpler_Eady_growth_rate) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
+      !$omp target exit data map(from: e)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
     elseif (CS%use_stored_slopes) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, halo=1, OBC=OBC, &
                                   OBC_N2=CS%OBC_friendly)
+      !$omp target exit data map(from: e)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
     else
+      !$omp target exit data map(from: e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
+    !$omp target exit data map(release: tv%T, tv%S, e)
+    !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
   endif
 
   if (query_averaging_enabled(CS%diag)) then
@@ -1377,9 +1387,12 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   !$omp target update to(h)
   !$omp target enter data map(alloc: e)
   call find_eta(h, tv, G, GV, US, e, halo_size=3)
-  !$omp target exit data map(from: e)
+  !$omp target enter data map(to: tv%T, tv%S)
+  !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                               slope_x, slope_y, halo=2, OBC=OBC, OBC_N2=CS%OBC_friendly)
+  !$omp target exit data map(release: tv%T, tv%S, e)
+  !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
 
 end subroutine calc_QG_slopes
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -688,14 +688,14 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
       call find_eta(h, tv, G, GV, US, e, halo_size=2)  !### Could be halo_size=1?
       !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
-      !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       !$omp target exit data map(release: tv%T, tv%S, e)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
-      !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
       !$omp target exit data map(from: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       do k=2,nz ; do j=js,je ; do i=is,ie
         N2 = max(0.25 * ((N2_u(I-1,j,K) + N2_u(I,j,K)) + (N2_v(i,J-1,K) + N2_v(i,J,K))), 0.0)
@@ -797,7 +797,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     if (CS%use_simpler_Eady_growth_rate) then
       !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
-      !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, dzu=dzu, dzv=dzv, &
@@ -805,13 +805,13 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
       !$omp target exit data map(from: e, dzu, dzv, dzSxN, dzSyN)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
-      !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
       !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target exit data map(delete: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
     elseif (CS%use_stored_slopes) then
       !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
-      !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v, halo=1, OBC=OBC, &
@@ -819,7 +819,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
       !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
       !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
-      !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+      !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
       !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
       !$omp target exit data map(delete: N2_u, N2_v )
     else
@@ -1407,12 +1407,12 @@ subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
   call find_eta(h, tv, G, GV, US, e, halo_size=3)
   !$omp target enter data map(to: tv%T, tv%S)
   !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
-  !$omp target enter data map(to: tv%p_surf) if (allocated(tv%p_surf))
+  !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
   call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                               slope_x, slope_y, halo=2, OBC=OBC, OBC_N2=CS%OBC_friendly)
   !$omp target exit data map(release: tv%T, tv%S, e)
   !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
-  !$omp target exit data map(release: tv%p_surf) if (allocated(tv%p_surf))
+  !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
 
 end subroutine calc_QG_slopes
 

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -848,7 +848,11 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
   if (use_EOS) then
     halo = 1 ! Default halo to fill is 1
+    !$omp target enter data map(to: h, tv%T, tv%S)
+    !$omp target enter data map(alloc: T, S)
     call vert_fill_TS(h, tv%T, tv%S, CS%kappa_smooth*dt, T, S, G, GV, US, halo, larger_h_denom=.true.)
+    !$omp target exit data map(from: T, S)
+    !$omp target exit data map(release: h, tv%T, tv%S)
   endif
 
   ! Rescale the thicknesses, perhaps using the specific volume.

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -143,7 +143,11 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, US, CS)
 
   ! Smooth the properties through massless layers.
   if (use_EOS) then
+    !$omp target enter data map(to: h, tv%T, tv%S)
+    !$omp target enter data map(alloc: T_f, S_f)
     call vert_fill_TS(h, tv%T, tv%S, CS%kappa_fill*dt, T_f, S_f, G, GV, US, larger_h_denom=.true.)
+    !$omp target exit data map(from: T_f, S_f)
+    !$omp target exit data map(release: h, tv%T, tv%S)
   endif
 
   call find_N2_bottom(G, GV, US, tv, fluxes, h, T_f, S_f, itide%h2, N2_bot, Rho_bot, h_bot, k_bot)

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -460,7 +460,11 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
       call hchksum(tv%S, "before vert_fill_TS tv%S", G%HI, unscale=US%S_to_ppt)
       call hchksum(h, "before vert_fill_TS h",G%HI, unscale=GV%H_to_m)
     endif
+    !$omp target enter data map(to: tv%T, tv%S, h)
+    !$omp target enter data map(alloc: T_f, S_f)
     call vert_fill_TS(h, tv%T, tv%S, kappa_dt_fill, T_f, S_f, G, GV, US, larger_h_denom=.true.)
+    !$omp target exit data map(from: T_f, S_f) 
+    !$omp target exit data map(release: tv%T, tv%S, h)
     if (CS%debug) then
       call hchksum(tv%T, "after vert_fill_TS tv%T", G%HI, unscale=US%C_to_degC)
       call hchksum(tv%S, "after vert_fill_TS tv%S", G%HI, unscale=US%S_to_ppt)

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -463,7 +463,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
     !$omp target enter data map(to: tv%T, tv%S, h)
     !$omp target enter data map(alloc: T_f, S_f)
     call vert_fill_TS(h, tv%T, tv%S, kappa_dt_fill, T_f, S_f, G, GV, US, larger_h_denom=.true.)
-    !$omp target exit data map(from: T_f, S_f) 
+    !$omp target exit data map(from: T_f, S_f)
     !$omp target exit data map(release: tv%T, tv%S, h)
     if (CS%debug) then
       call hchksum(tv%T, "after vert_fill_TS tv%T", G%HI, unscale=US%C_to_degC)


### PR DESCRIPTION
Fixes #75 . This PR replaces the 1d arrays used in MOM_isopycnal_slopes to calculate thermodynamic quantities at u,v, and h points with 3d arrays that are reused to calculate these quantities at those points. In the process, it replaces the zonal and meridional jki loops with do concurrents to offload the bulk of the slope calculation to the device without having to localize any arrays. 

To preserve cpu performance, this PR also blocks the new 3D thermodynamic arrays in the i,j, and k directions. Combined with calling the ~2d~ 3d version of the density derivative subroutines, this seems to create a small speed up on Gaea c5 with ifx, most likely due to ifx inlining the the call to `calculate_density_derivatives` when it is not in nested loops

ifx flags: 
```
FCFLAGS = -O3 -fp-model source -qno-opt-dynamic-align -march=core-avx-i
FMS_FCFLAGS = -O3 -fp-model source -qno-opt-dynamic-align
```
run command (gaea) : 
```
srun -n 64 --cpu-bind=map_cpu:$(seq -s, 0 63) 
```
The following times are all for the default `benchmark_ALE` configuration in marshallward/MOM6-examples

Gaea c5 dev/gfdl times:
```
benchmark_ALE_default_dev_gfdl_06-26-2026:(Calc_isoneutral_slopes)                48      0.070248      0.085415      0.077896      0.004534  0.014    41     0    63
benchmark_ALE_default_dev_gfdl_06-26-2026:(Calc_isoneutral_slopes)                48      0.070423      0.086607      0.077908      0.004686  0.014    41     0    63
benchmark_ALE_default_dev_gfdl_06-26-2026:(Calc_isoneutral_slopes)                48      0.068857      0.085634      0.076305      0.004796  0.014    41     0    63
benchmark_ALE_default_dev_gfdl_06-26-2026:(Calc_isoneutral_slopes)                48      0.068874      0.085490      0.076794      0.005104  0.014    41     0    63
benchmark_ALE_default_dev_gfdl_06-26-2026:(Calc_isoneutral_slopes)                48      0.068899      0.086147      0.077281      0.004755  0.014    41     0    63

```
Gaea c5 times for this branch: 
```
benchmark_ALE_default_64x1_kblock_3d_derivs_times:(Calc_isoneutral_slopes)                48      0.058043      0.074191      0.065522      0.004952  0.012    41     0    63     
benchmark_ALE_default_64x1_kblock_3d_derivs_times:(Calc_isoneutral_slopes)                48      0.058452      0.076108      0.066292      0.005065  0.012    41     0    63     
benchmark_ALE_default_64x1_kblock_3d_derivs_times:(Calc_isoneutral_slopes)                48      0.058209      0.075215      0.065712      0.005120  0.012    41     0    63     
benchmark_ALE_default_64x1_kblock_3d_derivs_times:(Calc_isoneutral_slopes)                48      0.058826      0.073308      0.066269      0.004296  0.012    41     0    63     
benchmark_ALE_default_64x1_kblock_3d_derivs_times:(Calc_isoneutral_slopes)                48      0.058252      0.075678      0.065908      0.004976  0.012    41     0    63  
```

Nvfortran 26.3 flags: 
```
FMS_FCFLAGS = -O3 -mp=gpu -gpu=mem:separate,cc80,sm_80 -Mnofma -Minfo=all
FCFLAGS = -O3 -mp=gpu -stdpar=gpu -gpu=mem:separate,cc80,sm_80 -Mnofma -Minfo=all
FCFLAGS += -Minline=name:flux_elem,name:flux_elem_OBC,name:ratio_max
LDFLAGS = -mp=gpu -stdpar=gpu -gpu=cc80,sm_80,mem:separate

```
Stellar A100 times (these times do NOT  include data transfers): 
```
benchmark_ALE_64x1_kblocked_3d_density_just_routine_times_2847335/job_output_files/64x1tiled_port_times_2847335.txt:141:(Calc_isoneutral_slopes)                48      0.078802      0.078802      0.078802      0.000000  0.001    41     0     0
benchmark_ALE_64x1_kblocked_3d_density_just_routine_times_2847336/job_output_files/64x1tiled_port_times_2847336.txt:141:(Calc_isoneutral_slopes)                48      0.078567      0.078567      0.078567      0.000000  0.001    41     0     0
benchmark_ALE_64x1_kblocked_3d_density_just_routine_times_2847337/job_output_files/64x1tiled_port_times_2847337.txt:141:(Calc_isoneutral_slopes)                48      0.079543      0.079543      0.079543      0.000000  0.001    41     0     0
benchmark_ALE_64x1_kblocked_3d_density_just_routine_times_2847338/job_output_files/64x1tiled_port_times_2847338.txt:141:(Calc_isoneutral_slopes)                48      0.079340      0.079340      0.079340      0.000000  0.001    41     0     0
benchmark_ALE_64x1_kblocked_3d_density_just_routine_times_2847339/job_output_files/64x1tiled_port_times_2847339.txt:141:(Calc_isoneutral_slopes)                48      0.079147      0.079147      0.079147      0.000000  0.001    41     0     0
```
Since this PR needs the 3d density derivative routines to get the full gpu speed up, it will have to be merged in after #185 