### PR TITLE
MOM lateral mixing coeffs clean up and port

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1291,12 +1291,12 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     Time_end_diag = Time_local + real_to_time(dt_tr_adv - dt, unscale=US%T_to_s)
     call enable_averages(dt_tr_adv, Time_end_diag, CS%diag)
     if (CS%thickness_diffuse) then
-      !$omp target update from(h, CS%uhtr, CS%vhtr)
       call cpu_clock_begin(id_clock_thick_diff)
 
       if (CS%VarMix%use_variable_mixing) &
         call calc_slope_functions(h, CS%tv, dt, G, GV, US, CS%VarMix, OBC=CS%OBC)
 
+      !$omp target update from(h, CS%uhtr, CS%vhtr)
       call thickness_diffuse(h, CS%uhtr, CS%vhtr, CS%tv, dt_tr_adv, G, GV, US, &
                              CS%MEKE, CS%VarMix, CS%CDp, CS%thickness_diffuse_CSp, &
                              CS%stoch_CS)
@@ -1468,12 +1468,12 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     if (CS%debug) call hchksum(h,"Pre-thickness_diffuse h", G%HI, haloshift=0, unscale=GV%H_to_MKS)
 
     if (CS%thickness_diffuse) then
-      !$omp target update from(h, CS%uhtr, CS%vhtr)
       call cpu_clock_begin(id_clock_thick_diff)
 
       if (CS%VarMix%use_variable_mixing) &
         call calc_slope_functions(h, CS%tv, dt, G, GV, US, CS%VarMix, OBC=CS%OBC)
 
+      !$omp target update from(h, CS%uhtr, CS%vhtr)
       call thickness_diffuse(h, CS%uhtr, CS%vhtr, CS%tv, dt, G, GV, US, &
                              CS%MEKE, CS%VarMix, CS%CDp, CS%thickness_diffuse_CSp, CS%stoch_CS)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3703,6 +3703,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                          restart_CSp, CS%MEKE_in_dynamics)
 
   allocate(CS%VarMix)
+  !$omp target enter data map(alloc: CS%VarMix)
   call VarMix_init(Time, G, GV, US, param_file, diag, CS%VarMix)
 
   allocate(CS%set_visc_CSp)
@@ -4744,6 +4745,7 @@ subroutine MOM_end(CS)
   call thickness_diffuse_end(CS%thickness_diffuse_CSp, CS%CDp)
   if (CS%interface_filter) call interface_filter_end(CS%interface_filter_CSp, CS%CDp)
   call VarMix_end(CS%VarMix)
+  !$omp target exit data map(delete: CS%VarMix)
 
   call set_visc_end(CS%visc, CS%set_visc_CSp)
   !$omp target exit data map(delete: CS%visc, CS%set_visc_CSp)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3703,7 +3703,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                          restart_CSp, CS%MEKE_in_dynamics)
 
   allocate(CS%VarMix)
-  !$omp target enter data map(alloc: CS%VarMix)
   call VarMix_init(Time, G, GV, US, param_file, diag, CS%VarMix)
 
   allocate(CS%set_visc_CSp)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1034,6 +1034,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (rescale_Kh) then
         !$omp target update from(Kh)
+        !$omp target update from(VarMix%Res_fn_h)
         do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           Kh(i,j,kk) = VarMix%Res_fn_h(i,j) * Kh(i,j,kk)
         enddo ; enddo ; enddo
@@ -1050,6 +1051,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
+            !$omp target update from(VarMix%Res_fn_h)
             do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               k = kstart + kk - 1
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
@@ -1062,6 +1064,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           endif
         else
           if (CS%res_scale_MEKE) then
+            !$omp target update from(VarMix%Res_fn_h)
             do kk=1,kmax ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
               Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
             enddo ; enddo ; enddo
@@ -1427,6 +1430,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (rescale_Kh) then
         !$omp target update from(Kh)
+        !$omp target update from(VarMix%Res_fn_q)
         do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J,kk) = VarMix%Res_fn_q(I,J) * Kh(I,J,kk)
         enddo ; enddo ; enddo
@@ -1439,6 +1443,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         !$omp target update from(Kh)
+        !$omp target update from(VarMix%Res_fn_q) if (CS%res_scale_MEKE)
         if (use_kh_struct) then
           do kk=1,kmax ; do J=js-1,Jeq ; do I=is-1,Ieq
             k = kstart + kk - 1

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -232,18 +232,16 @@ subroutine calc_depth_function(G, CS)
   ! For efficiency, the reciprocal of H0 should be used instead.
   H0 = CS%depth_scaled_khth_h0
   expo = CS%depth_scaled_khth_exp
-!$OMP do
-  do j=js,je ; do I=is-1,Ieq
+  do concurrent( j=js:je, i=is-1:Ieq ) local(h1,h2)
     h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
     h2 = max(G%meanSL(i+1,j) + G%bathyT(i+1,j), 0.0)
     CS%Depth_fn_u(I,j) = (MIN(1.0, (0.5 * (h1 + h2)) / H0))**expo
-  enddo ; enddo
-!$OMP do
-  do J=js-1,Jeq ; do i=is,ie
+  enddo
+  do concurrent( J=js-1:Jeq, i=is:ie ) local(h1,h2)
     h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
     h2 = max(G%meanSL(i,j+1) + G%bathyT(i,j+1), 0.0)
     CS%Depth_fn_v(i,J) = (MIN(1.0, (0.5 * (h1 + h2)) / H0))**expo
-  enddo ; enddo
+  enddo
 
 end subroutine calc_depth_function
 
@@ -2131,7 +2129,11 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
       oneOrTwo = 2.0
     endif
 
-    do J=js-1,Jeq ; do I=is-1,Ieq
+    !$omp target enter data map(alloc: CS%f2_dx2_q, CS%beta_dx2_q, &
+    !$omp&                             CS%f2_dx2_u, CS%beta_dx2_u, &
+    !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
+
+    do concurrent( J=js-1:Jeq, I=is-1:Ieq )
       CS%f2_dx2_q(I,J) = ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * &
                          max(G%Coriolis2Bu(I,J), absurdly_small_freq**2)
       CS%beta_dx2_q(I,J) = oneOrTwo * ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * (sqrt(0.5 * &
@@ -2139,9 +2141,9 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
              (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
             ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
              (((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2)) ) ))
-    enddo ; enddo
+    enddo
 
-    do j=js,je ; do I=is-1,Ieq
+    do concurrent( j=js:je, I=is-1:Ieq )
       CS%f2_dx2_u(I,j) = ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * &
           max(0.5* (G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I,J-1)), absurdly_small_freq**2)
       CS%beta_dx2_u(I,j) = oneOrTwo * ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * (sqrt( &
@@ -2150,9 +2152,9 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                   (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
                  ((((G%CoriolisBu(I+1,J-1)-G%CoriolisBu(I,J-1)) * G%IdxCv(i+1,J-1))**2) + &
                   (((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2)) ) ))
-    enddo ; enddo
+    enddo
 
-    do J=js-1,Jeq ; do i=is,ie
+    do concurrent( J=js-1:Jeq, i=is:ie )
       CS%f2_dx2_v(i,J) = ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * &
           max(0.5*(G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I-1,J)), absurdly_small_freq**2)
       CS%beta_dx2_v(i,J) = oneOrTwo * ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * (sqrt( &
@@ -2161,7 +2163,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                   (((G%CoriolisBu(I-1,J+1)-G%CoriolisBu(I-1,J)) * G%IdyCu(I-1,j+1))**2)) + &
                  ((((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2) + &
                   (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
-    enddo ; enddo
+    enddo
 
   endif
 
@@ -2187,7 +2189,10 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     allocate(CS%Rd_dx_h(isd:ied,jsd:jed), source=0.0)
     allocate(CS%beta_dx2_h(isd:ied,jsd:jed), source=0.0)
     allocate(CS%f2_dx2_h(isd:ied,jsd:jed), source=0.0)
-    do j=js-1,je+1 ; do i=is-1,ie+1
+
+    !$omp target enter data map(alloc: CS%f2_dx2_h, CS%beta_dx2_h)
+
+    do concurrent(j=js-1:je+1, i=is-1:ie+1)
       CS%f2_dx2_h(i,j) = ((G%dxT(i,j)**2) + (G%dyT(i,j)**2)) * &
           max(0.25 * ((G%Coriolis2Bu(I,J) + G%Coriolis2Bu(I-1,J-1)) + &
                       (G%Coriolis2Bu(I-1,J) + G%Coriolis2Bu(I,J-1))), &
@@ -2197,7 +2202,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
              (((G%CoriolisBu(I,J-1)-G%CoriolisBu(I-1,J-1)) * G%IdxCv(i,J-1))**2)) + &
             ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
              (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
-    enddo ; enddo
+    enddo
   endif
 
   if (CS%calculate_cg1) then
@@ -2293,6 +2298,7 @@ subroutine VarMix_end(CS)
   !$omp&                             CS%f2_dx2_q, CS%beta_dx2_q, CS%f2_dx2_u, CS%beta_dx2_u, &
   !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
   !$omp target exit data map(delete: CS%Rd_dx_h, CS%f2_dx2_h, CS%beta_dx2_h)
+  !$omp target exit data map(delete: CS%Depth_fn_u, CS%Depth_fn_v)
   !$omp target exit data map(delete: CS%cg1)
 
   if (allocated(CS%ebt_struct))  deallocate(CS%ebt_struct)

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -916,6 +916,9 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
                                  ! interface or the inward equivalent with OBCs [H4 ~> m4 or kg4 m-8]
   integer :: i, j, k, is, ie, js, je, nz
 
+  !$omp target enter data map(alloc: h4_u, h4_v,S2_u,S2_v,H_u, H_v)
+  !$omp target enter data map(to: CS%SN_u, CS%SN_v)
+
   if (.not. CS%initialized) call MOM_error(FATAL, "calc_Visbeck_coeffs_old: "// &
          "Module must be initialized before it is used.")
 
@@ -972,14 +975,13 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
     enddo
   else  ! The land mask is sufficient and there are no special considerations taken at OBC points.
     ! Use the masked product of the 4 thicknesses around a velocity-point interface for weights.
-    !$OMP parallel do default(shared)
-    do K=2,nz
-      do j=js-1,je+1 ; do I=is-1,ie
+    do concurrent(K=2:nz)
+      do concurrent(j=js-1:je+1, I=is-1:ie)
         h4_u(I,j,K) = G%mask2dCu(I,j) * ( (h(i,j,k)*h(i+1,j,k)) * (h(i,j,k-1)*h(i+1,j,k-1)) )
-      enddo ; enddo
-      do J=js-1,je ; do i=is-1,ie+1
+      enddo
+      do concurrent(J=js-1:je, i=is-1:ie+1)
         h4_v(i,J,K) = G%mask2dCv(i,J) * ( (h(i,j,k)*h(i,j+1,k)) * (h(i,j,k-1)*h(i,j+1,k-1)) )
-      enddo ; enddo
+      enddo
     enddo
   endif
 
@@ -987,12 +989,13 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   ! calculate the first-mode gravity wave speed and then blend the equatorial
   ! and midlatitude deformation radii, using calc_resoln_function as a template.
 
-  !$OMP parallel do default(shared) private(S2,H_u,Hdn,Hup,H_geom,N2,wNE,wSE,wSW,wNW)
-  do j=js,je
-    do I=is-1,ie
+  ! UMW NOTE: H_u should be local, but this causes segfaults.
+  do concurrent(j=js:je) !local( H_u )
+    do concurrent(I=is-1:ie)
       CS%SN_u(I,j) = 0. ; H_u(I) = 0. ; S2_u(I,j) = 0.
     enddo
-    do K=2,nz ; do I=is-1,ie
+    do K=2,nz ; do concurrent(I=is-1:ie) &
+      & local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2)
       Hdn = sqrt( h(i,j,k) * h(i+1,j,k) )
       Hup = sqrt( h(i,j,k-1) * h(i+1,j,k-1) )
       H_geom = sqrt( Hdn * Hup )
@@ -1020,7 +1023,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
       S2_u(I,j) = S2_u(I,j) + S2*H_geom
       H_u(I) = H_u(I) + H_geom
     enddo ; enddo
-    do I=is-1,ie
+    do concurrent(I=is-1:ie)
       if (H_u(I)>0.) then
         CS%SN_u(I,j) = G%OBCmaskCu(I,j) * CS%SN_u(I,j) / H_u(I)
         S2_u(I,j) =  G%OBCmaskCu(I,j) * S2_u(I,j) / H_u(I)
@@ -1030,12 +1033,13 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
     enddo
   enddo
 
-  !$OMP parallel do default(shared) private(S2,H_v,Hdn,Hup,H_geom,N2,wNE,wSE,wSW,wNW)
-  do J=js-1,je
-    do i=is,ie
+  ! UMW NOTE: H_v should be local, but this causes segfaults. 
+  do concurrent(J=js-1:je) !local( H_v )
+    do concurrent(i=is:ie)
       CS%SN_v(i,J) = 0. ; H_v(i) = 0. ; S2_v(i,J) = 0.
     enddo
-    do K=2,nz ; do i=is,ie
+    do K=2,nz ; do concurrent(i=is:ie) &
+      & local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2)
       Hdn = sqrt( h(i,j,k) * h(i,j+1,k) )
       Hup = sqrt( h(i,j,k-1) * h(i,j+1,k-1) )
       H_geom = sqrt( Hdn * Hup )
@@ -1063,7 +1067,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
       S2_v(i,J) = S2_v(i,J) + S2*H_geom
       H_v(i) = H_v(i) + H_geom
     enddo ; enddo
-    do i=is,ie
+    do concurrent(i=is:ie)
       if (H_v(i)>0.) then
         CS%SN_v(i,J) = G%OBCmaskCv(i,J) * CS%SN_v(i,J) / H_v(i)
         S2_v(i,J) = G%OBCmaskCv(i,J) * S2_v(i,J) / H_v(i)
@@ -1089,6 +1093,9 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
     call uvchksum("calc_Visbeck_coeffs_old SN_[uv]", CS%SN_u, CS%SN_v, G%HI, &
                   unscale=US%s_to_T, scalar_pair=.true.)
   endif
+
+  !$omp target exit data map(delete: h4_u, h4_v,S2_u,S2_v,H_u, H_v)
+  !$omp target exit data map(from: CS%SN_u, CS%SN_v)
 
 end subroutine calc_Visbeck_coeffs_old
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -24,11 +24,10 @@ use MOM_open_boundary,     only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary,     only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_MEKE_types,        only : MEKE_type
 
-!$ use omp_lib, only: omp_get_num_devices
-
 implicit none ; private
 
 #include <MOM_memory.h>
+#include "do_concurrent_compat.h"
 
 !> Variable mixing coefficients
 type, public :: VarMix_CS
@@ -232,12 +231,12 @@ subroutine calc_depth_function(G, CS)
   ! For efficiency, the reciprocal of H0 should be used instead.
   H0 = CS%depth_scaled_khth_h0
   expo = CS%depth_scaled_khth_exp
-  do concurrent( j=js:je, i=is-1:Ieq ) local(h1,h2)
+  do concurrent( j=js:je, i=is-1:Ieq ) DO_LOCALITY(local(h1,h2))
     h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
     h2 = max(G%meanSL(i+1,j) + G%bathyT(i+1,j), 0.0)
     CS%Depth_fn_u(I,j) = (MIN(1.0, (0.5 * (h1 + h2)) / H0))**expo
   enddo
-  do concurrent( J=js-1:Jeq, i=is:ie ) local(h1,h2)
+  do concurrent( J=js-1:Jeq, i=is:ie ) DO_LOCALITY(local(h1,h2))
     h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
     h2 = max(G%meanSL(i,j+1) + G%bathyT(i,j+1), 0.0)
     CS%Depth_fn_v(i,J) = (MIN(1.0, (0.5 * (h1 + h2)) / H0))**expo
@@ -247,7 +246,7 @@ end subroutine calc_depth_function
 
 !> Calculates and stores the non-dimensional resolution functions
 subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
-  type(ocean_grid_type),                     intent(inout) :: G  !< Ocean grid structure
+  type(ocean_grid_type),                     intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
   type(thermo_var_ptrs),                     intent(in)    :: tv !< Thermodynamic variables
@@ -359,9 +358,11 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
       CS%Rd_dx_h(i,j) = CS%cg1(i,j) / &
             (sqrt(CS%f2_dx2_h(i,j) + CS%cg1(i,j)*CS%beta_dx2_h(i,j)))
     enddo
-    !$omp target update from(CS%Rd_dx_h)
     if (query_averaging_enabled(CS%diag)) then
-      if (CS%id_Rd_dx > 0) call post_data(CS%id_Rd_dx, CS%Rd_dx_h, CS%diag)
+      if (CS%id_Rd_dx > 0) then
+        !$omp target update from(CS%Rd_dx_h)
+        call post_data(CS%id_Rd_dx, CS%Rd_dx_h, CS%diag)
+      endif
     endif
   endif
 
@@ -415,7 +416,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
   else
     do concurrent( J=js-1:Jeq, I=is-1:Ieq )
       cg1_q(I,J) = 0.25 * ((CS%cg1(i,j) + CS%cg1(i+1,j+1)) + (CS%cg1(i+1,j) + CS%cg1(i,j+1)))
-    enddo 
+    enddo
   endif
 
   !   Do this calculation on the extent used in MOM_hor_visc.F90, and
@@ -438,11 +439,11 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
       endif
     enddo ; enddo
   elseif (CS%Res_fn_power_visc == 2) then
-    do concurrent( j=js-1:je+1, i=is-1:ie+1 ) local(dx_term)
+    do concurrent( j=js-1:je+1, i=is-1:ie+1 ) DO_LOCALITY(local(dx_term))
       dx_term = CS%f2_dx2_h(i,j) + CS%cg1(i,j)*CS%beta_dx2_h(i,j)
       CS%Res_fn_h(i,j) = dx_term / (dx_term + (CS%Res_coef_visc * CS%cg1(i,j))**2)
     enddo
-    do concurrent( J=js-1:Jeq, I=is-1:Ieq ) local(dx_term)
+    do concurrent( J=js-1:Jeq, I=is-1:Ieq ) DO_LOCALITY(local(dx_term))
       dx_term = CS%f2_dx2_q(I,J) +  cg1_q(I,J) * CS%beta_dx2_q(I,J)
       CS%Res_fn_q(I,J) = dx_term / (dx_term + (CS%Res_coef_visc * cg1_q(I,J))**2)
     enddo
@@ -541,15 +542,15 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
         endif
       enddo ; enddo
     elseif (CS%Res_fn_power_khth == 2) then
-      do concurrent( j=js:je, I=is-1:Ieq ) local(dx_term)
+      do concurrent( j=js:je, I=is-1:Ieq ) DO_LOCALITY(local(dx_term))
         dx_term = CS%f2_dx2_u(I,j) + cg1_u(I,j) * CS%beta_dx2_u(I,j)
         CS%Res_fn_u(I,j) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_u(I,j))**2)
       enddo
-      do concurrent( J=js-1:Jeq, i=is:ie ) local(dx_term)
+      do concurrent( J=js-1:Jeq, i=is:ie ) DO_LOCALITY(local(dx_term))
         dx_term = CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)
         CS%Res_fn_v(i,J) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_v(i,J))**2)
       enddo
-      do concurrent( J=js-1:Jeq, i=is:ie ) local(dx_term)
+      do concurrent( J=js-1:Jeq, i=is:ie ) DO_LOCALITY(local(dx_term))
         dx_term = CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)
         CS%Res_fn_v(i,J) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_v(i,J))**2)
       enddo
