### PR TITLE
Reproducing_sum refactor; write_energy update

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1196,7 +1196,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
                               G, US, CS%sum_output_CSp)
 
   if (MOM_state_is_synchronized(CS)) then
-    !$omp target update from(u, v, h)
     call write_energy(CS%u, CS%v, CS%h, CS%tv, Time_local, CS%nstep_tot, &
                       G, GV, US, CS%sum_output_CSp, CS%tracer_flow_CSp, &
                       dt_forcing=real_to_time(time_interval, unscale=US%T_to_s) )
@@ -3976,6 +3975,7 @@ subroutine finish_MOM_initialization(Time, dirs, CS)
     deallocate(restart_CSp_tmp)
   endif
 
+  !$omp target update to(CS%u, CS%v, CS%h)
   call write_energy(CS%u, CS%v, CS%h, CS%tv, Time, 0, G, GV, US, &
                     CS%sum_output_CSp, CS%tracer_flow_CSp)
 

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -3,6 +3,7 @@
 ! SPDX-License-Identifier: Apache-2.0
 
 #include "do_concurrent_compat.h"
+
 !> Reports integrated quantities for monitoring the model state
 module MOM_sum_output
 
@@ -554,15 +555,11 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
          "write_energy: Module must be initialized before it is used.")
 
   !$omp target enter data map(alloc: areaTm, tmp1, PE_pt, Salt_int, Temp_int, eta, Z_0APE)
-  !$omp target update to(h)
 
   do concurrent (j=js:je, i=is:ie)
     areaTm(i,j) = G%mask2dT(i,j)*G%areaT(i,j)
   enddo
 
-  do concurrent (k=1:nz, j=1:size(tmp1,2), i=1:size(tmp1,1))
-    tmp1(i,j,k) = 0.0
-  enddo
   do concurrent (k=1:nz, j=js:je, i=is:ie)
     tmp1(i,j,k) = h(i,j,k) * (GV%H_to_RZ*areaTm(i,j))
   enddo
@@ -580,6 +577,8 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     endif
   endif ! Boussinesq
 
+  ! Tracer stock diagnostics (optional; depends on registered tracer packages).
+  ! TODO: Verify Tracer data transfers
   nTr_stocks = 0
   Tr_minmax_avail(:) = .false.
   if (CS%write_min_max .and. CS%write_min_max_loc) then
@@ -751,10 +750,6 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   endif
 
   ! Calculate the Kinetic Energy integrated over each layer.
-  !$omp target update to(u, v)
-  do concurrent (k=1:nz, j=1:size(tmp1,2), i=1:size(tmp1,1))
-    tmp1(i,j,k) = 0.0
-  enddo
   do concurrent (k=1:nz, j=js:je, i=is:ie)
     tmp1(i,j,k) = (0.25 * GV%H_to_RZ*(areaTm(i,j) * h(i,j,k))) * &
             (((u(I-1,j,k)**2) + (u(I,j,k)**2)) + ((v(i,J-1,k)**2) + (v(i,J,k)**2)))

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -3,6 +3,7 @@
 ! SPDX-License-Identifier: Apache-2.0
 
 #include "do_concurrent_compat.h"
+
 !> Interfaces to non-domain-oriented communication subroutines, including the
 !! MOM6 reproducing sums facility
 module MOM_coms
@@ -54,6 +55,8 @@ real, parameter :: max_efp_float = pr(1) * (2.**63 - 1.)
 logical :: overflow_error = .false. !< This becomes true if an overflow is encountered.
 logical :: NaN_error = .false.      !< This becomes true if a NaN is encountered.
 logical :: debug = .false.          !< Making this true enables debugging output.
+
+!$omp declare target(pr, I_pr)
 
 !> Find an accurate and order-invariant sum of a distributed 2d or 3d field, in some cases after
 !! undoing the scaling of the input array and restoring that scaling in the returned value
@@ -626,63 +629,25 @@ subroutine increment_ints(int_sum, int2, prec_error)
 
 end subroutine increment_ints
 
