### PR TITLE
vertvisc: Fix CS memory management

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -417,8 +417,8 @@ type, public :: MOM_control_struct ; private
     !< Control structure used for the interface height smoothing operator.
   type(mixedlayer_restrat_CS) :: mixedlayer_restrat_CSp
     !< Pointer to the control structure used for the mixed layer restratification
-  type(set_visc_CS)           :: set_visc_CSp
-    !< Pointer to the control structure used to set viscosities
+  type(set_visc_CS), allocatable :: set_visc_CSp
+    !< Control structure used to set viscosities
   type(diabatic_CS),             pointer :: diabatic_CSp => NULL()
     !< Pointer to the control structure for the diabatic driver
   type(MEKE_CS) :: MEKE_CSp
@@ -3706,8 +3706,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   !$omp target enter data map(alloc: CS%VarMix)
   call VarMix_init(Time, G, GV, US, param_file, diag, CS%VarMix)
 
-  !$omp target enter data map(to: CS%visc, CS%set_visc_CSp)
+  allocate(CS%set_visc_CSp)
+  !$omp target enter data map(alloc: CS%set_visc_CSp)
   call set_visc_init(Time, G, GV, US, param_file, diag, CS%visc, CS%set_visc_CSp, restart_CSp, CS%OBC)
+
   call thickness_diffuse_init(Time, G, GV, US, param_file, diag, CS%CDp, CS%thickness_diffuse_CSp)
   if (CS%interface_filter) &
     call interface_filter_init(Time, G, GV, US, param_file, diag, CS%CDp, CS%interface_filter_CSp)
@@ -4746,6 +4748,7 @@ subroutine MOM_end(CS)
 
   call set_visc_end(CS%visc, CS%set_visc_CSp)
   !$omp target exit data map(delete: CS%visc, CS%set_visc_CSp)
+  deallocate(CS%set_visc_CSp)
   deallocate(CS%visc)
 
   call MEKE_end(CS%MEKE)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2899,8 +2899,6 @@ subroutine set_visc_register_restarts(HI, G, GV, US, param_file, visc, restart_C
   if (useKPP .or. useEPBL .or. use_CVMix_shear .or. use_CVMix_conv .or. &
       (use_kappa_shear .and. .not.KS_at_vertex )) then
     call safe_alloc_ptr(visc%Kv_shear, isd, ied, jsd, jed, nz+1)
-    !$omp target enter data map(alloc: visc%Kv_shear)
-
     call register_restart_field(visc%Kv_shear, "Kv_shear", .false., restart_CS, &
                   "Shear-driven turbulent viscosity at interfaces", &
                   units=Kv_units, conversion=GV%HZ_T_to_MKS, z_grid='i')
@@ -3321,7 +3319,15 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
 
   CS%Hbbl = CS%dz_bbl * (US%Z_to_m * GV%m_to_H)  ! Rescaled for use in expressions in thickness units.
 
+  ! Update scalar data to device
+  !$omp target update to(visc)
   !$omp target update to(CS)
+
+  ! Now update arrays that were defined in set_visc_register_restarts()
+  !$omp target enter data map(to: visc%Kv_shear) &
+  !$omp   if (associated(visc%Kv_shear))
+  !$omp target enter data map(to: visc%Kv_shear_Bu) &
+  !$omp   if (associated(visc%Kv_shear_Bu))
 
   if (CS%RiNo_mix .and. kappa_shear_at_vertex(param_file)) then
     ! This is necessary for reproducibility across restarts in non-symmetric mode.

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1436,11 +1436,9 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
   ! These are used in diagnostics, so they need to be mapped back and forth
   !$omp target enter data map(to: hML_u, kv_u, kv_gl90_u )
   !$omp target enter data map(to: hML_v, kv_v, kv_gl90_v)
-  ! Kv_shear is persistently mapped on device via map(alloc:) in set_viscosity_init,
-  ! so map(to:) here would not copy host updates. Use target update to(...) to force
-  ! a host->device sync on every call.
+
   !$omp target update to(visc%Kv_shear) if (associated(visc%Kv_shear))
-  !$omp target enter data map(to: visc%Kv_shear_Bu) if (associated(visc%Kv_shear_Bu))
+  !$omp target update to(visc%Kv_shear_Bu) if (associated(visc%Kv_shear_Bu))
 
   !$omp target teams distribute parallel do collapse(2) &
   !$omp   private(z_i, z_i_gl90, dz_harm, hvel, dz_vel, a_cpl, a_cpl_gl90, &
@@ -2054,8 +2052,6 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
 
   !$omp target exit data map(delete: z_i, z_i_gl90, dz_harm, hvel, dz_vel, a_cpl, a_cpl_gl90, &
   !$omp& tv, varmix, hvel_shelf, dz_vel_shelf, a_shelf, hml_u, kv_u, kv_gl90_u)
-  ! Kv_shear stays persistently mapped (see entry above); only release Kv_shear_Bu.
-  !$omp target exit data map(release: visc%Kv_shear_Bu) if (associated(visc%Kv_shear_Bu))
 
   ! These are used in diagnostics, so they need to be mapped back and forth
   !$omp target exit data map(from: hML_u, kv_u, kv_gl90_u )


### PR DESCRIPTION
The visc object was being allocated twice, which was overwriting information about Kv_shear and Kv_shear_Bu that was defined in set_visc_register_restarts().  This was causing errors in kernels which needed both the arrays and the associated() state for flow control.

This patch fixes the allocation in a few ways:

* CS%visc is allocated once.

* CS%set_visc_CS is now an allocatable.

  (This may not be needed, but it is consistent with other types).

* CS%visc is now updated to device inside of set_visc_init()

* Device allocations of CS%visc%Kv_shear and CS%visc%Kv_shear_Bu are now moved into set_visc_init(), and applied after the CS%visc update.

* CS%Kv_shear_Bu is now handled outside of vertvisc_coef, just as done with CS%Kv_shear.

This appears to fix addressing errors observed in some double_gyre runs.