@@ -583,8 +584,10 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
 
 
   if (query_averaging_enabled(CS%diag)) then
-    !$omp target update from(CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v)
-    if (CS%id_Res_fn > 0) call post_data(CS%id_Res_fn, CS%Res_fn_h, CS%diag)
+    if (CS%id_Res_fn > 0) then
+     !$omp target update from(CS%Res_fn_h)
+      call post_data(CS%id_Res_fn, CS%Res_fn_h, CS%diag)
+    endif
     if (CS%id_BS_struct > 0) call post_data(CS%id_BS_struct, CS%BS_struct, CS%diag)
     if (CS%id_khth_struct > 0) call post_data(CS%id_khth_struct, CS%khth_struct, CS%diag)
     if (CS%id_khtr_struct > 0) call post_data(CS%id_khtr_struct, CS%khtr_struct, CS%diag)
@@ -602,7 +605,7 @@ end subroutine calc_resoln_function
 
 !> Calculates and stores functions of SQG mode
 subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE, OBC)
-  type(ocean_grid_type),                     intent(inout) :: G  !< Ocean grid structure
+  type(ocean_grid_type),                     intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV !< Vertical grid structure
   type(unit_scale_type),                     intent(in)    :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
@@ -770,10 +773,10 @@ end subroutine calc_sqg_struct
 !> Calculates and stores functions of isopycnal slopes, e.g. Sx, Sy, S*N, mostly used in the Visbeck et al.
 !! style scaling of diffusivity
 subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
-  type(ocean_grid_type),                     intent(inout) :: G  !< Ocean grid structure
+  type(ocean_grid_type),                     intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV !< Vertical grid structure
   type(unit_scale_type),                     intent(in)    :: US !< A dimensional unit scaling type
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h  !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
   type(thermo_var_ptrs),                     intent(in)    :: tv !< Thermodynamic variables
   real,                                      intent(in)    :: dt !< Time increment [T ~> s]
   type(VarMix_CS),                           intent(inout) :: CS !< Variable mixing control structure
@@ -836,7 +839,6 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     else
       !$omp target update from(e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
-      call cpu_clock_end(CS%id_clock_calc_slope_functions_using_just_e)
     endif
     !$omp target exit data map(delete: e)
   endif
@@ -860,7 +862,7 @@ end subroutine calc_slope_functions
 !! This is on older implementation that is susceptible to large values of Eady growth rate
 !! for incropping layers.
 subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
-  type(ocean_grid_type),                        intent(inout) :: G  !< Ocean grid structure
+  type(ocean_grid_type),                        intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),                      intent(in)    :: GV !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),    intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: slope_x !< Zonal isoneutral slope [Z L-1 ~> nondim]
@@ -974,13 +976,13 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   ! calculate the first-mode gravity wave speed and then blend the equatorial
   ! and midlatitude deformation radii, using calc_resoln_function as a template.
 
-  ! UMW NOTE: H_u should be local, but this causes segfaults.
+  ! UMW NOTE: H_u should be local, but this causes segfaults with nvfortran 26.3
   do concurrent(j=js:je) !local( H_u )
     do concurrent(I=is-1:ie)
       CS%SN_u(I,j) = 0. ; H_u(I) = 0. ; S2_u(I,j) = 0.
     enddo
     do K=2,nz ; do concurrent(I=is-1:ie) &
-      & local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2)
+        DO_LOCALITY(local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2))
       Hdn = sqrt( h(i,j,k) * h(i+1,j,k) )
       Hup = sqrt( h(i,j,k-1) * h(i+1,j,k-1) )
       H_geom = sqrt( Hdn * Hup )
@@ -1018,13 +1020,13 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
     enddo
   enddo
 
-  ! UMW NOTE: H_v should be local, but this causes segfaults. 
+  ! UMW NOTE: H_v should be local, but this causes segfaults with nvfortran 26.3
   do concurrent(J=js-1:je) !local( H_v )
     do concurrent(i=is:ie)
       CS%SN_v(i,J) = 0. ; H_v(i) = 0. ; S2_v(i,J) = 0.
     enddo
     do K=2,nz ; do concurrent(i=is:ie) &
-      & local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2)
+      & DO_LOCALITY(local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2))
       Hdn = sqrt( h(i,j,k) * h(i,j+1,k) )
       Hup = sqrt( h(i,j,k-1) * h(i,j+1,k-1) )
       H_geom = sqrt( Hdn * Hup )
@@ -1069,6 +1071,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   endif
 
   if (CS%debug) then
+    !$omp target update from(slope_x, slope_y, N2_u, N2_v, CS%SN_u, CS%SN_v)
     call uvchksum("calc_Visbeck_coeffs_old slope_[xy]", slope_x, slope_y, G%HI, &
                   unscale=US%Z_to_L, haloshift=1)
     ! call uvchksum("calc_Visbeck_coeffs_old S2_[uv]", S2_u, S2_v, G%HI, &
@@ -1240,9 +1243,9 @@ end subroutine calc_Eady_growth_rate_2D
 !> The original calc_slope_function() that calculated slopes using
 !! interface positions only, not accounting for density variations.
 subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
-  type(ocean_grid_type),                       intent(inout) :: G  !< Ocean grid structure
+  type(ocean_grid_type),                       intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),                     intent(in)    :: GV !< Vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   intent(inout) :: h  !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
   type(unit_scale_type),                       intent(in)    :: US !< A dimensional unit scaling type
   type(VarMix_CS),                             intent(inout) :: CS !< Variable mixing control structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: e  !< Interface position [Z ~> m]
@@ -1294,7 +1297,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   use_dztot = CS%full_depth_Eady_growth_rate ! .or. .not.(GV%Boussinesq or GV%semi_Boussinesq)
 
   if (use_dztot) then
-    do j=js-1,je+1 ; do i=is-1,ie+1 
+    do j=js-1,je+1 ; do i=is-1,ie+1
       dz_tot(i,j) = e(i,j,1) - e(i,j,nz+1)
     enddo ; enddo
     ! The following mathematically equivalent expression is more expensive but is less
@@ -1327,7 +1330,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     enddo
 
     ! Calculate N*S*h from this layer and add to the sum
-    do concurrent( j=js:je, i=is-1:ie ) local( S2, Hdn, Hup, H_geom )
+    do concurrent( j=js:je, i=is-1:ie ) DO_LOCALITY(local( S2, Hdn, Hup, H_geom ))
       S2 = ( E_x(I,j)**2  + 0.25*( &
             ((E_y(i,J)**2) + (E_y(i+1,J-1)**2)) + ((E_y(i+1,J)**2) + (E_y(i,J-1)**2)) ) )
       if (min(h(i,j,k-1), h(i+1,j,k-1), h(i,j,k), h(i+1,j,k)) < H_cutoff) S2 = 0.0
@@ -1338,7 +1341,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       ! N2 = GV%g_prime(k) / (GV%H_to_Z * max(Hdn, Hup, CS%h_min_N2))
       S2N2_u_local(I,j,k) = (H_geom * S2) * (GV%g_prime(k) / max(Hdn, Hup, CS%h_min_N2) )
     enddo
-    do concurrent( J=js-1:je, i=is:ie ) local( S2, Hdn, Hup, H_geom )
+    do concurrent( J=js-1:je, i=is:ie ) DO_LOCALITY(local( S2, Hdn, Hup, H_geom ))
       S2 = ( E_y(i,J)**2  + 0.25*( &
             ((E_x(I,j)**2) + (E_x(I-1,j+1)**2)) + ((E_x(I,j+1)**2) + (E_x(I-1,j)**2)) ) )
       if (min(h(i,j,k-1), h(i,j+1,k-1), h(i,j,k), h(i,j+1,k)) < H_cutoff) S2 = 0.0
@@ -1353,16 +1356,16 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   enddo ! k
 
   !UMW NOTE: For some reason, do concurrents in the following loops change answers
-  ! or segfault. 
+  ! or segfault.
 
   !$omp target teams
   do j=js,je
     !$omp loop
-    do I=is-1,ie 
+    do I=is-1,ie
       CS%SN_u(I,j) = 0.0
     enddo
     do k=nz,CS%VarMix_Ktop,-1
-      !$omp loop 
+      !$omp loop
       do I=is-1,ie
         CS%SN_u(I,j) = CS%SN_u(I,j) + S2N2_u_local(I,j,k)
       enddo

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -801,7 +801,6 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
   if (nkblock == 0) nkblock = GV%ke
 
   if (CS%calculate_Eady_growth_rate) then
-    !$omp target update to(h)
     !$omp target enter data map(alloc: e)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
 
@@ -877,7 +876,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   real :: H_geom        ! The geometric mean of Hup and Hdn [H ~> m or kg m-2].
   real :: S2max         ! An upper bound on the squared slopes [Z2 L-2 ~> nondim]
   real :: wNE, wSE, wSW, wNW ! Weights of adjacent points [nondim]
-  real :: H_u(SZIB_(G)), H_v(SZI_(G)) ! Layer thicknesses at u- and v-points [H ~> m or kg m-2]
+  real :: H_u(SZIB_(G), SZJ_(G)), H_v(SZI_(G), SZJB_(G)) ! Layer thicknesses at u- and v-points [H ~> m or kg m-2]
 
   ! Note that at some points in the code S2_u and S2_v hold the running depth
   ! integrals of the squared slope [H ~> m or kg m-2] before the average is taken.
@@ -897,8 +896,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
                                  ! interface or the inward equivalent with OBCs [H4 ~> m4 or kg4 m-8]
   integer :: i, j, k, is, ie, js, je, nz
 
-  !$omp target enter data map(alloc: h4_u, h4_v,S2_u,S2_v,H_u, H_v)
-  ! !$omp target enter data map(to: CS%SN_u, CS%SN_v)
+  !$omp target enter data map(alloc: h4_u, h4_v,S2_u,S2_v,H_u, H_v, OBC_dir_u, OBC_dir_v)
 
   if (.not. CS%initialized) call MOM_error(FATAL, "calc_Visbeck_coeffs_old: "// &
          "Module must be initialized before it is used.")
@@ -970,10 +968,9 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   ! calculate the first-mode gravity wave speed and then blend the equatorial
   ! and midlatitude deformation radii, using calc_resoln_function as a template.
 
-  ! H_u should be local, but this causes segfaults with nvfortran 26.3
-  do concurrent(j=js:je) !local( H_u )
+  do concurrent(j=js:je)
     do concurrent(I=is-1:ie)
-      CS%SN_u(I,j) = 0. ; H_u(I) = 0. ; S2_u(I,j) = 0.
+      CS%SN_u(I,j) = 0. ; H_u(I,j) = 0. ; S2_u(I,j) = 0.
     enddo
     do K=2,nz ; do concurrent(I=is-1:ie) &
         DO_LOCALITY(local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2))
@@ -1002,22 +999,21 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
       N2 = max(0., N2_u(I,j,k))
       CS%SN_u(I,j) = CS%SN_u(I,j) + sqrt( S2*N2 )*H_geom
       S2_u(I,j) = S2_u(I,j) + S2*H_geom
-      H_u(I) = H_u(I) + H_geom
+      H_u(I,j) = H_u(I,j) + H_geom
     enddo ; enddo
     do concurrent(I=is-1:ie)
-      if (H_u(I)>0.) then
-        CS%SN_u(I,j) = G%OBCmaskCu(I,j) * CS%SN_u(I,j) / H_u(I)
-        S2_u(I,j) =  G%OBCmaskCu(I,j) * S2_u(I,j) / H_u(I)
+      if (H_u(I,j)>0.) then
+        CS%SN_u(I,j) = G%OBCmaskCu(I,j) * CS%SN_u(I,j) / H_u(I,j)
+        S2_u(I,j) =  G%OBCmaskCu(I,j) * S2_u(I,j) / H_u(I,j)
       else
         CS%SN_u(I,j) = 0.
       endif
     enddo
   enddo
 
-  ! H_v should be local, but this causes segfaults with nvfortran 26.3
-  do concurrent(J=js-1:je) !local( H_v )
+  do concurrent(J=js-1:je)
     do concurrent(i=is:ie)
-      CS%SN_v(i,J) = 0. ; H_v(i) = 0. ; S2_v(i,J) = 0.
+      CS%SN_v(i,J) = 0. ; H_v(i,J) = 0. ; S2_v(i,J) = 0.
     enddo
     do K=2,nz ; do concurrent(i=is:ie) &
       & DO_LOCALITY(local(Hdn, Hup, H_geom, wSE, wNW, wNE, wSW, S2, N2))
@@ -1046,12 +1042,12 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
       N2 = max(0., N2_v(i,J,K))
       CS%SN_v(i,J) = CS%SN_v(i,J) + sqrt( S2*N2 )*H_geom
       S2_v(i,J) = S2_v(i,J) + S2*H_geom
-      H_v(i) = H_v(i) + H_geom
+      H_v(i,J) = H_v(i,J) + H_geom
     enddo ; enddo
     do concurrent(i=is:ie)
-      if (H_v(i)>0.) then
-        CS%SN_v(i,J) = G%OBCmaskCv(i,J) * CS%SN_v(i,J) / H_v(i)
-        S2_v(i,J) = G%OBCmaskCv(i,J) * S2_v(i,J) / H_v(i)
+      if (H_v(i,j)>0.) then
+        CS%SN_v(i,J) = G%OBCmaskCv(i,J) * CS%SN_v(i,J) / H_v(i,J)
+        S2_v(i,J) = G%OBCmaskCv(i,J) * S2_v(i,J) / H_v(i,J)
       else
         CS%SN_v(i,J) = 0.
       endif
@@ -1076,8 +1072,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
                   unscale=US%s_to_T, scalar_pair=.true.)
   endif
 
-  !$omp target exit data map(delete: h4_u, h4_v,S2_u,S2_v,H_u, H_v)
-  ! !$omp target exit data map(from: CS%SN_u, CS%SN_v)
+  !$omp target exit data map(delete: h4_u, h4_v,S2_u,S2_v,H_u, H_v, OBC_dir_u, OBC_dir_v)
 
 end subroutine calc_Visbeck_coeffs_old
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -550,10 +550,6 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
         dx_term = CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)
         CS%Res_fn_v(i,J) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_v(i,J))**2)
       enddo