-!> Decompose one real into its 6 signed EFP bin contributions. PURE so it can be
-!! called from do concurrent (stdpar offloads it automatically) as well as from
-!! the host. The arithmetic is exact (pr/I_pr are powers of two), so the bins are
-!! bit-identical CPU<->GPU. Scalar outputs avoid a per-thread local array, so no
-!! forced inlining is required. NaN/overflow are reported via flags rather than
-!! the module-level error logicals, so the routine is side-effect free.
-pure subroutine efp_decompose(r, e1, e2, e3, e4, e5, e6, rmag, is_nan, is_ovf)
-  real,                intent(in)  :: r      !< The real number being decomposed [a]
-  integer(kind=int64), intent(out) :: e1     !< Signed contribution to EFP bin 1
-  integer(kind=int64), intent(out) :: e2     !< Signed contribution to EFP bin 2
-  integer(kind=int64), intent(out) :: e3     !< Signed contribution to EFP bin 3
-  integer(kind=int64), intent(out) :: e4     !< Signed contribution to EFP bin 4
-  integer(kind=int64), intent(out) :: e5     !< Signed contribution to EFP bin 5
-  integer(kind=int64), intent(out) :: e6     !< Signed contribution to EFP bin 6
-  real,                intent(out) :: rmag   !< abs(r), or 0 if r is NaN/Inf [a]
-  integer,             intent(out) :: is_nan !< 1 if r is a NaN or Inf, else 0
-  integer,             intent(out) :: is_ovf !< 1 if abs(r) has no EFP representation, else 0
-
-  real :: rs  ! The remaining value to add, in arbitrary units [a]
-  integer(kind=int64) :: ival
-  integer :: sgn
-
-  e1 = 0_int64 ; e2 = 0_int64 ; e3 = 0_int64
-  e4 = 0_int64 ; e5 = 0_int64 ; e6 = 0_int64
-  rmag = 0.0 ; is_nan = 0 ; is_ovf = 0
-
-  if ((r >= 1e30) .eqv. (r < 1e30)) then ; is_nan = 1 ; return ; endif
-  sgn = 1 ; if (r < 0.0) sgn = -1
-  rs = abs(r) ; rmag = rs
-
-  ! Abort if the number has no EFP representation
-  if (rs > max_efp_float) then ; is_ovf = 1 ; return ; endif
-
-  ival = int(rs*I_pr(1), kind=int64) ; rs = rs - ival*pr(1) ; e1 = sgn*ival
-  ival = int(rs*I_pr(2), kind=int64) ; rs = rs - ival*pr(2) ; e2 = sgn*ival
-  ival = int(rs*I_pr(3), kind=int64) ; rs = rs - ival*pr(3) ; e3 = sgn*ival
-  ival = int(rs*I_pr(4), kind=int64) ; rs = rs - ival*pr(4) ; e4 = sgn*ival
-  ival = int(rs*I_pr(5), kind=int64) ; rs = rs - ival*pr(5) ; e5 = sgn*ival
-  ival = int(rs*I_pr(6), kind=int64) ; rs = rs - ival*pr(6) ; e6 = sgn*ival
-end subroutine efp_decompose
 
 !> Increment an EFP number with a real number without doing any carrying of
 !! of overflows and using only minimal error checking.
 subroutine increment_ints_faster(int_sum, r, max_mag_term)
-  integer(kind=int64), dimension(ni), intent(inout) :: int_sum  !< The array of EFP integers being incremented
-  real,                           intent(in)    :: r        !< The real number being added in arbitrary units [a]
-  real,                           intent(inout) :: max_mag_term !< A running maximum magnitude of the r's
-                                                            !! in arbitrary units [a]
+  integer(kind=int64), intent(inout) :: int_sum(ni)
+    !< The array of EFP integers being incremented
+  real, intent(in) :: r
+    !< The real number being added in arbitrary units [a]
+  real, intent(inout) :: max_mag_term
+    !< A running maximum magnitude of the r's in arbitrary units [a]
 
   ! This subroutine increments a number with another, both using the integer
   ! representation in real_to_ints, but without doing any carrying of overflow.
   ! The per-element decomposition is shared with the GPU kernel via efp_decompose.
-  integer(kind=int64) :: e1, e2, e3, e4, e5, e6
+  integer(kind=int64) :: e(ni)
   real    :: rmag
   integer :: is_nan, is_ovf
 
