### PR TITLE
map visc and visc%* after init

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3275,7 +3275,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call MEKE_alloc_register_restart(HI, US, param_file, CS%MEKE, restart_CSp)
 
   allocate(CS%visc)
-  !$omp target enter data map(alloc: CS%visc)
   call set_visc_register_restarts(HI, G, GV, US, param_file, CS%visc, restart_CSp, use_ice_shelf)
 
   call mixedlayer_restrat_register_restarts(HI, GV, US, param_file, &
@@ -3706,8 +3705,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(alloc: CS%VarMix)
   call VarMix_init(Time, G, GV, US, param_file, diag, CS%VarMix)
 
-  !$omp target enter data map(to: CS%visc, CS%set_visc_CSp)
   call set_visc_init(Time, G, GV, US, param_file, diag, CS%visc, CS%set_visc_CSp, restart_CSp, CS%OBC)
+  ! visc%Ray_u/v are initialized in set_visc_init and visc%Kv_shear, visc%Kv_shear_bu are
+  ! initiliazed in set_visc_register_restarts. Allocation/association status of these members
+  ! don't change from here. 
+  !$omp target enter data map(to: CS%set_visc_CSp, CS%visc, CS%visc%Kv_shear, CS%visc%Ray_u, CS%visc%Ray_v)
   call thickness_diffuse_init(Time, G, GV, US, param_file, diag, CS%CDp, CS%thickness_diffuse_CSp)
   if (CS%interface_filter) &
     call interface_filter_init(Time, G, GV, US, param_file, diag, CS%CDp, CS%interface_filter_CSp)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -3389,7 +3389,6 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   if (CS%Channel_drag .or. CS%body_force_drag) then
     allocate(visc%Ray_u(IsdB:IedB,jsd:jed,nz), source=0.0)
     allocate(visc%Ray_v(isd:ied,JsdB:JedB,nz), source=0.0)
-    !$omp target enter data map(to: visc%Ray_u, visc%Ray_v)
     CS%id_Ray_u = register_diag_field('ocean_model', 'Rayleigh_u', diag%axesCuL, &
        Time, 'Rayleigh drag velocity at u points', 'm s-1', conversion=GV%H_to_m*US%s_to_T)
     CS%id_Ray_v = register_diag_field('ocean_model', 'Rayleigh_v', diag%axesCvL, &


### PR DESCRIPTION
This fixes the GPU segfaults happening in vertvisc, vertvisc_coef, and vertvisc_remnant related to visc%* not being properly mapped - causing the GPU to not know about the correct allocated/associated status of the members.

I put the map *outside* of set_visc_init since the visc object is updated in both `set_visc_init` and `set_visc_register_restarts` and I didn't want to presume the order in which they were called. besides, the `visc` object is allocated in `MOM.F90`. 