-      do concurrent( J=js-1:Jeq, i=is:ie ) DO_LOCALITY(local(dx_term))
-        dx_term = CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)
-        CS%Res_fn_v(i,J) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_v(i,J))**2)
-      enddo
     elseif (mod(CS%Res_fn_power_khth, 2) == 0) then
       power_2 = CS%Res_fn_power_khth / 2
       do j=js,je ; do I=is-1,Ieq
@@ -600,6 +596,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
     call uvchksum("Res_fn_[uv]", CS%Res_fn_u, CS%Res_fn_v, G%HI, haloshift=0, &
                   unscale=1.0, scalar_pair=.true.)
   endif
+
   !$omp target exit data map(delete: cg1_q, cg1_u, cg1_v, dx_term)
 end subroutine calc_resoln_function
 
@@ -817,7 +814,6 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
                                   CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
                                   N2_v=N2_v, dzu=dzu, dzv=dzv, dzSxN=dzSxN, dzSyN=dzSyN, halo=1, &
                                   OBC=OBC, OBC_N2=CS%OBC_friendly)
-      !$omp target update from(e, dzu, dzv, dzSxN, dzSyN)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
@@ -831,13 +827,11 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
                                   CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
                                   N2_v=N2_v, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
-      !$omp target exit data map(from: CS%slope_x, CS%slope_y, N2_u, N2_v)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
       !$omp target exit data map(release: tv%T, tv%S, tv, CS%slope_x, CS%slope_y)
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
       !$omp target exit data map(delete: N2_u, N2_v )
     else