-  call efp_decompose(r, e1, e2, e3, e4, e5, e6, rmag, is_nan, is_ovf)
+  call efp_decompose(r, e, rmag, is_nan, is_ovf)
 
   if (is_nan /= 0) then ; NaN_error = .true. ; return ; endif
   if (rmag > abs(max_mag_term)) max_mag_term = r
@@ -690,68 +655,117 @@ subroutine increment_ints_faster(int_sum, r, max_mag_term)
   ! Abort if the number has no EFP representation
   if (is_ovf /= 0) then ; overflow_error = .true. ; return ; endif
 
-  int_sum(1) = int_sum(1) + e1 ; int_sum(2) = int_sum(2) + e2
-  int_sum(3) = int_sum(3) + e3 ; int_sum(4) = int_sum(4) + e4
-  int_sum(5) = int_sum(5) + e5 ; int_sum(6) = int_sum(6) + e6
+  int_sum(:) = int_sum(:) + e(:)
 
 end subroutine increment_ints_faster
 
-!> Per-slice EFP bin accumulation over a 2d window, GPU-friendly. Equivalent to
-!! looping increment_ints_faster over (is:ie, js:je), modulo: max_mag_term is
-!! updated with the magnitude (>=0) rather than the signed last-winner. Only
-!! consumer of max_mag_term is abs() in the overflow guard, so values are
-!! unchanged; only the sign in one FATAL message can differ.
+
+!> Increment an EFP number with a real number over a 2d array without doing any
+!! carrying of overflows and using only minimal error checking.
+!! modulo: max_mag_term is updated with the magnitude (>=0) rather than the
+!! signed last-winner. Only consumer of max_mag_term is abs() in the overflow
+!! guard, so values are unchanged; only the sign in one FATAL message can
+!! differ.
 subroutine increment_ints_2d(array, is, ie, js, je, descale, ints_sum, max_mag_term)
-  real, dimension(:,:),               intent(in)    :: array  !< Input slice in arbitrary units [a]
-  integer,                            intent(in)    :: is !< Starting i-index of the window (1-based)
-  integer,                            intent(in)    :: ie !< Ending i-index of the window (1-based)
-  integer,                            intent(in)    :: js !< Starting j-index of the window (1-based)
-  integer,                            intent(in)    :: je !< Ending j-index of the window (1-based)
-  real,                               intent(in)    :: descale !< unscale factor or 1.0 [a A-1 ~> 1]
-  integer(kind=int64), dimension(ni), intent(inout) :: ints_sum !< EFP bins, incremented in place
-  real,                               intent(inout) :: max_mag_term !< Running max magnitude [a]
+  real, intent(in) :: array(:,:)
+    !< The field being added, in arbitrary units [a]
+  integer, intent(in) :: is
+    !< Start i-index of the summed domain
+  integer, intent(in) :: ie
+    !< End i-index of the summed domain
+  integer, intent(in) :: js
+    !< Start j-index of the summed domain
+  integer, intent(in) :: je
+    !< End j-index of the summed domain
+  real, intent(in) :: descale
+    !< unscale factor or 1.0 [a A-1 ~> 1]
+  integer(kind=int64), intent(inout) :: ints_sum(ni)
+    !< The array of EFP integers being incremented
+  real, intent(inout) :: max_mag_term
+    !< A running maximum magnitude of the r's, in arbitrary units [a]
 
   integer :: i, j
-  integer(kind=int64) :: e1, e2, e3, e4, e5, e6
-  real :: r, rmag
-  integer(kind=int64) :: s1, s2, s3, s4, s5, s6
-  real :: mmag
+  integer(kind=int64) :: e(ni)
+  real :: r, rmag, mmag
   integer :: inan, iovf, lnan, lovf
-
-  s1 = ints_sum(1)
-  s2 = ints_sum(2)
-  s3 = ints_sum(3)
-  s4 = ints_sum(4)
-  s5 = ints_sum(5)
-  s6 = ints_sum(6)
 
   mmag = abs(max_mag_term)
   inan = 0 ; iovf = 0
 
-  ! The per-element decomposition is shared with the host path via efp_decompose;
-  ! the six int64 bins reduce as scalars (libnvomp array-section reductions are
-  ! avoided on purpose). array is copied in by stdpar if not already resident.
-  do concurrent (j=js:je, i=is:ie) DO_LOCALITY(local(r, e1, e2, e3, e4, e5, e6, rmag, lnan, lovf)) &
-    DO_LOCALITY(reduce(+: s1, s2, s3, s4, s5, s6) reduce(max: mmag) reduce(max: inan, iovf))
+  ! This subroutine increments a number with another, both using the integer
+  ! representation in real_to_ints, but without doing any carrying of overflow.
+  do concurrent (j=js:je, i=is:ie) &
+      DO_LOCALITY(local(r, e, rmag, lnan, lovf)) &
+      DO_LOCALITY(reduce(+: ints_sum) reduce(max: mmag, inan, iovf))
+
     r = descale*array(i,j)
-    call efp_decompose(r, e1, e2, e3, e4, e5, e6, rmag, lnan, lovf)
+
+    call efp_decompose(r, e, rmag, lnan, lovf)
+
     inan = max(inan, lnan)
     iovf = max(iovf, lovf)
+
     if (rmag > mmag) mmag = rmag
-    s1 = s1 + e1 ; s2 = s2 + e2 ; s3 = s3 + e3
-    s4 = s4 + e4 ; s5 = s5 + e5 ; s6 = s6 + e6
+
+    ints_sum(:) = ints_sum(:) + e(:)
   enddo
 
-  ints_sum(1) = s1
-  ints_sum(2) = s2
-  ints_sum(3) = s3
-  ints_sum(4) = s4
-  ints_sum(5) = s5
-  ints_sum(6) = s6
   max_mag_term = mmag
+
   if (inan /= 0) NaN_error = .true.
   if (iovf /= 0) overflow_error = .true.
 end subroutine increment_ints_2d
+
+
+!> Decompose one real into its 6 signed EFP bin contributions.  The function is
+!! used for both CPU and GPU kernels.  NaNs and overflows are reported by
+!! flags, rather than the module-level error logicals, so that the routine is
+!! free of side effects.
+pure subroutine efp_decompose(r, e, rmag, is_nan, is_ovf)
+  !$omp declare target
+  real, intent(in)  :: r
+    !< The real number being decomposed [a]
+  integer(kind=int64), intent(out) :: e(ni)
+    !< Signed contribution to EFP bins
+  real, intent(out) :: rmag
+    !< Equals abs(r), or 0 if r is NaN/Inf [a]
+  integer, intent(out) :: is_nan
+    !< Equals 1 if r is a NaN or Inf, else 0
+  integer, intent(out) :: is_ovf
+    !< Equals 1 if abs(r) has no EFP representation, else 0
+
+  real :: rs
+    ! The remaining value to add, in arbitrary units [a]
+  integer(kind=int64) :: ival
+  integer :: sgn
+  integer :: n
+
+  e(:) = 0
+  rmag = 0.0 ; is_nan = 0 ; is_ovf = 0
+
+  if ((r >= 1e30) .eqv. (r < 1e30)) then
+    is_nan = 1
+    return
+  endif
+
+  sgn = 1
+  if (r < 0.0) sgn = -1
+
+  rs = abs(r) ; rmag = rs
+
+  ! Abort if the number has no EFP representation
+  if (rs > max_efp_float) then
+    is_ovf = 1
+    return
+  endif
+
+  do n=1,ni
+    ival = int(rs * I_pr(n), kind=int64)
+    rs = rs - ival * pr(n)
+    e(n) = sgn * ival
+  enddo
+end subroutine efp_decompose
+
 
 !> This subroutine handles carrying of the overflow.
 subroutine carry_overflow(int_sum, prec_error)


### PR DESCRIPTION
* increment_ints_2d and increment_ints_faster are modified to use arrays based on the precision width parameter `ni`.

* Redundant data transfers around write_energy were removed, and an additional transfer is added to one associated with initialization.

* Redundant temporary array initializations (which are also still in dev/gfdl) have been removed.

* Loop bounds based on size() are replaced wth grid G%[ij][se]d bounds, in order accommodate (optional) global indexing.