-      !$omp target update from(e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
     !$omp target exit data map(delete: e)
@@ -904,7 +898,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   integer :: i, j, k, is, ie, js, je, nz
 
   !$omp target enter data map(alloc: h4_u, h4_v,S2_u,S2_v,H_u, H_v)
-  !$omp target enter data map(to: CS%SN_u, CS%SN_v)
+  ! !$omp target enter data map(to: CS%SN_u, CS%SN_v)
 
   if (.not. CS%initialized) call MOM_error(FATAL, "calc_Visbeck_coeffs_old: "// &
          "Module must be initialized before it is used.")
@@ -1083,7 +1077,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   endif
 
   !$omp target exit data map(delete: h4_u, h4_v,S2_u,S2_v,H_u, H_v)
-  !$omp target exit data map(from: CS%SN_u, CS%SN_v)
+  ! !$omp target exit data map(from: CS%SN_u, CS%SN_v)
 
 end subroutine calc_Visbeck_coeffs_old
 
@@ -1285,14 +1279,10 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   !$omp target enter data map(alloc: E_x, E_y, S2N2_u_local, S2N2_v_local)
-  !$omp target update to(CS%h_min_N2, CS%VarMix_Ktop)
-  !$omp target enter data map(to: CS, CS%SN_u, CS%SN_v)
 
   h_neglect = GV%H_subroundoff
   H_cutoff = real(2*nz) * (GV%Angstrom_H + h_neglect)
   dZ_cutoff = real(2*nz) * (GV%Angstrom_Z + GV%dz_subroundoff)
-
-  !$omp target enter data map(to:dZ_cutoff)
 
   use_dztot = CS%full_depth_Eady_growth_rate ! .or. .not.(GV%Boussinesq or GV%semi_Boussinesq)
 
@@ -1355,32 +1345,24 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
 
   enddo ! k
 
-  !UMW NOTE: For some reason, do concurrents in the following loops change answers
-  ! or segfault.
-
-  !$omp target teams
   do j=js,je
-    !$omp loop
-    do I=is-1,ie
+    do concurrent( I=is-1:ie )
       CS%SN_u(I,j) = 0.0
     enddo
     do k=nz,CS%VarMix_Ktop,-1
-      !$omp loop
-      do I=is-1,ie
+      do concurrent( I=is-1:ie )
         CS%SN_u(I,j) = CS%SN_u(I,j) + S2N2_u_local(I,j,k)
       enddo
     enddo
     ! SN above contains S^2*N^2*H, convert to vertical average of S*N
 
     if (use_dztot) then
-      !$omp loop
       do I=is-1,ie
         CS%SN_u(I,j) = G%OBCmaskCu(I,j) * sqrt( CS%SN_u(I,j) / &
                                                 max(dz_tot(i,j), dz_tot(i+1,j), GV%dz_subroundoff) )
       enddo
     else
-      !$omp loop private(h1,h2)
-      do I=is-1,ie
+      do concurrent( I=is-1:ie ) DO_LOCALITY(local(h1, h2))
         h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
         h2 = max(G%meanSL(i+1,j) + G%bathyT(i+1,j), 0.0)
         if ( min(h1, h2) > dZ_cutoff ) then
@@ -1391,29 +1373,23 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       enddo
     endif
   enddo
-  !$omp end target teams
 
-  !$omp target teams
   do J=js-1,je
-    !$omp loop
-    do i=is,ie
+    do concurrent( i=is:ie )
       CS%SN_v(i,J) = 0.0
     enddo
     do k=nz,CS%VarMix_Ktop,-1
-      !$omp loop
-      do i=is,ie
+      do concurrent( i=is:ie )
         CS%SN_v(i,J) = CS%SN_v(i,J) + S2N2_v_local(i,J,k)
       enddo
     enddo
     if (use_dztot) then
-      !$omp loop
       do i=is,ie
         CS%SN_v(i,J) = G%OBCmaskCv(i,J) * sqrt( CS%SN_v(i,J) / &
                                                 max(dz_tot(i,j), dz_tot(i,j+1), GV%dz_subroundoff) )
       enddo
     else
-      !$omp loop private(h1,h2)
-      do i=is,ie
+      do concurrent( i=is:ie ) DO_LOCALITY(local(h1, h2))
         ! There is a primordial horizontal indexing bug on the following line from the previous
         ! versions of the code.  This comment should be deleted by the end of 2024.
         ! if ( min(G%bathyT(i,j), G%bathyT(i+1,j)) + G%Z_ref > dZ_cutoff ) then
@@ -1427,10 +1403,8 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       enddo
     endif
   enddo
-  !$omp end target teams
 
-  !$omp target exit data map(delete: E_x, E_y, S2N2_u_local, S2N2_v_local, dZ_cutoff)
-  !$omp target exit data map(from: CS%SN_u, CS%SN_v)
+  !$omp target exit data map(delete: E_x, E_y, S2N2_u_local, S2N2_v_local )
 
 end subroutine calc_slope_functions_using_just_e
 
@@ -2132,11 +2106,8 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
       oneOrTwo = 2.0
     endif
 
-    !$omp target enter data map(alloc: CS%f2_dx2_q, CS%beta_dx2_q, &
-    !$omp&                             CS%f2_dx2_u, CS%beta_dx2_u, &
-    !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
 
-    do concurrent( J=js-1:Jeq, I=is-1:Ieq )
+    do J=js-1,Jeq ; do I=is-1,Ieq
       CS%f2_dx2_q(I,J) = ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * &
                          max(G%Coriolis2Bu(I,J), absurdly_small_freq**2)
       CS%beta_dx2_q(I,J) = oneOrTwo * ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * (sqrt(0.5 * &
@@ -2144,9 +2115,9 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
              (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
             ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
              (((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2)) ) ))
-    enddo
+    enddo ; enddo
 
-    do concurrent( j=js:je, I=is-1:Ieq )
+    do j=js,je ; do I=is-1,Ieq
       CS%f2_dx2_u(I,j) = ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * &
           max(0.5* (G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I,J-1)), absurdly_small_freq**2)
       CS%beta_dx2_u(I,j) = oneOrTwo * ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * (sqrt( &
@@ -2155,9 +2126,9 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                   (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
                  ((((G%CoriolisBu(I+1,J-1)-G%CoriolisBu(I,J-1)) * G%IdxCv(i+1,J-1))**2) + &
                   (((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2)) ) ))
-    enddo
+    enddo ; enddo
 
-    do concurrent( J=js-1:Jeq, i=is:ie )
+    do J=js-1,Jeq ; do i=is,ie
       CS%f2_dx2_v(i,J) = ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * &
           max(0.5*(G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I-1,J)), absurdly_small_freq**2)
       CS%beta_dx2_v(i,J) = oneOrTwo * ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * (sqrt( &
@@ -2166,7 +2137,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                   (((G%CoriolisBu(I-1,J+1)-G%CoriolisBu(I-1,J)) * G%IdyCu(I-1,j+1))**2)) + &
                  ((((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2) + &
                   (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
-    enddo
+    enddo ; enddo
 
   endif
 
@@ -2193,9 +2164,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     allocate(CS%beta_dx2_h(isd:ied,jsd:jed), source=0.0)
     allocate(CS%f2_dx2_h(isd:ied,jsd:jed), source=0.0)
 
-    !$omp target enter data map(alloc: CS%f2_dx2_h, CS%beta_dx2_h)
-
-    do concurrent(j=js-1:je+1, i=is-1:ie+1)
+    do j=js-1,je+1 ; do i=is-1,ie+1
       CS%f2_dx2_h(i,j) = ((G%dxT(i,j)**2) + (G%dyT(i,j)**2)) * &
           max(0.25 * ((G%Coriolis2Bu(I,J) + G%Coriolis2Bu(I-1,J-1)) + &
                       (G%Coriolis2Bu(I-1,J) + G%Coriolis2Bu(I,J-1))), &
@@ -2205,7 +2174,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
              (((G%CoriolisBu(I,J-1)-G%CoriolisBu(I-1,J-1)) * G%IdxCv(i,J-1))**2)) + &
             ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
              (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
-    enddo
+    enddo ; enddo
   endif
 
   if (CS%calculate_cg1) then
@@ -2290,19 +2259,48 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   ! Re-enable variable mixing if one of the schemes was enabled
   CS%use_variable_mixing = in_use .or. CS%use_variable_mixing
 
+  ! Map CS to device at initialization.
+  !$omp target enter data map(to: CS)
+
+  ! Zero intialized arrays that will be filled in later
+  !$omp target enter data map(alloc: CS%cg1)
+  !$omp target enter data map(alloc: CS%Rd_dx_h)
+  !$omp target enter data map(alloc: CS%Depth_fn_u, CS%Depth_fn_v)
+  !$omp target enter data map(alloc: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v)
+  !$omp target enter data map(alloc: CS%SN_u, CS%SN_v)
+
+  ! Arrays that will be filled in during initialization
+  !$omp target enter data map(to: CS%f2_dx2_h, CS%beta_dx2_h, &
+  !$omp&                          CS%f2_dx2_q, CS%beta_dx2_q, &
+  !$omp&                          CS%f2_dx2_u, CS%beta_dx2_u, &
+  !$omp&                          CS%f2_dx2_v, CS%beta_dx2_v)
+
+  ! These are used in hor_diff and thickness diffuse. Allocate once at initialization
+  !$omp target enter data map(to: CS%L2u, CS%L2v)
+
 end subroutine VarMix_init
 
 !> Destructor for VarMix control structure
 subroutine VarMix_end(CS)
   type(VarMix_CS), intent(inout) :: CS
 
-  ! Remove component arrays from device before host deallocation;
-  !$omp target exit data map(delete: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v, &
-  !$omp&                             CS%f2_dx2_q, CS%beta_dx2_q, CS%f2_dx2_u, CS%beta_dx2_u, &
-  !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
-  !$omp target exit data map(delete: CS%Rd_dx_h, CS%f2_dx2_h, CS%beta_dx2_h)
-  !$omp target exit data map(delete: CS%Depth_fn_u, CS%Depth_fn_v)
+  ! Remove component arrays from device before host deallocation
   !$omp target exit data map(delete: CS%cg1)
+  !$omp target exit data map(delete: CS%Rd_dx_h)
+  !$omp target exit data map(delete: CS%Depth_fn_u, CS%Depth_fn_v)
+  !$omp target exit data map(delete: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v)
+  !$omp target exit data map(delete: CS%SN_u, CS%SN_v)
+
+  !$omp target exit data map(delete: CS%f2_dx2_h, CS%beta_dx2_h, &
+  !$omp&                             CS%f2_dx2_q, CS%beta_dx2_q, &
+  !$omp&                             CS%f2_dx2_u, CS%beta_dx2_u, &
+  !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
+
+  ! These are used in MOM_tracer_hor_diff and thickness diffuse.
+  !$omp target exit data map(delete: CS%L2u, CS%L2v)
+
+  ! Delete control structure from device
+  !$omp target exit data map(delete: CS)
 
   if (allocated(CS%ebt_struct))  deallocate(CS%ebt_struct)
   if (allocated(CS%sqg_struct))  deallocate(CS%sqg_struct)
@@ -2344,8 +2342,6 @@ subroutine VarMix_end(CS)
   if (allocated(CS%Laplac3_const_v)) deallocate(CS%Laplac3_const_v)
   if (allocated(CS%KH_u_QG)) deallocate(CS%KH_u_QG)
   if (allocated(CS%KH_v_QG)) deallocate(CS%KH_v_QG)
-  ! Delete control structure from device
-  !$omp target exit data map(delete: CS)
 
 end subroutine VarMix_end
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1298,21 +1298,21 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   !$omp target enter data map(alloc: E_x, E_y, S2N2_u_local, S2N2_v_local)
-  !$omp target enter data map(alloc: E_x, E_y, S2N2_u_local, S2N2_v_local)
+  !$omp target update to(CS%h_min_N2, CS%VarMix_Ktop)
   !$omp target enter data map(to: CS, CS%SN_u, CS%SN_v)
 
   h_neglect = GV%H_subroundoff
   H_cutoff = real(2*nz) * (GV%Angstrom_H + h_neglect)
   dZ_cutoff = real(2*nz) * (GV%Angstrom_Z + GV%dz_subroundoff)
 
+  !$omp target enter data map(to:dZ_cutoff)
+
   use_dztot = CS%full_depth_Eady_growth_rate ! .or. .not.(GV%Boussinesq or GV%semi_Boussinesq)
 
-  !$omp target enter data map(alloc: dz_tot) if (use_dztot)
-
   if (use_dztot) then
-    do concurrent( j=js-1:je+1, i=is-1:ie+1 )
+    do j=js-1,je+1 ; do i=is-1,ie+1 
       dz_tot(i,j) = e(i,j,1) - e(i,j,nz+1)
-    enddo 
+    enddo ; enddo
     ! The following mathematically equivalent expression is more expensive but is less
     ! sensitive to roundoff for large Z_ref:
     ! call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
@@ -1368,23 +1368,32 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
 
   enddo ! k
 
-  !do concurrent( j=js:je )
+  !UMW NOTE: For some reason, do concurrents in the following loops change answers
+  ! or segfault. 
+
+  !$omp target teams
   do j=js,je
-    do concurrent( I=is-1:ie )
+    !$omp loop
+    do I=is-1,ie 
       CS%SN_u(I,j) = 0.0
     enddo
-    do k=nz,CS%VarMix_Ktop,-1 ; do concurrent( I=is-1:ie )
-      CS%SN_u(I,j) = CS%SN_u(I,j) + S2N2_u_local(I,j,k)
-    enddo ; enddo
+    do k=nz,CS%VarMix_Ktop,-1
+      !$omp loop 
+      do I=is-1,ie
+        CS%SN_u(I,j) = CS%SN_u(I,j) + S2N2_u_local(I,j,k)
+      enddo
+    enddo
     ! SN above contains S^2*N^2*H, convert to vertical average of S*N
 
     if (use_dztot) then
-      do concurrent( I=is-1:ie )
+      !$omp loop
+      do I=is-1,ie
         CS%SN_u(I,j) = G%OBCmaskCu(I,j) * sqrt( CS%SN_u(I,j) / &
                                                 max(dz_tot(i,j), dz_tot(i+1,j), GV%dz_subroundoff) )
       enddo
     else
-      do concurrent( I=is-1:ie ) local( h1, h2 )
+      !$omp loop private(h1,h2)
+      do I=is-1,ie
         h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
         h2 = max(G%meanSL(i+1,j) + G%bathyT(i+1,j), 0.0)
         if ( min(h1, h2) > dZ_cutoff ) then
@@ -1395,22 +1404,29 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       enddo
     endif
   enddo
+  !$omp end target teams
 
-  !do concurrent( J=js-1:je )
+  !$omp target teams
   do J=js-1,je
-    do concurrent( i=is:ie )
+    !$omp loop
+    do i=is,ie
       CS%SN_v(i,J) = 0.0
     enddo
-    do k=nz,CS%VarMix_Ktop,-1 ; do concurrent( i=is:ie )
-      CS%SN_v(i,J) = CS%SN_v(i,J) + S2N2_v_local(i,J,k)
-    enddo ; enddo
+    do k=nz,CS%VarMix_Ktop,-1
+      !$omp loop
+      do i=is,ie
+        CS%SN_v(i,J) = CS%SN_v(i,J) + S2N2_v_local(i,J,k)
+      enddo
+    enddo
     if (use_dztot) then
-      do concurrent( i=is:ie )
+      !$omp loop
+      do i=is,ie
         CS%SN_v(i,J) = G%OBCmaskCv(i,J) * sqrt( CS%SN_v(i,J) / &
                                                 max(dz_tot(i,j), dz_tot(i,j+1), GV%dz_subroundoff) )
       enddo
     else
-      do concurrent( i=is:ie ) local( h1, h2 )
+      !$omp loop private(h1,h2)
+      do i=is,ie
         ! There is a primordial horizontal indexing bug on the following line from the previous
         ! versions of the code.  This comment should be deleted by the end of 2024.
         ! if ( min(G%bathyT(i,j), G%bathyT(i+1,j)) + G%Z_ref > dZ_cutoff ) then
@@ -1424,12 +1440,10 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       enddo
     endif
   enddo
+  !$omp end target teams
 
-  !$omp target exit data map(delete: dz_tot) if (use_dztot)
-
-  !$omp target exit data map(delete: E_x, E_y, S2N2_u_local, S2N2_v_local)
+  !$omp target exit data map(delete: E_x, E_y, S2N2_u_local, S2N2_v_local, dZ_cutoff)
   !$omp target exit data map(from: CS%SN_u, CS%SN_v)
-  !$omp target exit data map(release: CS)
 
 end subroutine calc_slope_functions_using_just_e
 
@@ -1980,10 +1994,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     endif
   endif
 
-  ! Move Ktop to device
-  !$omp target enter data map(to: CS%VarMix_Ktop)
-  !$omp target enter data map(to: CS%h_min_N2)
-
   if (KhTr_Slope_Cff>0. .or. KhTh_Slope_Cff>0.) then
     in_use = .true.
     call get_param(param_file, mdl, "VISBECK_L_SCALE", CS%Visbeck_L_scale, &
@@ -2332,6 +2342,8 @@ subroutine VarMix_end(CS)
   if (allocated(CS%Laplac3_const_v)) deallocate(CS%Laplac3_const_v)
   if (allocated(CS%KH_u_QG)) deallocate(CS%KH_u_QG)
   if (allocated(CS%KH_v_QG)) deallocate(CS%KH_v_QG)
+  ! Delete control structure from device
+  !$omp target exit data map(delete: CS)
 
 end subroutine VarMix_end
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -852,6 +852,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     else
       !$omp target update from(e)
       call calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
+      call cpu_clock_end(CS%id_clock_calc_slope_functions_using_just_e)
     endif
     !$omp target exit data map(delete: e)
   endif
@@ -1296,17 +1297,22 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
+  !$omp target enter data map(alloc: E_x, E_y, S2N2_u_local, S2N2_v_local)
+  !$omp target enter data map(alloc: E_x, E_y, S2N2_u_local, S2N2_v_local)
+  !$omp target enter data map(to: CS, CS%SN_u, CS%SN_v)
+
   h_neglect = GV%H_subroundoff
   H_cutoff = real(2*nz) * (GV%Angstrom_H + h_neglect)
   dZ_cutoff = real(2*nz) * (GV%Angstrom_Z + GV%dz_subroundoff)
 
   use_dztot = CS%full_depth_Eady_growth_rate ! .or. .not.(GV%Boussinesq or GV%semi_Boussinesq)
 
+  !$omp target enter data map(alloc: dz_tot) if (use_dztot)
+
   if (use_dztot) then
-    !$OMP parallel do default(shared)
-    do j=js-1,je+1 ; do i=is-1,ie+1
+    do concurrent( j=js-1:je+1, i=is-1:ie+1 )
       dz_tot(i,j) = e(i,j,1) - e(i,j,nz+1)
-    enddo ; enddo
+    enddo 
     ! The following mathematically equivalent expression is more expensive but is less
     ! sensitive to roundoff for large Z_ref:
     ! call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
@@ -1322,23 +1328,22 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   ! calculate the first-mode gravity wave speed and then blend the equatorial
   ! and midlatitude deformation radii, using calc_resoln_function as a template.
 
-  !$OMP parallel do default(shared) private(E_x,E_y,S2,Hdn,Hup,H_geom,N2)
   do k=nz,CS%VarMix_Ktop,-1
 
     ! Calculate the interface slopes E_x and E_y and u- and v- points respectively
-    do j=js-1,je+1 ; do I=is-1,ie
+    do concurrent( j=js-1:je+1, i=is-1:ie )
       E_x(I,j) = (e(i+1,j,K)-e(i,j,K))*G%IdxCu(I,j)
       ! Mask slopes where interface intersects topography
       if (min(h(i,j,k),h(i+1,j,k)) < H_cutoff) E_x(I,j) = 0.
-    enddo ; enddo
-    do J=js-1,je ; do i=is-1,ie+1
+    enddo
+    do concurrent( J=js-1:je, i=is-1:ie+1 )
       E_y(i,J) = (e(i,j+1,K)-e(i,j,K))*G%IdyCv(i,J)
       ! Mask slopes where interface intersects topography
       if (min(h(i,j,k),h(i,j+1,k)) < H_cutoff) E_y(i,J) = 0.
-    enddo ; enddo
+    enddo
 
     ! Calculate N*S*h from this layer and add to the sum
-    do j=js,je ; do I=is-1,ie
+    do concurrent( j=js:je, i=is-1:ie ) local( S2, Hdn, Hup, H_geom )
       S2 = ( E_x(I,j)**2  + 0.25*( &
             ((E_y(i,J)**2) + (E_y(i+1,J-1)**2)) + ((E_y(i+1,J)**2) + (E_y(i,J-1)**2)) ) )
       if (min(h(i,j,k-1), h(i+1,j,k-1), h(i,j,k), h(i+1,j,k)) < H_cutoff) S2 = 0.0
@@ -1348,8 +1353,8 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       H_geom = sqrt(Hdn*Hup)
       ! N2 = GV%g_prime(k) / (GV%H_to_Z * max(Hdn, Hup, CS%h_min_N2))
       S2N2_u_local(I,j,k) = (H_geom * S2) * (GV%g_prime(k) / max(Hdn, Hup, CS%h_min_N2) )
-    enddo ; enddo
-    do J=js-1,je ; do i=is,ie
+    enddo
+    do concurrent( J=js-1:je, i=is:ie ) local( S2, Hdn, Hup, H_geom )
       S2 = ( E_y(i,J)**2  + 0.25*( &
             ((E_x(I,j)**2) + (E_x(I-1,j+1)**2)) + ((E_x(I,j+1)**2) + (E_x(I-1,j)**2)) ) )
       if (min(h(i,j,k-1), h(i,j+1,k-1), h(i,j,k), h(i,j+1,k)) < H_cutoff) S2 = 0.0
@@ -1359,25 +1364,27 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       H_geom = sqrt(Hdn*Hup)
       ! N2 = GV%g_prime(k) / (GV%H_to_Z * max(Hdn, Hup, CS%h_min_N2))
       S2N2_v_local(i,J,k) = (H_geom * S2) * (GV%g_prime(k) / (max(Hdn, Hup, CS%h_min_N2)))
-    enddo ; enddo
+    enddo
 
   enddo ! k
 
-  !$OMP parallel do default(shared)
+  !do concurrent( j=js:je )
   do j=js,je
-    do I=is-1,ie ; CS%SN_u(I,j) = 0.0 ; enddo
-    do k=nz,CS%VarMix_Ktop,-1 ; do I=is-1,ie
+    do concurrent( I=is-1:ie )
+      CS%SN_u(I,j) = 0.0
+    enddo
+    do k=nz,CS%VarMix_Ktop,-1 ; do concurrent( I=is-1:ie )
       CS%SN_u(I,j) = CS%SN_u(I,j) + S2N2_u_local(I,j,k)
     enddo ; enddo
     ! SN above contains S^2*N^2*H, convert to vertical average of S*N
 
     if (use_dztot) then
-      do I=is-1,ie
+      do concurrent( I=is-1:ie )
         CS%SN_u(I,j) = G%OBCmaskCu(I,j) * sqrt( CS%SN_u(I,j) / &
                                                 max(dz_tot(i,j), dz_tot(i+1,j), GV%dz_subroundoff) )
       enddo
     else
-      do I=is-1,ie
+      do concurrent( I=is-1:ie ) local( h1, h2 )
         h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
         h2 = max(G%meanSL(i+1,j) + G%bathyT(i+1,j), 0.0)
         if ( min(h1, h2) > dZ_cutoff ) then
@@ -1388,19 +1395,22 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       enddo
     endif
   enddo
-  !$OMP parallel do default(shared)
+
+  !do concurrent( J=js-1:je )
   do J=js-1,je
-    do i=is,ie ; CS%SN_v(i,J) = 0.0 ; enddo
-    do k=nz,CS%VarMix_Ktop,-1 ; do i=is,ie
+    do concurrent( i=is:ie )
+      CS%SN_v(i,J) = 0.0
+    enddo
+    do k=nz,CS%VarMix_Ktop,-1 ; do concurrent( i=is:ie )
       CS%SN_v(i,J) = CS%SN_v(i,J) + S2N2_v_local(i,J,k)
     enddo ; enddo
     if (use_dztot) then
-      do i=is,ie
+      do concurrent( i=is:ie )
         CS%SN_v(i,J) = G%OBCmaskCv(i,J) * sqrt( CS%SN_v(i,J) / &
                                                 max(dz_tot(i,j), dz_tot(i,j+1), GV%dz_subroundoff) )
       enddo
     else
-      do i=is,ie
+      do concurrent( i=is:ie ) local( h1, h2 )
         ! There is a primordial horizontal indexing bug on the following line from the previous
         ! versions of the code.  This comment should be deleted by the end of 2024.
         ! if ( min(G%bathyT(i,j), G%bathyT(i+1,j)) + G%Z_ref > dZ_cutoff ) then
@@ -1414,6 +1424,12 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       enddo
     endif
   enddo
+
+  !$omp target exit data map(delete: dz_tot) if (use_dztot)
+
+  !$omp target exit data map(delete: E_x, E_y, S2N2_u_local, S2N2_v_local)
+  !$omp target exit data map(from: CS%SN_u, CS%SN_v)
+  !$omp target exit data map(release: CS)
 
 end subroutine calc_slope_functions_using_just_e
 
@@ -1963,6 +1979,10 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                    do_not_log=CS%use_stored_slopes)
     endif
   endif
+
+  ! Move Ktop to device
+  !$omp target enter data map(to: CS%VarMix_Ktop)
+  !$omp target enter data map(to: CS%h_min_N2)
 
   if (KhTr_Slope_Cff>0. .or. KhTh_Slope_Cff>0.) then
     in_use = .true.

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -806,7 +806,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
 
     if (CS%use_simpler_Eady_growth_rate) then
-      !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
@@ -817,10 +817,10 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
       call calc_Eady_growth_rate_2D(CS, G, GV, US, h, e, dzu, dzv, dzSxN, dzSyN, CS%SN_u, CS%SN_v)
       !$omp target exit data map(release: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
-      !$omp target exit data map(release: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target exit data map(release: tv, tv%T, tv%S)
       !$omp target exit data map(delete: N2_u, N2_v, dzu, dzv, dzSxN, dzSyN)
     elseif (CS%use_stored_slopes) then
-      !$omp target enter data map(to: tv, tv%T, tv%S, CS%slope_x, CS%slope_y)
+      !$omp target enter data map(to: tv, tv%T, tv%S)
       !$omp target enter data map(to: tv%SpV_avg) if (allocated(tv%SpV_avg))
       !$omp target enter data map(to: tv%p_surf) if (associated(tv%p_surf))
       !$omp target enter data map(alloc: N2_u, N2_v)
@@ -828,7 +828,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
                                   CS%slope_x, CS%slope_y, niblock, njblock, nkblock, N2_u=N2_u, &
                                   N2_v=N2_v, halo=1, OBC=OBC, OBC_N2=CS%OBC_friendly)
       call calc_Visbeck_coeffs_old(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, US, CS, OBC)
-      !$omp target exit data map(release: tv%T, tv%S, tv, CS%slope_x, CS%slope_y)
+      !$omp target exit data map(release: tv%T, tv%S, tv)
       !$omp target exit data map(release: tv%p_surf) if (associated(tv%p_surf))
       !$omp target exit data map(delete: N2_u, N2_v )
     else
@@ -970,7 +970,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   ! calculate the first-mode gravity wave speed and then blend the equatorial
   ! and midlatitude deformation radii, using calc_resoln_function as a template.
 
-  ! UMW NOTE: H_u should be local, but this causes segfaults with nvfortran 26.3
+  ! H_u should be local, but this causes segfaults with nvfortran 26.3
   do concurrent(j=js:je) !local( H_u )
     do concurrent(I=is-1:ie)
       CS%SN_u(I,j) = 0. ; H_u(I) = 0. ; S2_u(I,j) = 0.
@@ -1014,7 +1014,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
     enddo
   enddo
 
-  ! UMW NOTE: H_v should be local, but this causes segfaults with nvfortran 26.3
+  ! H_v should be local, but this causes segfaults with nvfortran 26.3
   do concurrent(J=js-1:je) !local( H_v )
     do concurrent(i=is:ie)
       CS%SN_v(i,J) = 0. ; H_v(i) = 0. ; S2_v(i,J) = 0.
@@ -2147,6 +2147,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   if (CS%use_stored_slopes .or. (CS%interpolated_sqg_struct .and. (CS%sqg_expo>0.0))) then
     allocate(CS%slope_x(IsdB:IedB,jsd:jed,GV%ke+1), source=0.0)
     allocate(CS%slope_y(isd:ied,JsdB:JedB,GV%ke+1), source=0.0)
+    !$omp target enter data map(alloc: CS%slope_x, CS%slope_y)
   endif
 
   if (CS%calculate_Eady_growth_rate) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1245,9 +1245,9 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: e  !< Interface position [Z ~> m]
   ! type(thermo_var_ptrs),                     intent(in)    :: tv !< Thermodynamic variables
   ! Local variables
-  real :: E_x(SZIB_(G),SZJ_(G), merge(GV%ke, CS%nkblock, CS%nkblock==0) )  ! X-slope of interface at u 
+  real :: E_x(SZIB_(G),SZJ_(G), merge(GV%ke, CS%nkblock, CS%nkblock==0) )  ! X-slope of interface at u
                                                                            ! points [Z L-1 ~> nondim] (for diagnostics)
-  real :: E_y(SZI_(G),SZJB_(G), merge(GV%ke, CS%nkblock, CS%nkblock==0) )  ! Y-slope of interface at v 
+  real :: E_y(SZI_(G),SZJB_(G), merge(GV%ke, CS%nkblock, CS%nkblock==0) )  ! Y-slope of interface at v
                                                                            ! points [Z L-1 ~> nondim] (for diagnostics)
   real :: dz_tot(SZI_(G),SZJ_(G)) ! The total thickness of the water columns [Z ~> m]
   ! real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! The vertical distance across each layer [Z ~> m]
@@ -1327,7 +1327,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
       ! Mask slopes where interface intersects topography
       if (min(h(i,j,k),h(i,j+1,k)) < H_cutoff) E_y(i,J,kk) = 0.
     enddo
-  
+
     ! Calculate N*S*h from this layer and add to the sum
     do concurrent( kk=1:kmax, j=js:je, i=is-1:ie ) DO_LOCALITY(local( S2, Hdn, Hup, H_geom, k ))
       k = kk + k_start - 1
@@ -1373,7 +1373,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
                                                 max(dz_tot(i,j), dz_tot(i+1,j), GV%dz_subroundoff) )
       enddo
     else
-      !$omp loop
+      !$omp loop private( h1, h2 )
       do I=is-1,ie
         h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
         h2 = max(G%meanSL(i+1,j) + G%bathyT(i+1,j), 0.0)
@@ -1404,7 +1404,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
                                                 max(dz_tot(i,j), dz_tot(i,j+1), GV%dz_subroundoff) )
       enddo
     else
-      !$omp loop
+      !$omp loop private( h1, h2 )
       do i=is,ie
         ! There is a primordial horizontal indexing bug on the following line from the previous
         ! versions of the code.  This comment should be deleted by the end of 2024.
@@ -1861,7 +1861,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "artifacts from altering the equivalent barotropic mode structure.  "//&
                  "This monotonzization is disabled if this parameter is negative.", &
                  units="m", default=-1.0, scale=GV%m_to_H)
-    allocate(CS%ebt_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
   endif
 
   use_SQG = CS%BS_use_sqg_struct .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct .or. &
@@ -1889,22 +1888,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   if (CS%kdgl90_use_ebt_struct .and. CS%kdgl90_use_sqg_struct) call MOM_error(FATAL, &
     "calc_resoln_function: Only one of KD_GL90_USE_EBT_STRUCT and KD_GL90_USE_SQG_STRUCT can be true")
 
-  if (CS%BS_EBT_power>0. .or. CS%BS_use_sqg_struct) then
-    allocate(CS%BS_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
-  endif
-
-  if (CS%khth_use_ebt_struct .or. CS%khth_use_sqg_struct) then
-    allocate(CS%khth_struct(isd:ied, jsd:jed, gv%ke), source=0.0)
-  endif
-
-  if (CS%khtr_use_ebt_struct .or. CS%khtr_use_sqg_struct) then
-    allocate(CS%khtr_struct(isd:ied, jsd:jed, gv%ke), source=0.0)
-  endif
-
-  if (CS%kdgl90_use_ebt_struct .or. CS%kdgl90_use_sqg_struct) then
-    allocate(CS%kdgl90_struct(isd:ied, jsd:jed, gv%ke), source=0.0)
-  endif
-
   if (CS%use_stored_slopes) then
     if (KhTr_Slope_Cff>0. .or. KhTh_Slope_Cff>0.) then
       call get_param(param_file, mdl, "VISBECK_MAX_SLOPE", CS%Visbeck_S_max, &
@@ -1920,8 +1903,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   if (CS%use_stored_slopes .or. (CS%interpolated_sqg_struct .and. (CS%sqg_expo>0.0))) then
     ! CS%calculate_Eady_growth_rate=.true.
     in_use = .true.
-    allocate(CS%slope_x(IsdB:IedB,jsd:jed,GV%ke+1), source=0.0)
-    allocate(CS%slope_y(isd:ied,JsdB:JedB,GV%ke+1), source=0.0)
     call get_param(param_file, mdl, "KD_SMOOTH", CS%kappa_smooth, &
                  "A diapycnal diffusivity that is used to interpolate "//&
                  "more sensible values of T & S into thin layers.", &
@@ -1930,12 +1911,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
 
   if (CS%calculate_Eady_growth_rate) then
     in_use = .true.
-    allocate(CS%SN_u(IsdB:IedB,jsd:jed), source=0.0)
-    allocate(CS%SN_v(isd:ied,JsdB:JedB), source=0.0)
-    CS%id_SN_u = register_diag_field('ocean_model', 'SN_u', diag%axesCu1, Time, &
-       'Inverse eddy time-scale, S*N, at u-points', 's-1', conversion=US%s_to_T)
-    CS%id_SN_v = register_diag_field('ocean_model', 'SN_v', diag%axesCv1, Time, &
-       'Inverse eddy time-scale, S*N, at v-points', 's-1', conversion=US%s_to_T)
     call get_param(param_file, mdl, "USE_SIMPLER_EADY_GROWTH_RATE", CS%use_simpler_Eady_growth_rate, &
                    "If true, use a simpler method to calculate the Eady growth rate "//&
                    "that avoids division by layer thickness. Recommended.", default=.false.)
@@ -1977,51 +1952,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "The fixed length scale in the Visbeck formula, or if negative a nondimensional "//&
                  "scaling factor relating this length scale squared to the cell areas.", &
                  units="m or nondim", default=0.0, scale=US%m_to_L)
-    allocate(CS%L2u(IsdB:IedB,jsd:jed), source=0.0)
-    allocate(CS%L2v(isd:ied,JsdB:JedB), source=0.0)
-    if (CS%Visbeck_L_scale<0) then
-      ! Undo the rescaling of CS%Visbeck_L_scale.
-      do j=js,je ; do I=is-1,Ieq
-        CS%L2u(I,j) = (US%L_to_m*CS%Visbeck_L_scale)**2 * G%areaCu(I,j)
-      enddo ; enddo
-      do J=js-1,Jeq ; do i=is,ie
-        CS%L2v(i,J) = (US%L_to_m*CS%Visbeck_L_scale)**2 * G%areaCv(i,J)
-      enddo ; enddo
-    else
-      CS%L2u(:,:) = CS%Visbeck_L_scale**2
-      CS%L2v(:,:) = CS%Visbeck_L_scale**2
-    endif
-
-    CS%id_L2u = register_diag_field('ocean_model', 'L2u', diag%axesCu1, Time, &
-       'Length scale squared for mixing coefficient, at u-points', &
-       'm2', conversion=US%L_to_m**2)
-    CS%id_L2v = register_diag_field('ocean_model', 'L2v', diag%axesCv1, Time, &
-       'Length scale squared for mixing coefficient, at v-points', &
-       'm2', conversion=US%L_to_m**2)
-  endif
-
-  CS%id_sqg_struct = register_diag_field('ocean_model', 'sqg_struct', diag%axesTl, Time, &
-            'Vertical structure of SQG mode', 'nondim')
-  if (CS%BS_use_sqg_struct .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
-      .or. CS%kdgl90_use_sqg_struct .or. CS%id_sqg_struct>0) then
-    allocate(CS%sqg_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
-  endif
-
-  if (CS%BS_EBT_power>0. .or. CS%BS_use_sqg_struct) then
-    CS%id_BS_struct = register_diag_field('ocean_model', 'BS_struct', diag%axesTl, Time, &
-              'Vertical structure of backscatter', 'nondim')
-  endif
-  if (CS%khth_use_ebt_struct .or. CS%khth_use_sqg_struct) then
-    CS%id_khth_struct = register_diag_field('ocean_model', 'khth_struct', diag%axesTl, Time, &
-            'Vertical structure of thickness diffusivity', 'nondim')
-  endif
-  if (CS%khtr_use_ebt_struct .or. CS%khtr_use_sqg_struct) then
-    CS%id_khtr_struct = register_diag_field('ocean_model', 'khtr_struct', diag%axesTl, Time, &
-            'Vertical structure of tracer diffusivity', 'nondim')
-  endif
-  if (CS%kdgl90_use_ebt_struct .or. CS%kdgl90_use_sqg_struct) then
-    CS%id_kdgl90_struct = register_diag_field('ocean_model', 'kdgl90_struct', diag%axesTl, Time, &
-            'Vertical structure of GL90 diffusivity', 'nondim')
   endif
 
   if ((CS%calculate_Eady_growth_rate .and. CS%use_stored_slopes) ) then
@@ -2061,20 +1991,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   if (CS%Resoln_scaling_used) then
     CS%calculate_Rd_dx = .true.
     CS%calculate_res_fns = .true.
-    allocate(CS%Res_fn_h(isd:ied,jsd:jed), source=0.0)
-    allocate(CS%Res_fn_q(IsdB:IedB,JsdB:JedB), source=0.0)
-    allocate(CS%Res_fn_u(IsdB:IedB,jsd:jed), source=0.0)
-    allocate(CS%Res_fn_v(isd:ied,JsdB:JedB), source=0.0)
-    allocate(CS%beta_dx2_q(IsdB:IedB,JsdB:JedB), source=0.0)
-    allocate(CS%beta_dx2_u(IsdB:IedB,jsd:jed), source=0.0)
-    allocate(CS%beta_dx2_v(isd:ied,JsdB:JedB), source=0.0)
-    allocate(CS%f2_dx2_q(IsdB:IedB,JsdB:JedB), source=0.0)
-    allocate(CS%f2_dx2_u(IsdB:IedB,jsd:jed), source=0.0)
-    allocate(CS%f2_dx2_v(isd:ied,JsdB:JedB), source=0.0)
-
-    CS%id_Res_fn = register_diag_field('ocean_model', 'Res_fn', diag%axesT1, Time, &
-       'Resolution function for scaling diffusivities', 'nondim')
-
     call get_param(param_file, mdl, "KH_RES_SCALE_COEF", CS%Res_coef_khth, &
                  "A coefficient that determines how KhTh is scaled away if "//&
                  "RESOLN_SCALED_... is true, as "//&
@@ -2121,46 +2037,10 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     if (Gill_equatorial_Ld) then
       oneOrTwo = 2.0
     endif
-
-
-    do J=js-1,Jeq ; do I=is-1,Ieq
-      CS%f2_dx2_q(I,J) = ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * &
-                         max(G%Coriolis2Bu(I,J), absurdly_small_freq**2)
-      CS%beta_dx2_q(I,J) = oneOrTwo * ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * (sqrt(0.5 * &
-          ( ((((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2) + &
-             (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
-            ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
-             (((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2)) ) ))
-    enddo ; enddo
-
-    do j=js,je ; do I=is-1,Ieq
-      CS%f2_dx2_u(I,j) = ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * &
-          max(0.5* (G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I,J-1)), absurdly_small_freq**2)
-      CS%beta_dx2_u(I,j) = oneOrTwo * ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * (sqrt( &
-          ((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2 + &
-          0.25*( ((((G%CoriolisBu(I,J-1)-G%CoriolisBu(I-1,J-1)) * G%IdxCv(i,J-1))**2) + &
-                  (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
-                 ((((G%CoriolisBu(I+1,J-1)-G%CoriolisBu(I,J-1)) * G%IdxCv(i+1,J-1))**2) + &
-                  (((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2)) ) ))
-    enddo ; enddo
-
-    do J=js-1,Jeq ; do i=is,ie
-      CS%f2_dx2_v(i,J) = ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * &
-          max(0.5*(G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I-1,J)), absurdly_small_freq**2)
-      CS%beta_dx2_v(i,J) = oneOrTwo * ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * (sqrt( &
-          ((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2 + &
-          0.25*( ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
-                  (((G%CoriolisBu(I-1,J+1)-G%CoriolisBu(I-1,J)) * G%IdyCu(I-1,j+1))**2)) + &
-                 ((((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2) + &
-                  (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
-    enddo ; enddo
-
   endif
 
   if (CS%Depth_scaled_KhTh) then
     CS%calculate_depth_fns = .true.
-    allocate(CS%Depth_fn_u(IsdB:IedB,jsd:jed), source=0.0)
-    allocate(CS%Depth_fn_v(isd:ied,JsdB:JedB), source=0.0)
     call get_param(param_file, mdl, "DEPTH_SCALED_KHTH_H0", CS%depth_scaled_khth_h0, &
                    "The depth above which KHTH is scaled away.", &
                    units="m", scale=US%m_to_Z, default=1000.)
@@ -2174,28 +2054,10 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
        'Ratio between deformation radius and grid spacing', 'm m-1')
   CS%calculate_Rd_dx = CS%calculate_Rd_dx .or. (CS%id_Rd_dx>0)
 
-  if (CS%calculate_Rd_dx) then
-    CS%calculate_cg1 = .true. ! We will need %cg1
-    allocate(CS%Rd_dx_h(isd:ied,jsd:jed), source=0.0)
-    allocate(CS%beta_dx2_h(isd:ied,jsd:jed), source=0.0)
-    allocate(CS%f2_dx2_h(isd:ied,jsd:jed), source=0.0)
-
-    do j=js-1,je+1 ; do i=is-1,ie+1
-      CS%f2_dx2_h(i,j) = ((G%dxT(i,j)**2) + (G%dyT(i,j)**2)) * &
-          max(0.25 * ((G%Coriolis2Bu(I,J) + G%Coriolis2Bu(I-1,J-1)) + &
-                      (G%Coriolis2Bu(I-1,J) + G%Coriolis2Bu(I,J-1))), &
-              absurdly_small_freq**2)
-      CS%beta_dx2_h(i,j) = oneOrTwo * ((G%dxT(i,j)**2) + (G%dyT(i,j)**2)) * (sqrt(0.5 * &
-          ( ((((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2) + &
-             (((G%CoriolisBu(I,J-1)-G%CoriolisBu(I-1,J-1)) * G%IdxCv(i,J-1))**2)) + &
-            ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
-             (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
-    enddo ; enddo
-  endif
+  if (CS%calculate_Rd_dx) CS%calculate_cg1 = .true. ! We will need %cg1
 
   if (CS%calculate_cg1) then
     in_use = .true.
-    allocate(CS%cg1(isd:ied,jsd:jed), source=0.0)
     call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
                  default=99991231)
@@ -2243,6 +2105,184 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                "If true, include the beta term in the Leith nonlinear eddy viscosity.", &
                default=.true.)
 
+    if (.not. CS%use_stored_slopes) call MOM_error(FATAL, &
+           "MOM_lateral_mixing_coeffs.F90, VarMix_init: "//&
+           "USE_STORED_SLOPES must be True when using QG Leith.")
+  endif
+
+  ! Re-enable variable mixing if one of the schemes was enabled
+  CS%use_variable_mixing = in_use .or. CS%use_variable_mixing
+
+  !$omp target update to( CS )
+
+  if (CS%Resoln_use_ebt .or. CS%khth_use_ebt_struct .or. CS%kdgl90_use_ebt_struct &
+      .or. CS%BS_EBT_power>0. .or. CS%khtr_use_ebt_struct) then
+    allocate(CS%ebt_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
+  endif
+
+  if (CS%BS_EBT_power>0. .or. CS%BS_use_sqg_struct) then
+    allocate(CS%BS_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
+    CS%id_BS_struct = register_diag_field('ocean_model', 'BS_struct', diag%axesTl, Time, &
+              'Vertical structure of backscatter', 'nondim')
+  endif
+
+  if (CS%khth_use_ebt_struct .or. CS%khth_use_sqg_struct) then
+    allocate(CS%khth_struct(isd:ied, jsd:jed, gv%ke), source=0.0)
+    CS%id_khth_struct = register_diag_field('ocean_model', 'khth_struct', diag%axesTl, Time, &
+            'Vertical structure of thickness diffusivity', 'nondim')
+  endif
+
+  if (CS%khtr_use_ebt_struct .or. CS%khtr_use_sqg_struct) then
+    allocate(CS%khtr_struct(isd:ied, jsd:jed, gv%ke), source=0.0)
+    CS%id_khtr_struct = register_diag_field('ocean_model', 'khtr_struct', diag%axesTl, Time, &
+            'Vertical structure of tracer diffusivity', 'nondim')
+  endif
+
+  if (CS%kdgl90_use_ebt_struct .or. CS%kdgl90_use_sqg_struct) then
+    allocate(CS%kdgl90_struct(isd:ied, jsd:jed, gv%ke), source=0.0)
+    CS%id_kdgl90_struct = register_diag_field('ocean_model', 'kdgl90_struct', diag%axesTl, Time, &
+            'Vertical structure of GL90 diffusivity', 'nondim')
+  endif
+
+  if (CS%use_stored_slopes .or. (CS%interpolated_sqg_struct .and. (CS%sqg_expo>0.0))) then
+    allocate(CS%slope_x(IsdB:IedB,jsd:jed,GV%ke+1), source=0.0)
+    allocate(CS%slope_y(isd:ied,JsdB:JedB,GV%ke+1), source=0.0)
+  endif
+
+  if (CS%calculate_Eady_growth_rate) then
+    allocate(CS%SN_u(IsdB:IedB,jsd:jed), source=0.0)
+    allocate(CS%SN_v(isd:ied,JsdB:JedB), source=0.0)
+    CS%id_SN_u = register_diag_field('ocean_model', 'SN_u', diag%axesCu1, Time, &
+       'Inverse eddy time-scale, S*N, at u-points', 's-1', conversion=US%s_to_T)
+    CS%id_SN_v = register_diag_field('ocean_model', 'SN_v', diag%axesCv1, Time, &
+       'Inverse eddy time-scale, S*N, at v-points', 's-1', conversion=US%s_to_T)
+    !$omp target enter data map(alloc: CS%SN_u, CS%SN_v)
+  endif
+
+  CS%id_sqg_struct = register_diag_field('ocean_model', 'sqg_struct', diag%axesTl, Time, &
+            'Vertical structure of SQG mode', 'nondim')
+  if (CS%BS_use_sqg_struct .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
+      .or. CS%kdgl90_use_sqg_struct .or. CS%id_sqg_struct>0) then
+    allocate(CS%sqg_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
+  endif
+
+  if (KhTr_Slope_Cff>0. .or. KhTh_Slope_Cff>0.) then
+    allocate(CS%L2u(IsdB:IedB,jsd:jed), source=0.0)
+    allocate(CS%L2v(isd:ied,JsdB:JedB), source=0.0)
+    ! These are used in hor_diff and thickness diffuse. Allocate once at initialization
+    !$omp target enter data map(alloc: CS%L2u, CS%L2v)
+
+    if (CS%Visbeck_L_scale<0) then
+      ! Undo the rescaling of CS%Visbeck_L_scale. This do-concurrent kernel fills CS%L2u/L2v
+      ! directly on the device, so no host->device update is needed (or wanted -- the host
+      ! copy is never touched here and pushing it would overwrite the values just computed).
+      do concurrent( j=js:je, I=is-1:Ieq)
+        CS%L2u(I,j) = (US%L_to_m*CS%Visbeck_L_scale)**2 * G%areaCu(I,j)
+      enddo
+      do concurrent( J=js-1:Jeq, i=is:ie)
+        CS%L2v(i,J) = (US%L_to_m*CS%Visbeck_L_scale)**2 * G%areaCv(i,J)
+      enddo
+    else
+      CS%L2u(:,:) = CS%Visbeck_L_scale**2
+      CS%L2v(:,:) = CS%Visbeck_L_scale**2
+      !$omp target update to( CS%L2u, CS%L2v)
+    endif
+
+    CS%id_L2u = register_diag_field('ocean_model', 'L2u', diag%axesCu1, Time, &
+       'Length scale squared for mixing coefficient, at u-points', &
+       'm2', conversion=US%L_to_m**2)
+    CS%id_L2v = register_diag_field('ocean_model', 'L2v', diag%axesCv1, Time, &
+       'Length scale squared for mixing coefficient, at v-points', &
+       'm2', conversion=US%L_to_m**2)
+  endif
+
+  if (CS%Resoln_scaling_used) then
+    allocate(CS%Res_fn_h(isd:ied,jsd:jed), source=0.0)
+    allocate(CS%Res_fn_q(IsdB:IedB,JsdB:JedB), source=0.0)
+    allocate(CS%Res_fn_u(IsdB:IedB,jsd:jed), source=0.0)
+    allocate(CS%Res_fn_v(isd:ied,JsdB:JedB), source=0.0)
+    allocate(CS%beta_dx2_q(IsdB:IedB,JsdB:JedB), source=0.0)
+    allocate(CS%beta_dx2_u(IsdB:IedB,jsd:jed), source=0.0)
+    allocate(CS%beta_dx2_v(isd:ied,JsdB:JedB), source=0.0)
+    allocate(CS%f2_dx2_q(IsdB:IedB,JsdB:JedB), source=0.0)
+    allocate(CS%f2_dx2_u(IsdB:IedB,jsd:jed), source=0.0)
+    allocate(CS%f2_dx2_v(isd:ied,JsdB:JedB), source=0.0)
+
+    !$omp target enter data map(alloc: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v)
+    !$omp target enter data map(alloc: CS%f2_dx2_q, CS%beta_dx2_q, &
+    !$omp&                             CS%f2_dx2_u, CS%beta_dx2_u, &
+    !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
+
+    CS%id_Res_fn = register_diag_field('ocean_model', 'Res_fn', diag%axesT1, Time, &
+       'Resolution function for scaling diffusivities', 'nondim')
+
+    do concurrent( J=js-1:Jeq, I=is-1:Ieq)
+      CS%f2_dx2_q(I,J) = ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * &
+                         max(G%Coriolis2Bu(I,J), absurdly_small_freq**2)
+      CS%beta_dx2_q(I,J) = oneOrTwo * ((G%dxBu(I,J)**2) + (G%dyBu(I,J)**2)) * (sqrt(0.5 * &
+          ( ((((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2) + &
+             (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
+            ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
+             (((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2)) ) ))
+    enddo
+
+    do concurrent( j=js:je, I=is-1:Ieq)
+      CS%f2_dx2_u(I,j) = ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * &
+          max(0.5* (G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I,J-1)), absurdly_small_freq**2)
+      CS%beta_dx2_u(I,j) = oneOrTwo * ((G%dxCu(I,j)**2) + (G%dyCu(I,j)**2)) * (sqrt( &
+          ((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2 + &
+          0.25*( ((((G%CoriolisBu(I,J-1)-G%CoriolisBu(I-1,J-1)) * G%IdxCv(i,J-1))**2) + &
+                  (((G%CoriolisBu(I+1,J)-G%CoriolisBu(I,J)) * G%IdxCv(i+1,J))**2)) + &
+                 ((((G%CoriolisBu(I+1,J-1)-G%CoriolisBu(I,J-1)) * G%IdxCv(i+1,J-1))**2) + &
+                  (((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2)) ) ))
+    enddo
+
+    do concurrent( J=js-1:Jeq, i=is:ie)
+      CS%f2_dx2_v(i,J) = ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * &
+          max(0.5*(G%Coriolis2Bu(I,J)+G%Coriolis2Bu(I-1,J)), absurdly_small_freq**2)
+      CS%beta_dx2_v(i,J) = oneOrTwo * ((G%dxCv(i,J)**2) + (G%dyCv(i,J)**2)) * (sqrt( &
+          ((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2 + &
+          0.25*( ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
+                  (((G%CoriolisBu(I-1,J+1)-G%CoriolisBu(I-1,J)) * G%IdyCu(I-1,j+1))**2)) + &
+                 ((((G%CoriolisBu(I,J+1)-G%CoriolisBu(I,J)) * G%IdyCu(I,j+1))**2) + &
+                  (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
+    enddo
+
+  endif
+
+  if (CS%Depth_scaled_KhTh) then
+    allocate(CS%Depth_fn_u(IsdB:IedB,jsd:jed), source=0.0)
+    allocate(CS%Depth_fn_v(isd:ied,JsdB:JedB), source=0.0)
+    !$omp target enter data map(alloc: CS%Depth_fn_u, CS%Depth_fn_v)
+  endif
+
+  if (CS%calculate_Rd_dx) then
+    allocate(CS%Rd_dx_h(isd:ied,jsd:jed), source=0.0)
+    allocate(CS%beta_dx2_h(isd:ied,jsd:jed), source=0.0)
+    allocate(CS%f2_dx2_h(isd:ied,jsd:jed), source=0.0)
+
+    !$omp target enter data map(alloc: CS%Rd_dx_h)
+    !$omp target enter data map(alloc: CS%f2_dx2_h, CS%beta_dx2_h)
+
+    do concurrent( j=js-1:je+1, i=is-1:ie+1)
+      CS%f2_dx2_h(i,j) = ((G%dxT(i,j)**2) + (G%dyT(i,j)**2)) * &
+          max(0.25 * ((G%Coriolis2Bu(I,J) + G%Coriolis2Bu(I-1,J-1)) + &
+                      (G%Coriolis2Bu(I-1,J) + G%Coriolis2Bu(I,J-1))), &
+              absurdly_small_freq**2)
+      CS%beta_dx2_h(i,j) = oneOrTwo * ((G%dxT(i,j)**2) + (G%dyT(i,j)**2)) * (sqrt(0.5 * &
+          ( ((((G%CoriolisBu(I,J)-G%CoriolisBu(I-1,J)) * G%IdxCv(i,J))**2) + &
+             (((G%CoriolisBu(I,J-1)-G%CoriolisBu(I-1,J-1)) * G%IdxCv(i,J-1))**2)) + &
+            ((((G%CoriolisBu(I,J)-G%CoriolisBu(I,J-1)) * G%IdyCu(I,j))**2) + &
+             (((G%CoriolisBu(I-1,J)-G%CoriolisBu(I-1,J-1)) * G%IdyCu(I-1,j))**2)) ) ))
+    enddo
+  endif
+
+  if (CS%calculate_cg1) then
+    allocate(CS%cg1(isd:ied,jsd:jed), source=0.0)
+    !$omp target enter data map(alloc: CS%cg1)
+  endif
+
+  if (CS%Use_QG_Leith_GM) then
     allocate(CS%Laplac3_const_u(IsdB:IedB,jsd:jed), source=0.0)
     allocate(CS%Laplac3_const_v(isd:ied,JsdB:JedB), source=0.0)
     allocate(CS%KH_u_QG(IsdB:IedB,jsd:jed,GV%ke), source=0.0)
@@ -2266,33 +2306,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
       grid_sp_v3 = grid_sp_v2*sqrt(grid_sp_v2)
       CS%Laplac3_const_v(i,J) = Leith_Lap_const * grid_sp_v3
     enddo ; enddo
-
-    if (.not. CS%use_stored_slopes) call MOM_error(FATAL, &
-           "MOM_lateral_mixing_coeffs.F90, VarMix_init: "//&
-           "USE_STORED_SLOPES must be True when using QG Leith.")
   endif
-
-  ! Re-enable variable mixing if one of the schemes was enabled
-  CS%use_variable_mixing = in_use .or. CS%use_variable_mixing
-
-  ! Map CS to device at initialization.
-  !$omp target enter data map(to: CS)
-
-  ! Zero intialized arrays that will be filled in later
-  !$omp target enter data map(alloc: CS%cg1)
-  !$omp target enter data map(alloc: CS%Rd_dx_h)
-  !$omp target enter data map(alloc: CS%Depth_fn_u, CS%Depth_fn_v)
-  !$omp target enter data map(alloc: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v)
-  !$omp target enter data map(alloc: CS%SN_u, CS%SN_v)
-
-  ! Arrays that will be filled in during initialization
-  !$omp target enter data map(to: CS%f2_dx2_h, CS%beta_dx2_h, &
-  !$omp&                          CS%f2_dx2_q, CS%beta_dx2_q, &
-  !$omp&                          CS%f2_dx2_u, CS%beta_dx2_u, &
-  !$omp&                          CS%f2_dx2_v, CS%beta_dx2_v)
-
-  ! These are used in hor_diff and thickness diffuse. Allocate once at initialization
-  !$omp target enter data map(to: CS%L2u, CS%L2v)
 
 end subroutine VarMix_init
 
@@ -2300,23 +2314,21 @@ end subroutine VarMix_init
 subroutine VarMix_end(CS)
   type(VarMix_CS), intent(inout) :: CS
 
-  ! Remove component arrays from device before host deallocation
-  !$omp target exit data map(delete: CS%cg1)
-  !$omp target exit data map(delete: CS%Rd_dx_h)
-  !$omp target exit data map(delete: CS%Depth_fn_u, CS%Depth_fn_v)
-  !$omp target exit data map(delete: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v)
-  !$omp target exit data map(delete: CS%SN_u, CS%SN_v)
+  !$omp target exit data map(delete: CS%cg1) if (allocated(CS%cg1))
+  !$omp target exit data map(delete: CS%Rd_dx_h) if (allocated(CS%Rd_dx_h))
+  !$omp target exit data map(delete: CS%Depth_fn_u, CS%Depth_fn_v) if (allocated(CS%Depth_fn_u))
+  !$omp target exit data map(delete: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v) &
+  !$omp&   if (allocated(CS%Res_fn_h))
+  !$omp target exit data map(delete: CS%SN_u, CS%SN_v) if (allocated(CS%SN_u))
 
-  !$omp target exit data map(delete: CS%f2_dx2_h, CS%beta_dx2_h, &
-  !$omp&                             CS%f2_dx2_q, CS%beta_dx2_q, &
+  !$omp target exit data map(delete: CS%f2_dx2_h, CS%beta_dx2_h) if (allocated(CS%f2_dx2_h))
+  !$omp target exit data map(delete: CS%f2_dx2_q, CS%beta_dx2_q, &
   !$omp&                             CS%f2_dx2_u, CS%beta_dx2_u, &
-  !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
+  !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v) &
+  !$omp&   if (allocated(CS%f2_dx2_q))
 
   ! These are used in MOM_tracer_hor_diff and thickness diffuse.
-  !$omp target exit data map(delete: CS%L2u, CS%L2v)
-
-  ! Delete control structure from device
-  !$omp target exit data map(delete: CS)
+  !$omp target exit data map(delete: CS%L2u, CS%L2v) if (allocated(CS%L2u))
 
   if (allocated(CS%ebt_struct))  deallocate(CS%ebt_struct)
   if (allocated(CS%sqg_struct))  deallocate(CS%sqg_struct)

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1245,8 +1245,10 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: e  !< Interface position [Z ~> m]
   ! type(thermo_var_ptrs),                     intent(in)    :: tv !< Thermodynamic variables
   ! Local variables
-  real :: E_x(SZIB_(G),SZJ_(G))  ! X-slope of interface at u points [Z L-1 ~> nondim] (for diagnostics)
-  real :: E_y(SZI_(G),SZJB_(G))  ! Y-slope of interface at v points [Z L-1 ~> nondim] (for diagnostics)
+  real :: E_x(SZIB_(G),SZJ_(G), merge(GV%ke, CS%nkblock, CS%nkblock==0) )  ! X-slope of interface at u 
+                                                                           ! points [Z L-1 ~> nondim] (for diagnostics)
+  real :: E_y(SZI_(G),SZJB_(G), merge(GV%ke, CS%nkblock, CS%nkblock==0) )  ! Y-slope of interface at v 
+                                                                           ! points [Z L-1 ~> nondim] (for diagnostics)
   real :: dz_tot(SZI_(G),SZJ_(G)) ! The total thickness of the water columns [Z ~> m]
   ! real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! The vertical distance across each layer [Z ~> m]
   real :: H_cutoff      ! Local estimate of a minimum thickness for masking [H ~> m or kg m-2]
@@ -1266,6 +1268,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
                         ! bathymetric depth for certain calculations.
   integer :: is, ie, js, je, nz
   integer :: i, j, k
+  integer :: kk, k_start, k_end, kmax, nkblock
 
   if (.not. CS%initialized) call MOM_error(FATAL, "calc_slope_functions_using_just_e: "// &
          "Module must be initialized before it is used.")
@@ -1277,8 +1280,9 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
          "%SN_v is not associated with use_variable_mixing.")
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+  nkblock = merge(GV%ke, CS%nkblock, CS%nkblock==0)
 
-  !$omp target enter data map(alloc: E_x, E_y, S2N2_u_local, S2N2_v_local)
+  !$omp target enter data map(alloc: E_x, E_y, S2N2_u_local, S2N2_v_local, dz_tot )
 
   h_neglect = GV%H_subroundoff
   H_cutoff = real(2*nz) * (GV%Angstrom_H + h_neglect)
@@ -1305,52 +1309,59 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
   ! calculate the first-mode gravity wave speed and then blend the equatorial
   ! and midlatitude deformation radii, using calc_resoln_function as a template.
 
-  do k=nz,CS%VarMix_Ktop,-1
 
-    ! Calculate the interface slopes E_x and E_y and u- and v- points respectively
-    do concurrent( j=js-1:je+1, i=is-1:ie )
-      E_x(I,j) = (e(i+1,j,K)-e(i,j,K))*G%IdxCu(I,j)
-      ! Mask slopes where interface intersects topography
-      if (min(h(i,j,k),h(i+1,j,k)) < H_cutoff) E_x(I,j) = 0.
-    enddo
-    do concurrent( J=js-1:je, i=is-1:ie+1 )
-      E_y(i,J) = (e(i,j+1,K)-e(i,j,K))*G%IdyCv(i,J)
-      ! Mask slopes where interface intersects topography
-      if (min(h(i,j,k),h(i,j+1,k)) < H_cutoff) E_y(i,J) = 0.
-    enddo
+  ! Calculate the interface slopes E_x and E_y and u- and v- points respectively
+  do k_start=CS%VarMix_Ktop,nz,nkblock
+    k_end = min(k_start+nkblock-1, nz)
+    kmax = k_end - k_start + 1
 
+    do concurrent( kk=1:kmax, j=js-1:je+1, i=is-1:ie ) DO_LOCALITY(local( k ))
+      k = k_start + kk - 1
+      E_x(I,j,kk) = (e(i+1,j,K)-e(i,j,K))*G%IdxCu(I,j)
+      ! Mask slopes where interface intersects topography
+      if (min(h(i,j,k),h(i+1,j,k)) < H_cutoff) E_x(I,j,kk) = 0.
+    enddo
+    do concurrent( kk=1:kmax, J=js-1:je, i=is-1:ie+1 ) DO_LOCALITY(local( k ))
+      k = kk + k_start - 1
+      E_y(i,J,kk) = (e(i,j+1,K)-e(i,j,K))*G%IdyCv(i,J)
+      ! Mask slopes where interface intersects topography
+      if (min(h(i,j,k),h(i,j+1,k)) < H_cutoff) E_y(i,J,kk) = 0.
+    enddo
+  
     ! Calculate N*S*h from this layer and add to the sum
-    do concurrent( j=js:je, i=is-1:ie ) DO_LOCALITY(local( S2, Hdn, Hup, H_geom ))
-      S2 = ( E_x(I,j)**2  + 0.25*( &
-            ((E_y(i,J)**2) + (E_y(i+1,J-1)**2)) + ((E_y(i+1,J)**2) + (E_y(i,J-1)**2)) ) )
+    do concurrent( kk=1:kmax, j=js:je, i=is-1:ie ) DO_LOCALITY(local( S2, Hdn, Hup, H_geom, k ))
+      k = kk + k_start - 1
+      S2 = ( E_x(I,j,kk)**2  + 0.25*( &
+            ((E_y(i,J,kk)**2) + (E_y(i+1,J-1,kk)**2)) + ((E_y(i+1,J,kk)**2) + (E_y(i,J-1,kk)**2)) ) )
       if (min(h(i,j,k-1), h(i+1,j,k-1), h(i,j,k), h(i+1,j,k)) < H_cutoff) S2 = 0.0
-
       Hdn = 2.*h(i,j,k)*h(i,j,k-1) / (h(i,j,k) + h(i,j,k-1) + h_neglect)
       Hup = 2.*h(i+1,j,k)*h(i+1,j,k-1) / (h(i+1,j,k) + h(i+1,j,k-1) + h_neglect)
       H_geom = sqrt(Hdn*Hup)
       ! N2 = GV%g_prime(k) / (GV%H_to_Z * max(Hdn, Hup, CS%h_min_N2))
       S2N2_u_local(I,j,k) = (H_geom * S2) * (GV%g_prime(k) / max(Hdn, Hup, CS%h_min_N2) )
     enddo
-    do concurrent( J=js-1:je, i=is:ie ) DO_LOCALITY(local( S2, Hdn, Hup, H_geom ))
-      S2 = ( E_y(i,J)**2  + 0.25*( &
-            ((E_x(I,j)**2) + (E_x(I-1,j+1)**2)) + ((E_x(I,j+1)**2) + (E_x(I-1,j)**2)) ) )
+    do concurrent( kk=1:kmax, J=js-1:je, i=is:ie ) DO_LOCALITY(local( S2, Hdn, Hup, H_geom, k ))
+      k = kk + k_start - 1
+      S2 = ( E_y(i,J,kk)**2  + 0.25*( &
+            ((E_x(I,j,kk)**2) + (E_x(I-1,j+1,kk)**2)) + ((E_x(I,j+1,kk)**2) + (E_x(I-1,j,kk)**2)) ) )
       if (min(h(i,j,k-1), h(i,j+1,k-1), h(i,j,k), h(i,j+1,k)) < H_cutoff) S2 = 0.0
-
       Hdn = 2.*h(i,j,k)*h(i,j,k-1) / (h(i,j,k) + h(i,j,k-1) + h_neglect)
       Hup = 2.*h(i,j+1,k)*h(i,j+1,k-1) / (h(i,j+1,k) + h(i,j+1,k-1) + h_neglect)
       H_geom = sqrt(Hdn*Hup)
       ! N2 = GV%g_prime(k) / (GV%H_to_Z * max(Hdn, Hup, CS%h_min_N2))
       S2N2_v_local(i,J,k) = (H_geom * S2) * (GV%g_prime(k) / (max(Hdn, Hup, CS%h_min_N2)))
     enddo
+  enddo
 
-  enddo ! k
-
+  !$omp target teams loop
   do j=js,je
-    do concurrent( I=is-1:ie )
+    !$omp loop
+    do I=is-1,ie
       CS%SN_u(I,j) = 0.0
     enddo
     do k=nz,CS%VarMix_Ktop,-1
-      do concurrent( I=is-1:ie )
+      !$omp loop
+      do I=is-1,ie
         CS%SN_u(I,j) = CS%SN_u(I,j) + S2N2_u_local(I,j,k)
       enddo
     enddo
@@ -1362,7 +1373,8 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
                                                 max(dz_tot(i,j), dz_tot(i+1,j), GV%dz_subroundoff) )
       enddo
     else
-      do concurrent( I=is-1:ie ) DO_LOCALITY(local(h1, h2))
+      !$omp loop
+      do I=is-1,ie
         h1 = max(G%meanSL(i,j) + G%bathyT(i,j), 0.0)
         h2 = max(G%meanSL(i+1,j) + G%bathyT(i+1,j), 0.0)
         if ( min(h1, h2) > dZ_cutoff ) then
@@ -1374,12 +1386,15 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
   enddo
 
+  !$omp target teams loop
   do J=js-1,je
-    do concurrent( i=is:ie )
+    !$omp loop
+    do i=is,ie
       CS%SN_v(i,J) = 0.0
     enddo
     do k=nz,CS%VarMix_Ktop,-1
-      do concurrent( i=is:ie )
+      !$omp loop
+      do i=is,ie
         CS%SN_v(i,J) = CS%SN_v(i,J) + S2N2_v_local(i,J,k)
       enddo
     enddo
@@ -1389,7 +1404,8 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
                                                 max(dz_tot(i,j), dz_tot(i,j+1), GV%dz_subroundoff) )
       enddo
     else
-      do concurrent( i=is:ie ) DO_LOCALITY(local(h1, h2))
+      !$omp loop
+      do i=is,ie
         ! There is a primordial horizontal indexing bug on the following line from the previous
         ! versions of the code.  This comment should be deleted by the end of 2024.
         ! if ( min(G%bathyT(i,j), G%bathyT(i+1,j)) + G%Z_ref > dZ_cutoff ) then
@@ -1404,7 +1420,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
     endif
   enddo
 
-  !$omp target exit data map(delete: E_x, E_y, S2N2_u_local, S2N2_v_local )
+  !$omp target exit data map(delete: E_x, E_y, S2N2_u_local, S2N2_v_local, dz_tot )
 
 end subroutine calc_slope_functions_using_just_e
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -273,6 +273,8 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
+  !$omp target enter data map(alloc: cg1_q, cg1_u, cg1_v, dx_term)
+
   if (.not. CS%initialized) call MOM_error(FATAL, "calc_resoln_function: "// &
          "Module must be initialized before it is used.")
 
@@ -300,6 +302,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
 
     call create_group_pass(CS%pass_cg1, CS%cg1, G%Domain)
     call do_group_pass(CS%pass_cg1, G%Domain)
+    !$omp target update to(CS%cg1)
   endif
 
   if (CS%BS_use_sqg_struct .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
@@ -354,11 +357,11 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
   if (CS%calculate_rd_dx) then
     if (.not. allocated(CS%Rd_dx_h)) call MOM_error(FATAL, &
       "calc_resoln_function: %Rd_dx_h is not associated with calculate_rd_dx.")
-    !$OMP parallel do default(shared)
-    do j=js-1,je+1 ; do i=is-1,ie+1
+    do concurrent( j=js-1:je+1, i=is-1:ie+1 )
       CS%Rd_dx_h(i,j) = CS%cg1(i,j) / &
             (sqrt(CS%f2_dx2_h(i,j) + CS%cg1(i,j)*CS%beta_dx2_h(i,j)))
-    enddo ; enddo
+    enddo
+    !$omp target update from(CS%Rd_dx_h)
     if (query_averaging_enabled(CS%diag)) then
       if (CS%id_Rd_dx > 0) call post_data(CS%id_Rd_dx, CS%Rd_dx_h, CS%diag)
     endif
@@ -397,10 +400,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
     apply_v_OBC = OBC%v_OBCs_on_PE
   endif
 
-  !$OMP parallel default(shared) private(dx_term,power_2)
-
   if (apply_u_OBC .or. apply_v_OBC) then
-    !$OMP do
     do J=js-1,Jeq ; do I=is-1,Ieq
       if ((OBC%segnum_u(I,j) /= 0) .or. (OBC%segnum_u(I,j+1) /= 0) .or. &
           (OBC%segnum_v(i,J) /= 0) .or. (OBC%segnum_u(i+1,J) /= 0)) then
@@ -415,16 +415,14 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
       endif
     enddo ; enddo
   else
-    !$OMP do
-    do J=js-1,Jeq ; do I=is-1,Ieq
+    do concurrent( J=js-1:Jeq, I=is-1:Ieq )
       cg1_q(I,J) = 0.25 * ((CS%cg1(i,j) + CS%cg1(i+1,j+1)) + (CS%cg1(i+1,j) + CS%cg1(i,j+1)))
-    enddo ; enddo
+    enddo 
   endif
 
   !   Do this calculation on the extent used in MOM_hor_visc.F90, and
   ! MOM_tracer.F90 so that no halo update is needed.
   if (CS%Res_fn_power_visc >= 100) then
-    !$OMP do
     do j=js-1,je+1 ; do i=is-1,ie+1
       dx_term = CS%f2_dx2_h(i,j) + CS%cg1(i,j)*CS%beta_dx2_h(i,j)
       if ((CS%Res_coef_visc * CS%cg1(i,j))**2 > dx_term) then
@@ -433,7 +431,6 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
         CS%Res_fn_h(i,j) = 1.0
       endif
     enddo ; enddo
-    !$OMP do
     do J=js-1,Jeq ; do I=is-1,Ieq
       dx_term = CS%f2_dx2_q(I,J) +  cg1_q(I,J) * CS%beta_dx2_q(I,J)
       if ((CS%Res_coef_visc * cg1_q(I,J))**2 > dx_term) then
@@ -443,39 +440,33 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
       endif
     enddo ; enddo
   elseif (CS%Res_fn_power_visc == 2) then
-    !$OMP do
-    do j=js-1,je+1 ; do i=is-1,ie+1
+    do concurrent( j=js-1:je+1, i=is-1:ie+1 ) local(dx_term)
       dx_term = CS%f2_dx2_h(i,j) + CS%cg1(i,j)*CS%beta_dx2_h(i,j)
       CS%Res_fn_h(i,j) = dx_term / (dx_term + (CS%Res_coef_visc * CS%cg1(i,j))**2)
-    enddo ; enddo
-    !$OMP do
-    do J=js-1,Jeq ; do I=is-1,Ieq
+    enddo
+    do concurrent( J=js-1:Jeq, I=is-1:Ieq ) local(dx_term)
       dx_term = CS%f2_dx2_q(I,J) +  cg1_q(I,J) * CS%beta_dx2_q(I,J)
       CS%Res_fn_q(I,J) = dx_term / (dx_term + (CS%Res_coef_visc * cg1_q(I,J))**2)
-    enddo ; enddo
+    enddo
   elseif (mod(CS%Res_fn_power_visc, 2) == 0) then
     power_2 = CS%Res_fn_power_visc / 2
-    !$OMP do
     do j=js-1,je+1 ; do i=is-1,ie+1
       dx_term = (US%L_T_to_m_s**2*(CS%f2_dx2_h(i,j) + CS%cg1(i,j)*CS%beta_dx2_h(i,j)))**power_2
       CS%Res_fn_h(i,j) = dx_term / &
           (dx_term + (CS%Res_coef_visc * US%L_T_to_m_s*CS%cg1(i,j))**CS%Res_fn_power_visc)
     enddo ; enddo
-    !$OMP do
     do J=js-1,Jeq ; do I=is-1,Ieq
       dx_term = (US%L_T_to_m_s**2*(CS%f2_dx2_q(I,J) + cg1_q(I,J) * CS%beta_dx2_q(I,J)))**power_2
       CS%Res_fn_q(I,J) = dx_term / &
           (dx_term + (CS%Res_coef_visc * US%L_T_to_m_s*cg1_q(I,J))**CS%Res_fn_power_visc)
     enddo ; enddo
   else
-    !$OMP do
     do j=js-1,je+1 ; do i=is-1,ie+1
       dx_term = (US%L_T_to_m_s*sqrt(CS%f2_dx2_h(i,j) + &
                                     CS%cg1(i,j)*CS%beta_dx2_h(i,j)))**CS%Res_fn_power_visc
       CS%Res_fn_h(i,j) = dx_term / &
          (dx_term + (CS%Res_coef_visc * US%L_T_to_m_s*CS%cg1(i,j))**CS%Res_fn_power_visc)
     enddo ; enddo
-    !$OMP do
     do J=js-1,Jeq ; do I=is-1,Ieq
       dx_term = (US%L_T_to_m_s*sqrt(CS%f2_dx2_q(I,J) + &
                                     cg1_q(I,J) * CS%beta_dx2_q(I,J)))**CS%Res_fn_power_visc
@@ -511,35 +502,30 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
 
   else ! .not.CS%interpolate_Res_fn
     if (apply_u_OBC) then
-      !$OMP do
       do j=js,je ; do I=is-1,Ieq
         cg1_u(I,j) = 0.5 * (CS%cg1(i,j) + CS%cg1(i+1,j))
         if (OBC%segnum_u(I,j) > 0) cg1_u(I,j) = CS%cg1(i,j) ! Eastern OBC
         if (OBC%segnum_u(I,j) < 0) cg1_u(I,j) = CS%cg1(i+1,j) ! Western OBC
       enddo ; enddo
     else
-      !$OMP do
-      do j=js,je ; do I=is-1,Ieq
+      do concurrent( j=js:je, I=is-1:Ieq )
         cg1_u(I,j) = 0.5 * (CS%cg1(i,j) + CS%cg1(i+1,j))
-      enddo ; enddo
+      enddo
     endif
 
     if (apply_v_OBC) then
-      !$OMP do
       do J=js-1,Jeq ; do i=is,ie
         cg1_v(i,J) = 0.5 * (CS%cg1(i,j) + CS%cg1(i,j+1))
         if (OBC%segnum_v(i,J) > 0) cg1_v(i,J) = CS%cg1(i,j) ! Northern OBC
         if (OBC%segnum_v(i,J) < 0) cg1_v(i,J) = CS%cg1(i,j+1) ! Southern OBC
       enddo ; enddo
     else
-      !$OMP do
-      do J=js-1,Jeq ; do i=is,ie
+      do concurrent( J=js-1:Jeq, i=is:ie )
         cg1_v(i,J) = 0.5 * (CS%cg1(i,j) + CS%cg1(i,j+1))
-      enddo ; enddo
+      enddo
     endif
 
     if (CS%Res_fn_power_khth >= 100) then
-      !$OMP do
       do j=js,je ; do I=is-1,Ieq
         dx_term = CS%f2_dx2_u(I,j) + cg1_u(I,j) * CS%beta_dx2_u(I,j)
         if ((CS%Res_coef_khth * cg1_u(I,j))**2 > dx_term) then
@@ -548,7 +534,6 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
           CS%Res_fn_u(I,j) = 1.0
         endif
       enddo ; enddo
-      !$OMP do
       do J=js-1,Jeq ; do i=is,ie
         dx_term = CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)
         if ((CS%Res_coef_khth * cg1_v(i,J))**2 > dx_term) then
@@ -558,39 +543,37 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
         endif
       enddo ; enddo
     elseif (CS%Res_fn_power_khth == 2) then
-      !$OMP do
-      do j=js,je ; do I=is-1,Ieq
+      do concurrent( j=js:je, I=is-1:Ieq ) local(dx_term)
         dx_term = CS%f2_dx2_u(I,j) + cg1_u(I,j) * CS%beta_dx2_u(I,j)
         CS%Res_fn_u(I,j) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_u(I,j))**2)
-      enddo ; enddo
-      !$OMP do
-      do J=js-1,Jeq ; do i=is,ie
+      enddo
+      do concurrent( J=js-1:Jeq, i=is:ie ) local(dx_term)
         dx_term = CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)
         CS%Res_fn_v(i,J) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_v(i,J))**2)
-      enddo ; enddo
+      enddo
+      do concurrent( J=js-1:Jeq, i=is:ie ) local(dx_term)
+        dx_term = CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)
+        CS%Res_fn_v(i,J) = dx_term / (dx_term + (CS%Res_coef_khth * cg1_v(i,J))**2)
+      enddo
     elseif (mod(CS%Res_fn_power_khth, 2) == 0) then
       power_2 = CS%Res_fn_power_khth / 2
-      !$OMP do
       do j=js,je ; do I=is-1,Ieq
         dx_term = (US%L_T_to_m_s**2 * (CS%f2_dx2_u(I,j) + cg1_u(I,j) * CS%beta_dx2_u(I,j)))**power_2
         CS%Res_fn_u(I,j) = dx_term / &
             (dx_term + (CS%Res_coef_khth * US%L_T_to_m_s*cg1_u(I,j))**CS%Res_fn_power_khth)
       enddo ; enddo
-      !$OMP do
       do J=js-1,Jeq ; do i=is,ie
         dx_term = (US%L_T_to_m_s**2 * (CS%f2_dx2_v(i,J) + cg1_v(i,J) * CS%beta_dx2_v(i,J)))**power_2
         CS%Res_fn_v(i,J) = dx_term / &
             (dx_term + (CS%Res_coef_khth * US%L_T_to_m_s*cg1_v(i,J))**CS%Res_fn_power_khth)
       enddo ; enddo
     else
-      !$OMP do
       do j=js,je ; do I=is-1,Ieq
         dx_term = (US%L_T_to_m_s*sqrt(CS%f2_dx2_u(I,j) + &
                                       cg1_u(I,j) * CS%beta_dx2_u(I,j)))**CS%Res_fn_power_khth
         CS%Res_fn_u(I,j) = dx_term / &
             (dx_term + (CS%Res_coef_khth * US%L_T_to_m_s*cg1_u(I,j))**CS%Res_fn_power_khth)
       enddo ; enddo
-      !$OMP do
       do J=js-1,Jeq ; do i=is,ie
         dx_term = (US%L_T_to_m_s*sqrt(CS%f2_dx2_v(i,J) + &
                                       cg1_v(i,J) * CS%beta_dx2_v(i,J)))**CS%Res_fn_power_khth
@@ -599,9 +582,10 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
       enddo ; enddo
     endif
   endif
-  !$OMP end parallel
+
 
   if (query_averaging_enabled(CS%diag)) then
+    !$omp target update from(CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v)
     if (CS%id_Res_fn > 0) call post_data(CS%id_Res_fn, CS%Res_fn_h, CS%diag)
     if (CS%id_BS_struct > 0) call post_data(CS%id_BS_struct, CS%BS_struct, CS%diag)
     if (CS%id_khth_struct > 0) call post_data(CS%id_khth_struct, CS%khth_struct, CS%diag)
@@ -610,10 +594,12 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, OBC, dt)
   endif
 
   if (CS%debug) then
+    !$omp target update from(CS%cg1, CS%Res_fn_u, CS%Res_fn_v)
     call hchksum(CS%cg1, "calc_resoln_fn cg1", G%HI, haloshift=1, unscale=US%L_T_to_m_s)
     call uvchksum("Res_fn_[uv]", CS%Res_fn_u, CS%Res_fn_v, G%HI, haloshift=0, &
                   unscale=1.0, scalar_pair=.true.)
   endif
+  !$omp target exit data map(delete: cg1_q, cg1_u, cg1_v, dx_term)
 end subroutine calc_resoln_function
 
 !> Calculates and stores functions of SQG mode
@@ -2301,6 +2287,13 @@ end subroutine VarMix_init
 !> Destructor for VarMix control structure
 subroutine VarMix_end(CS)
   type(VarMix_CS), intent(inout) :: CS
+
+  ! Remove component arrays from device before host deallocation;
+  !$omp target exit data map(delete: CS%Res_fn_h, CS%Res_fn_q, CS%Res_fn_u, CS%Res_fn_v, &
+  !$omp&                             CS%f2_dx2_q, CS%beta_dx2_q, CS%f2_dx2_u, CS%beta_dx2_u, &
+  !$omp&                             CS%f2_dx2_v, CS%beta_dx2_v)
+  !$omp target exit data map(delete: CS%Rd_dx_h, CS%f2_dx2_h, CS%beta_dx2_h)
+  !$omp target exit data map(delete: CS%cg1)
 
   if (allocated(CS%ebt_struct))  deallocate(CS%ebt_struct)
   if (allocated(CS%sqg_struct))  deallocate(CS%sqg_struct)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -256,7 +256,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (use_VarMix) then
     if (use_Visbeck) then
-      !$omp target update from( VarMix%SN_u)
+      !$omp target update from( VarMix%L2u, VarMix%SN_u)
       !$OMP do
       do j=js,je ; do I=is-1,ie
         Khth_loc_u(I,j) = Khth_loc_u(I,j) + &
@@ -363,7 +363,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (use_VarMix) then
     if (use_Visbeck) then
-      !$omp target update from( VarMix%SN_v )
+      !$omp target update from( VarMix%L2v, VarMix%SN_v )
       !$OMP do
       do J=js-1,je ; do i=is,ie
         Khth_loc_v(i,J) = Khth_loc_v(i,J) + CS%KHTH_Slope_Cff*VarMix%L2v(i,J)*VarMix%SN_v(i,J)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -256,6 +256,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (use_VarMix) then
     if (use_Visbeck) then
+      !$omp target update from( VarMix%SN_u)
       !$OMP do
       do j=js,je ; do I=is-1,ie
         Khth_loc_u(I,j) = Khth_loc_u(I,j) + &
@@ -266,6 +267,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (allocated(MEKE%Kh)) then
     if (CS%MEKE_GEOMETRIC) then
+      !$omp target update from( VarMix%SN_u)
       !$OMP do
       do j=js,je ; do I=is-1,ie
         Khth_loc_u(I,j) = Khth_loc_u(I,j) + G%OBCmaskCu(I,j) * CS%MEKE_GEOMETRIC_alpha * &
@@ -280,6 +282,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   if (Resoln_scaled) then
+    !$omp target update from( VarMix%Res_fn_u )
     !$OMP do
     do j=js,je ; do I=is-1,ie
       Khth_loc_u(I,j) = Khth_loc_u(I,j) * VarMix%Res_fn_u(I,j)
@@ -287,6 +290,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   if (Depth_scaled) then
+    !$omp target update from( VarMix%Depth_fn_u )
     !$OMP do
     do j=js,je ; do I=is-1,ie
       Khth_loc_u(I,j) = Khth_loc_u(I,j) * VarMix%Depth_fn_u(I,j)
@@ -359,6 +363,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (use_VarMix) then
     if (use_Visbeck) then
+      !$omp target update from( VarMix%SN_v )
       !$OMP do
       do J=js-1,je ; do i=is,ie
         Khth_loc_v(i,J) = Khth_loc_v(i,J) + CS%KHTH_Slope_Cff*VarMix%L2v(i,J)*VarMix%SN_v(i,J)
@@ -367,6 +372,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
   if (allocated(MEKE%Kh)) then
     if (CS%MEKE_GEOMETRIC) then
+      !$omp target update from( VarMix%SN_v )
       !$OMP do
       do J=js-1,je ; do i=is,ie
         Khth_loc_v(i,J) = Khth_loc_v(i,J) + G%OBCmaskCv(i,J) * CS%MEKE_GEOMETRIC_alpha * &
@@ -381,6 +387,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   if (Resoln_scaled) then
+    !$omp target update from( VarMix%Res_fn_v )
     !$OMP do
     do J=js-1,je ; do i=is,ie
       Khth_loc_v(i,J) = Khth_loc_v(i,J) * VarMix%Res_fn_v(i,J)
@@ -388,6 +395,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   if (Depth_scaled) then
+    !$omp target update from( VarMix%Depth_fn_v )
     !$OMP do
     do J=js-1,je ; do i=is,ie
       Khth_loc_v(i,J) = Khth_loc_v(i,J) * VarMix%Depth_fn_v(i,J)
@@ -451,6 +459,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (allocated(MEKE%Kh)) then
     if (CS%MEKE_GEOMETRIC) then
+      !$omp target update from( VarMix%SN_u, VarMix%SN_v )
       if (CS%MEKE_GEOM_answer_date < 20190101) then
         !$OMP do
         do j=js,je ; do i=is,ie
@@ -501,6 +510,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     call hchksum(h, "thickness_diffuse_1 h", G%HI, haloshift=1, unscale=GV%H_to_m)
     call hchksum(e, "thickness_diffuse_1 e", G%HI, haloshift=1, unscale=US%Z_to_m)
     if (use_stored_slopes) then
+      !$omp target update from(VarMix%slope_x, VarMix%slope_y)
       call uvchksum("VarMix%slope_[xy]", VarMix%slope_x, VarMix%slope_y, &
                     G%HI, haloshift=0, unscale=US%Z_to_L)
     endif
@@ -511,6 +521,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   ! Calculate uhD, vhD from h, e, KH_u, KH_v, tv%T/S
+  !$omp target update from(VarMix%slope_x, VarMix%slope_y)
   if (STOCH%skeb_use_gm) then
     if (use_stored_slopes) then
       call thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV, US, MEKE, CS, &

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -521,9 +521,9 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   ! Calculate uhD, vhD from h, e, KH_u, KH_v, tv%T/S
-  !$omp target update from(VarMix%slope_x, VarMix%slope_y)
   if (STOCH%skeb_use_gm) then
     if (use_stored_slopes) then
+      !$omp target update from(VarMix%slope_x, VarMix%slope_y)
       call thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV, US, MEKE, CS, &
                                   int_slope_u, int_slope_v, VarMix%slope_x, VarMix%slope_y, &
                                   STOCH=STOCH, VarMix=VarMix)
@@ -533,6 +533,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     endif
   else
     if (use_stored_slopes) then
+      !$omp target update from(VarMix%slope_x, VarMix%slope_y)
       call thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV, US, MEKE, CS, &
                                   int_slope_u, int_slope_v, VarMix%slope_x, VarMix%slope_y)
     else

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1429,9 +1429,9 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
 
   ! First do u-points
 
-  ! TODO: tv and VarMix probably should be conditionally transferred (if at all)
+  ! TODO: tv probably should be conditionally transferred (if at all)
   !$omp target enter data map(alloc: z_i, z_i_gl90, dz_harm, hvel, dz_vel, a_cpl, a_cpl_gl90, &
-  !$omp& tv, varmix, hvel_shelf, dz_vel_shelf, a_shelf)
+  !$omp& tv, hvel_shelf, dz_vel_shelf, a_shelf)
 
   ! These are used in diagnostics, so they need to be mapped back and forth
   !$omp target enter data map(to: hML_u, kv_u, kv_gl90_u )
@@ -2051,7 +2051,7 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
   endif ; enddo ; enddo
 
   !$omp target exit data map(delete: z_i, z_i_gl90, dz_harm, hvel, dz_vel, a_cpl, a_cpl_gl90, &
-  !$omp& tv, varmix, hvel_shelf, dz_vel_shelf, a_shelf, hml_u, kv_u, kv_gl90_u)
+  !$omp& tv, hvel_shelf, dz_vel_shelf, a_shelf, hml_u, kv_u, kv_gl90_u)
 
   ! These are used in diagnostics, so they need to be mapped back and forth
   !$omp target exit data map(from: hML_u, kv_u, kv_gl90_u )

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -250,8 +250,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
   if (do_online) then
     if (use_VarMix) then
       MEKE_KhTr_fac = MEKE%KhTr_fac
-      !$omp target enter data map(to: VarMix, VarMix%SN_u, VarMix%L2u, VarMix%Res_fn_h, &
-      !$omp   VarMix%Rd_dx_h, MEKE, MEKE%Kh)
+      !$omp target enter data map(to: MEKE, MEKE%Kh)
       do concurrent (j=js:je, I=is-1:ie)
         Kh_loc = CS%KhTr
         if (use_Eady) Kh_loc = Kh_loc + CS%KhTr_Slope_Cff*VarMix%L2u(I,j)*VarMix%SN_u(I,j)
@@ -284,8 +283,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
           Kh_v(i,J,1) = max(Kh_loc, CS%KhTr_min) ! Re-apply min
         endif
       enddo
-      !$omp target exit data map(release: VarMix, VarMix%SN_u, VarMix%L2u, VarMix%SN_v, &
-      !$omp   VarMix%L2v, VarMix%Res_fn_h, VarMix%Rd_dx_h, MEKE, MEKE%Kh)
+      !$omp target exit data map(release: MEKE, MEKE%Kh)
 
       do concurrent (j=js:je, I=is-1:ie)
         khdt_x(I,j) = dt*(Kh_u(I,j,1)*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
@@ -294,6 +292,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
         khdt_y(i,J) = dt*(Kh_v(i,J,1)*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
       enddo
     elseif (Resoln_scaled) then
+      !$omp target update from(VarMix%Res_fn_h)
       !$OMP parallel do default(shared) private(Res_fn)
       do j=js,je ; do I=is-1,ie
         Res_fn = 0.5 * (VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i+1,j))


### PR DESCRIPTION
Fixes #74 for benchmark and benchmark_ALE.

As before, the following CPU times were measured with `ifx (IFX) 2025.2.1 20250806` and the following flags:
```
FCFLAGS = -O3 -fp-model source -qno-opt-dynamic-align -march=core-avx-i
``` 
And the following run command: 
```
srun -n 64 --cpu-bind=map_cpu:$(seq -s, 0 63) 
```

The GPU times were measured with `nvfortran 26.3-0 64-bit target on x86-64 Linux -tp znver2` and with the following flags: 
```
FCFLAGS = -O3 -mp=gpu -stdpar=gpu -gpu=mem:separate,cc80,sm_80 -Mnofma -Minfo=all
FCFLAGS += -Minline=name:flux_elem,name:flux_elem_OBC,name:ratio_max
LDFLAGS = -mp=gpu -stdpar=gpu -gpu=cc80,sm_80,mem:separate
```

## Benchmark
dev/gfdl cpu:
```
benchmark_dev_gfdl_times:(MOM Lateral Mixing)                    12      0.007211      0.011240      0.009644      0.001057  0.004    31     0    63
benchmark_dev_gfdl_times:(MOM Lateral Mixing)                    12      0.007244      0.011204      0.009686      0.001003  0.004    31     0    63
benchmark_dev_gfdl_times:(MOM Lateral Mixing)                    12      0.007207      0.010711      0.009288      0.000902  0.004    31     0    63
benchmark_dev_gfdl_times:(MOM Lateral Mixing)                    12      0.007457      0.011046      0.009365      0.000863  0.004    31     0    63
benchmark_dev_gfdl_times:(MOM Lateral Mixing)                    12      0.007653      0.010851      0.009345      0.000847  0.004    31     0    63
```
This PR cpu:
```
benchmark_lat_mix_times:(MOM Lateral Mixing)                    12      0.007415      0.011109      0.009438      0.000932  0.004    31     0    63
benchmark_lat_mix_times:(MOM Lateral Mixing)                    12      0.007126      0.011048      0.009494      0.000941  0.004    31     0    63
benchmark_lat_mix_times:(MOM Lateral Mixing)                    12      0.007098      0.010964      0.009347      0.001058  0.004    31     0    63
benchmark_lat_mix_times:(MOM Lateral Mixing)                    12      0.007642      0.011139      0.009513      0.000905  0.004    31     0    63
benchmark_lat_mix_times:(MOM Lateral Mixing)                    12      0.007248      0.011302      0.009488      0.000978  0.004    31     0    63
```
Stellar A100s:
```
benchmark_lat_mix:(MOM Lateral Mixing)                    12      0.232069      0.232069      0.232069      0.000000  0.021    31     0     0     
benchmark_lat_mix:(MOM Lateral Mixing)                    12      0.231228      0.231228      0.231228      0.000000  0.021    31     0     0     
benchmark_lat_mix:(MOM Lateral Mixing)                    12      0.228434      0.228434      0.228434      0.000000  0.021    31     0     0     
benchmark_lat_mix:(MOM Lateral Mixing)                    12      0.233983      0.233983      0.233983      0.000000  0.021    31     0     0     
benchmark_lat_mix:(MOM Lateral Mixing)                    12      0.229659      0.229659      0.229659      0.000000  0.021    31     0     0 
```
Still not sure why the GPU times are so much slower. At least one factor is data transfers in `calc_resoln_functions` to run `wave_speed` on the CPU, though I don't think this explains the whole difference. In any case, I was gonna revisit this once #71 is resolved 

## Benchmark_ALE
dev/gfdl cpu:
```
benchmark_ALE_dev_gfdl_times:(MOM Lateral Mixing)                    96      0.112417      0.138619      0.124596      0.007406  0.023    31     0    63
benchmark_ALE_dev_gfdl_times:(MOM Lateral Mixing)                    96      0.114753      0.138377      0.125043      0.006535  0.024    31     0    63
benchmark_ALE_dev_gfdl_times:(MOM Lateral Mixing)                    96      0.111421      0.138042      0.124742      0.007640  0.024    31     0    63
benchmark_ALE_dev_gfdl_times:(MOM Lateral Mixing)                    96      0.117462      0.140629      0.128512      0.006622  0.025    31     0    63
benchmark_ALE_dev_gfdl_times:(MOM Lateral Mixing)                    96      0.112859      0.139784      0.124901      0.007943  0.024    31     0    63
```
This PR cpu: 
```
benchmark_ALE_lat_mix_2d_h:(MOM Lateral Mixing)                    96      0.101642      0.123094      0.112113      0.006229  0.021    31     0    63
benchmark_ALE_lat_mix_2d_h:(MOM Lateral Mixing)                    96      0.099128      0.121786      0.110950      0.006133  0.021    31     0    63
benchmark_ALE_lat_mix_2d_h:(MOM Lateral Mixing)                    96      0.101531      0.122105      0.112214      0.006004  0.021    31     0    63
benchmark_ALE_lat_mix_2d_h:(MOM Lateral Mixing)                    96      0.101361      0.123020      0.111788      0.006316  0.021    31     0    63
benchmark_ALE_lat_mix_2d_h:(MOM Lateral Mixing)                    96      0.100454      0.122945      0.111209      0.005871  0.021    31     0    63
```
Stellar A100s
```
benchmark_ALE_lat_mix_port:(MOM Lateral Mixing)                    96      0.961531      0.961531      0.961531      0.000000  0.015    31     0     0
benchmark_ALE_lat_mix_port:(MOM Lateral Mixing)                    96      0.961717      0.961717      0.961717      0.000000  0.015    31     0     0
benchmark_ALE_lat_mix_port:(MOM Lateral Mixing)                    96      0.959411      0.959411      0.959411      0.000000  0.015    31     0     0
benchmark_ALE_lat_mix_port:(MOM Lateral Mixing)                    96      0.973234      0.973234      0.973234      0.000000  0.015    31     0     0
benchmark_ALE_lat_mix_port:(MOM Lateral Mixing)                    96      0.966769      0.966769      0.966769      0.000000  0.015    31     0     0
```
As before, these times including existing data transfers, and I am still not sure what is causing the performance difference. 
