### PR TITLE
EOS: 2D and 3D density implementations of methods

### DIFF
--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -71,8 +71,10 @@ interface calculate_density
   module procedure calculate_density_scalar
   module procedure calculate_density_1d
   module procedure calculate_density_2d
+  module procedure calculate_density_3d
   module procedure calculate_stanley_density_scalar
   module procedure calculate_stanley_density_1d
+  module procedure calculate_stanley_density_2d
 end interface calculate_density
 
 !> Calculates specific volume of sea water from T, S and P
@@ -86,6 +88,7 @@ interface calculate_density_derivs
   module procedure calculate_density_derivs_scalar, calculate_density_derivs_array
   module procedure calculate_density_derivs_1d
   module procedure calculate_density_derivs_2d
+  module procedure calculate_density_derivs_3d
 end interface calculate_density_derivs
 
 !> Calculate the derivatives of specific volume with temperature and salinity from T, S, and P
@@ -97,6 +100,7 @@ end interface calculate_specific_vol_derivs
 !! salinity, and pressure from T, S and P
 interface calculate_density_second_derivs
   module procedure calculate_density_second_derivs_scalar, calculate_density_second_derivs_1d
+  module procedure calculate_density_second_derivs_2d
 end interface calculate_density_second_derivs
 
 !> Calculates the freezing point of sea water from T, S and P
@@ -419,6 +423,68 @@ subroutine calculate_density_2d(T, S, pressure, rho, EOS, dom, rho_ref)
 end subroutine calculate_density_2d
 
 
+!> Calls the appropriate subroutine to calculate density of sea water for 3-D array inputs.
+subroutine calculate_density_3d(T, S, pressure, rho, EOS, dom, rho_ref)
+  real, intent(in) :: T(:,:,:)
+    !< Potential temperature referenced to the surface [C ~> degC]
+  real, intent(in) :: S(:,:,:)
+    !< Salinity [S ~> ppt]
+  real, intent(in) :: pressure(:,:,:)
+    !< Pressure [R L2 T-2 ~> Pa]
+  real, intent(inout) :: rho(:,:,:)
+    !< Density (in-situ if pressure is local) [R ~> kg m-3]
+  type(EOS_type), intent(in) :: EOS
+    !< Equation of state structure
+  integer, optional, intent(in) :: dom(3,2)
+    !< The domain of indices to work on, taking into account that arrays start
+    !! at 1.  The first index is the rank (i, j, k) and the second is the bound
+    !! (1 = lower, 2 = upper).
+  real, optional, intent(in) :: rho_ref
+    !< A reference density [R ~> kg m-3]
+
+  real, dimension(size(rho,1), size(rho,2), size(rho,3)) :: pres
+    ! Pressure converted to [Pa]
+  real, dimension(size(rho,1), size(rho,2), size(rho,3)) :: Ta
+    ! Temperature converted to [degC]
+  real, dimension(size(rho,1), size(rho,2), size(rho,3)) :: Sa
+    ! Salinity converted to [ppt]
+  integer :: is, ie, js, je, ks, ke
+  integer :: domain(3,2)
+
+  if (present(dom)) then
+    domain(:,:) = dom(:,:)
+  else
+    domain(1,:) = [1, size(rho,1)]
+    domain(2,:) = [1, size(rho,2)]
+    domain(3,:) = [1, size(rho,3)]
+  endif
+
+  is = domain(1,1) ; ie = domain(1,2)
+  js = domain(2,1) ; je = domain(2,2)
+  ks = domain(3,1) ; ke = domain(3,2)
+
+  if ((EOS%RL2_T2_to_Pa == 1.0) .and. (EOS%R_to_kg_m3 == 1.0) .and. &
+      (EOS%C_to_degC == 1.0) .and. (EOS%S_to_ppt == 1.0)) then
+    call EOS%type%calculate_density_array_3d(T, S, pressure, rho, domain, &
+        rho_ref=rho_ref)
+  else ! This is the same as above, but with some extra work to rescale variables.
+    pres(is:ie, js:je, ks:ke) = EOS%RL2_T2_to_Pa * pressure(is:ie, js:je, ks:ke)
+    Ta(is:ie, js:je, ks:ke) = EOS%C_to_degC * T(is:ie, js:je, ks:ke)
+    Sa(is:ie, js:je, ks:ke) = EOS%S_to_ppt * S(is:ie, js:je, ks:ke)
+
+    if (present(rho_ref)) then
+      call EOS%type%calculate_density_array_3d(Ta, Sa, pres, rho, domain, &
+          rho_ref=EOS%R_to_kg_m3*rho_ref)
+    else
+      call EOS%type%calculate_density_array_3d(Ta, Sa, pres, rho, domain)
+    endif
+  endif
+
+  if (EOS%kg_m3_to_R /= 1.) &
+    rho(is:ie, js:je, ks:ke) = EOS%kg_m3_to_R * rho(is:ie, js:je, ks:ke)
+end subroutine calculate_density_3d
+
+
 !> Calls the appropriate subroutine to calculate the density of sea water for 1-D array inputs
 !! including the variance of T, S and covariance of T-S,
 !! potentially limiting the domain of indices that are worked on.
@@ -467,6 +533,39 @@ subroutine calculate_stanley_density_1d(T, S, pressure, Tvar, TScov, Svar, rho, 
   enddo ; endif ; endif
 
 end subroutine calculate_stanley_density_1d
+
+!> Calls the Stanley density routine for each row of 2-D array inputs.
+subroutine calculate_stanley_density_2d(T, S, pressure, Tvar, TScov, Svar, rho, EOS, dom, rho_ref, scale)
+  real, dimension(:,:),  intent(in)    :: T        !< Potential temperature referenced to the surface [C ~> degC]
+  real, dimension(:,:),  intent(in)    :: S        !< Salinity [S ~> ppt]
+  real, dimension(:,:),  intent(in)    :: pressure !< Pressure [R L2 T-2 ~> Pa]
+  real, dimension(:,:),  intent(in)    :: Tvar     !< Variance of potential temperature [C2 ~> degC2]
+  real, dimension(:,:),  intent(in)    :: TScov    !< Covariance of potential temperature and salinity [C S ~> degC ppt]
+  real, dimension(:,:),  intent(in)    :: Svar     !< Variance of salinity [S2 ~> ppt2]
+  real, dimension(:,:),  intent(inout) :: rho      !< Density (in-situ if pressure is local) [R ~> kg m-3]
+  type(EOS_type),        intent(in)    :: EOS      !< Equation of state structure
+  integer, dimension(2,2), optional, intent(in) :: dom !< The domain of indices to work on, taking
+                                                       !! into account that arrays start at 1.
+  real,                  optional, intent(in) :: rho_ref !< A reference density [R ~> kg m-3]
+  real,                  optional, intent(in) :: scale !< A multiplicative factor by which to scale density
+                                                   !! in combination with scaling stored in EOS [various]
+  integer :: j, js, je
+  integer, dimension(2) :: dom_row
+
+  if (present(dom)) then
+    js = dom(2,1) ; je = dom(2,2)
+    dom_row = [dom(1,1), dom(1,2)]
+  else
+    js = 1 ; je = size(rho,2)
+    dom_row = [1, size(rho,1)]
+  endif
+
+  do j=js,je
+    call calculate_stanley_density_1d(T(:,j), S(:,j), pressure(:,j), &
+                                      Tvar(:,j), TScov(:,j), Svar(:,j), &
+                                      rho(:,j), EOS, dom_row, rho_ref, scale)
+  enddo
+end subroutine calculate_stanley_density_2d
 
 !> Calls the appropriate subroutine to calculate the specific volume of sea water
 !! for 1-D array inputs.
@@ -952,6 +1051,68 @@ subroutine calculate_density_derivs_2d(T, S, pressure, drho_dT, drho_dS, EOS, do
 end subroutine calculate_density_derivs_2d
 
 
+!> Calls the appropriate subroutine to calculate density derivatives for 3-D array inputs.
+subroutine calculate_density_derivs_3d(T, S, pressure, drho_dT, drho_dS, EOS, dom)
+  real, intent(in) :: T(:,:,:)
+    !< Potential temperature referenced to the surface [degC]
+  real, intent(in) :: S(:,:,:)
+    !< Salinity [ppt]
+  real, intent(in) :: pressure(:,:,:)
+    !< Pressure [Pa]
+  real, intent(inout) :: drho_dT(:,:,:)
+    !< The partial derivative of density with potential temperature
+    !! [kg m-3 degC-1] or other units determined by the optional scale argument
+  real, intent(inout) :: drho_dS(:,:,:)
+    !< The partial derivative of density with salinity, in [kg m-3 ppt-1] or
+    !! other units determined by the optional scale argument
+  type(EOS_type), intent(in) :: EOS
+    !< Equation of state structure
+  integer, optional, intent(in) :: dom(3,2)
+    !< The domain of indices to work on, taking into account that arrays start
+    !! at 1.  The first index is the rank (i, j, k) and the second is the bound
+    !! (1 = lower, 2 = upper).
+
+  ! Local variables
+  real :: Ta(size(T,1), size(T,2), size(T,3))
+    ! Temperature converted to [degC]
+  real :: Sa(size(S,1), size(S,2), size(S,3))
+    ! Salinity converted to [ppt]
+  real :: press(size(pressure,1), size(pressure,2), size(pressure,3))
+    ! Pressure converted to [Pa]
+  integer :: is, ie, js, je, ks, ke
+  integer :: domain(3,2)
+
+  if (present(dom)) then
+    domain(:,:) = dom(:,:)
+  else
+    domain(1,:) = [1, size(drho_dT, 1)]
+    domain(2,:) = [1, size(drho_dT, 2)]
+    domain(3,:) = [1, size(drho_dT, 3)]
+  endif
+  is = domain(1,1) ; ie = domain(1,2)
+  js = domain(2,1) ; je = domain(2,2)
+  ks = domain(3,1) ; ke = domain(3,2)
+
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+      "calculate_density_derivs_3d: EOS%form_of_EOS is not valid.")
+
+  if (all([EOS%RL2_T2_to_Pa, EOS%C_to_degC, EOS%S_to_ppt] == 1.)) then
+    call EOS%type%calculate_density_derivs_3d(T, S, pressure, drho_dT, drho_dS, domain)
+  else
+    press(is:ie, js:je, ks:ke) = EOS%RL2_T2_to_Pa * pressure(is:ie, js:je, ks:ke)
+    Ta(is:ie, js:je, ks:ke) = EOS%C_to_degC * T(is:ie, js:je, ks:ke)
+    Sa(is:ie, js:je, ks:ke) = EOS%S_to_ppt * S(is:ie, js:je, ks:ke)
+
+    call EOS%type%calculate_density_derivs_3d(Ta, Sa, press, drho_dT, drho_dS, domain)
+  endif
+
+  if (EOS%kg_m3_to_R * EOS%C_to_degC /= 1.) &
+    drho_dT(is:ie, js:je, ks:ke) = EOS%kg_m3_to_R * EOS%C_to_degC * drho_dT(is:ie, js:je, ks:ke)
+  if (EOS%kg_m3_to_R * EOS%S_to_ppt /= 1.) &
+    drho_dS(is:ie, js:je, ks:ke) = EOS%kg_m3_to_R * EOS%S_to_ppt * drho_dS(is:ie, js:je, ks:ke)
+end subroutine calculate_density_derivs_3d
+
+
 !> Calls the appropriate subroutines to calculate density derivatives by promoting a scalar
 !! to a one-element array
 subroutine calculate_density_derivs_scalar(T, S, pressure, drho_dT, drho_dS, EOS, scale)
@@ -1070,6 +1231,86 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
   enddo ; endif
 
 end subroutine calculate_density_second_derivs_1d
+
+!> Calls the appropriate subroutine to calculate density second derivatives for 2D array inputs.
+subroutine calculate_density_second_derivs_2d(T, S, pressure, drho_dS_dS, drho_dS_dT, drho_dT_dT, &
+                                              drho_dS_dP, drho_dT_dP, EOS, dom, scale)
+  real, intent(in) :: T(:,:)         !< Potential temperature referenced to the surface [C ~> degC]
+  real, intent(in) :: S(:,:)         !< Salinity [S ~> ppt]
+  real, intent(in) :: pressure(:,:)  !< Pressure [R L2 T-2 ~> Pa]
+  real, intent(inout) :: drho_dS_dS(:,:) !< Partial derivative of beta with respect to S
+                                         !! [R S-2 ~> kg m-3 ppt-2]
+  real, intent(inout) :: drho_dS_dT(:,:) !< Partial derivative of beta with respect to T
+                                         !! [R S-1 C-1 ~> kg m-3 ppt-1 degC-1]
+  real, intent(inout) :: drho_dT_dT(:,:) !< Partial derivative of alpha with respect to T
+                                         !! [R C-2 ~> kg m-3 degC-2]
+  real, intent(inout) :: drho_dS_dP(:,:) !< Partial derivative of beta with respect to pressure
+                                         !! [T2 S-1 L-2 ~> kg m-3 ppt-1 Pa-1]
+  real, intent(inout) :: drho_dT_dP(:,:) !< Partial derivative of alpha with respect to pressure
+                                         !! [T2 C-1 L-2 ~> kg m-3 degC-1 Pa-1]
+  type(EOS_type), intent(in) :: EOS      !< Equation of state structure
+  integer, optional, intent(in) :: dom(2,2) !< The domain of indices to work on
+  real,    optional, intent(in) :: scale    !< A multiplicative factor by which to scale density [various]
+
+  ! Local variables
+  real :: Ta(size(T,1), size(T,2))       ! Temperature converted to [degC]
+  real :: Sa(size(S,1), size(S,2))       ! Salinity converted to [ppt]
+  real :: press(size(pressure,1), size(pressure,2)) ! Pressure converted to [Pa]
+  real :: rho_scale  ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
+  integer :: is, ie, js, je
+  integer :: domain(2,2)
+
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+      "calculate_density_second_derivs_2d: EOS%form_of_EOS is not valid.")
+
+  if (present(dom)) then
+    domain(:,:) = dom(:,:)
+  else
+    domain(1,:) = [1, size(drho_dT_dT, 1)]
+    domain(2,:) = [1, size(drho_dT_dT, 2)]
+  endif
+  is = domain(1,1) ; ie = domain(1,2)
+  js = domain(2,1) ; je = domain(2,2)
+
+  if (all([EOS%RL2_T2_to_Pa, EOS%C_to_degC, EOS%S_to_ppt] == 1.)) then
+    call EOS%type%calculate_density_second_derivs_2d(T, S, pressure, &
+        drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, domain)
+  else
+    press(is:ie, js:je) = EOS%RL2_T2_to_Pa * pressure(is:ie, js:je)
+    Ta(is:ie, js:je) = EOS%C_to_degC * T(is:ie, js:je)
+    Sa(is:ie, js:je) = EOS%S_to_ppt * S(is:ie, js:je)
+    call EOS%type%calculate_density_second_derivs_2d(Ta, Sa, press, &
+        drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, domain)
+  endif
+
+  rho_scale = EOS%kg_m3_to_R
+  if (present(scale)) rho_scale = rho_scale * scale
+  if (rho_scale /= 1.0) then
+    drho_dS_dS(is:ie, js:je) = rho_scale * drho_dS_dS(is:ie, js:je)
+    drho_dS_dT(is:ie, js:je) = rho_scale * drho_dS_dT(is:ie, js:je)
+    drho_dT_dT(is:ie, js:je) = rho_scale * drho_dT_dT(is:ie, js:je)
+    drho_dS_dP(is:ie, js:je) = rho_scale * drho_dS_dP(is:ie, js:je)
+    drho_dT_dP(is:ie, js:je) = rho_scale * drho_dT_dP(is:ie, js:je)
+  endif
+
+  if (EOS%RL2_T2_to_Pa /= 1.0) then
+    drho_dS_dP(is:ie, js:je) = EOS%RL2_T2_to_Pa * drho_dS_dP(is:ie, js:je)
+    drho_dT_dP(is:ie, js:je) = EOS%RL2_T2_to_Pa * drho_dT_dP(is:ie, js:je)
+  endif
+
+  if (EOS%C_to_degC /= 1.0) then
+    drho_dS_dT(is:ie, js:je) = EOS%C_to_degC * drho_dS_dT(is:ie, js:je)
+    drho_dT_dT(is:ie, js:je) = EOS%C_to_degC**2 * drho_dT_dT(is:ie, js:je)
+    drho_dT_dP(is:ie, js:je) = EOS%C_to_degC * drho_dT_dP(is:ie, js:je)
+  endif
+
+  if (EOS%S_to_ppt /= 1.0) then
+    drho_dS_dS(is:ie, js:je) = EOS%S_to_ppt**2 * drho_dS_dS(is:ie, js:je)
+    drho_dS_dT(is:ie, js:je) = EOS%S_to_ppt * drho_dS_dT(is:ie, js:je)
+    drho_dS_dP(is:ie, js:je) = EOS%S_to_ppt * drho_dS_dP(is:ie, js:je)
+  endif
+
+end subroutine calculate_density_second_derivs_2d
 
 !> Calls the appropriate subroutine to calculate density second derivatives for scalar inputs.
 subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, drho_dS_dT, drho_dT_dT, &

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -183,10 +183,16 @@ contains
   procedure :: calculate_density_array => calculate_density_array_Roquet_rho
   !> Local implementation of generic calculate_density_array_2d for efficiency
   procedure :: calculate_density_array_2d => calculate_density_array_2d_Roquet_rho
+  !> Local implementation of generic calculate_density_array_3d for efficiency
+  procedure :: calculate_density_array_3d => calculate_density_array_3d_Roquet_rho
   !> Local implementation of generic calculate_spec_vol_array for efficiency
   procedure :: calculate_spec_vol_array => calculate_spec_vol_array_Roquet_rho
   !> Local implementation of generic calculate_density_derivs_2d for efficiency
   procedure :: calculate_density_derivs_2d => calculate_density_derivs_2d_Roquet_rho
+  !> Local implementation of generic calculate_density_derivs_3d for efficiency
+  procedure :: calculate_density_derivs_3d => calculate_density_derivs_3d_Roquet_rho
+  !> Local implementation of generic calculate_density_second_derivs_2d for efficiency
+  procedure :: calculate_density_second_derivs_2d => calculate_density_second_derivs_2d_Roquet_rho
 
 end type Roquet_rho_EOS
 
@@ -455,23 +461,23 @@ elemental subroutine calculate_density_derivs_elem_Roquet_rho(this, T, S, pressu
 
 end subroutine calculate_density_derivs_elem_Roquet_rho
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure
-elemental subroutine calculate_density_second_derivs_elem_Roquet_rho(this, T, S, pressure, &
+!> Second derivatives of density with respect to temperature, salinity, and pressure.
+!! Free-function form without "this" for use in do concurrent GPU regions with nvfortran.
+elemental subroutine calculate_density_second_derivs_elem_Roquet_rho_loc(T, S, pressure, &
                        drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
-  class(Roquet_rho_EOS), intent(in) :: this !< This EOS
-  real,               intent(in)    :: T !< Conservative temperature [degC]
-  real,               intent(in)    :: S !< Absolute salinity [g kg-1]
-  real,               intent(in)    :: pressure !< Pressure [Pa]
-  real,               intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
-                                                  !! to S [kg m-3 ppt-2]
-  real,               intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
-                                                  !! to T [kg m-3 ppt-1 degC-1]
-  real,               intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
-                                                  !! to T [kg m-3 degC-2]
-  real,               intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
-                                                  !! to pressure [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
-  real,               intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
-                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  real, intent(in)    :: T           !< Conservative temperature [degC]
+  real, intent(in)    :: S           !< Absolute salinity [g kg-1]
+  real, intent(in)    :: pressure    !< Pressure [Pa]
+  real, intent(inout) :: drho_ds_ds  !< Partial derivative of beta with respect
+                                     !! to S [kg m-3 ppt-2]
+  real, intent(inout) :: drho_ds_dt  !< Partial derivative of beta with respect
+                                     !! to T [kg m-3 ppt-1 degC-1]
+  real, intent(inout) :: drho_dt_dt  !< Partial derivative of alpha with respect
+                                     !! to T [kg m-3 degC-2]
+  real, intent(inout) :: drho_ds_dp  !< Partial derivative of beta with respect
+                                     !! to pressure [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
+  real, intent(inout) :: drho_dt_dp  !< Partial derivative of alpha with respect
+                                     !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
 
   ! Local variables
   real :: zp     ! Pressure [Pa]
@@ -544,6 +550,30 @@ elemental subroutine calculate_density_second_derivs_elem_Roquet_rho(this, T, S,
                    + zt*(2.*EOS021 + (zs*(2.*EOS121 +  zs*(2.*EOS221)) &
                                     + zt*(3.*EOS031 + (zs*(3.*EOS131) + zt*(4.*EOS041))) )) )
   drho_dt_dp =  (d2R_p0 + zp*(d2R_p1 + zp*d2R_p2))
+
+end subroutine calculate_density_second_derivs_elem_Roquet_rho_loc
+
+!> Wrapper for calculate_density_second_derivs_elem_Roquet_rho_loc created to preserve API
+!! while calling without "this" variable that causes runtime errors on GPU with nvfortran.
+elemental subroutine calculate_density_second_derivs_elem_Roquet_rho(this, T, S, pressure, &
+                       drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+  class(Roquet_rho_EOS), intent(in) :: this !< This EOS
+  real,               intent(in)    :: T !< Conservative temperature [degC]
+  real,               intent(in)    :: S !< Absolute salinity [g kg-1]
+  real,               intent(in)    :: pressure !< Pressure [Pa]
+  real,               intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                  !! to S [kg m-3 ppt-2]
+  real,               intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                  !! to T [kg m-3 ppt-1 degC-1]
+  real,               intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                  !! to T [kg m-3 degC-2]
+  real,               intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                  !! to pressure [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
+  real,               intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+
+  call calculate_density_second_derivs_elem_Roquet_rho_loc(T, S, pressure, &
+      drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
 
 end subroutine calculate_density_second_derivs_elem_Roquet_rho
 
@@ -721,6 +751,45 @@ subroutine calculate_density_array_2d_Roquet_rho(this, T, S, pressure, rho, dom,
   endif
 end subroutine calculate_density_array_2d_Roquet_rho
 
+!> Calculate the in-situ density for 3D array inputs and outputs.
+subroutine calculate_density_array_3d_Roquet_rho(this, T, S, pressure, rho, dom, rho_ref)
+  class(Roquet_rho_EOS), intent(in) :: this
+    !< This EOS
+  real, intent(in)  :: T(:,:,:)
+    !< Conservative temperature [degC]
+  real, intent(in)  :: S(:,:,:)
+    !< Absolute salinity [g kg-1]
+  real, intent(in)  :: pressure(:,:,:)
+    !< Pressure [Pa]
+  real, intent(out) :: rho(:,:,:)
+    !< In situ density [kg m-3]
+  integer, intent(in) :: dom(3,2)
+    !< Index bounds of domain.  First index is rank, second is bounds
+  real, optional, intent(in) :: rho_ref
+    !< A reference density [kg m-3]
+
+  integer :: is, ie, js, je, ks, ke
+  integer :: i, j, k
+
+  is = dom(1,1) ; ie = dom(1,2)
+  js = dom(2,1) ; je = dom(2,2)
+  ks = dom(3,1) ; ke = dom(3,2)
+
+  ! The element functions are called via their free-function (_loc) forms rather than
+  ! through the polymorphic "this" binding, which causes runtime errors in do concurrent
+  ! regions offloaded to the GPU with nvfortran.
+  if (present(rho_ref)) then
+    do concurrent (k=ks:ke, j=js:je, i=is:ie)
+      rho(i,j,k) = density_anomaly_elem_Roquet_rho_loc(T(i,j,k), S(i,j,k), &
+          pressure(i,j,k), rho_ref)
+    enddo
+  else
+    do concurrent (k=ks:ke, j=js:je, i=is:ie)
+      rho(i,j,k) = density_elem_Roquet_rho_loc(T(i,j,k), S(i,j,k), pressure(i,j,k))
+    enddo
+  endif
+end subroutine calculate_density_array_3d_Roquet_rho
+
 !> Calculate the in-situ density derivatives for 2D array inputs and outputs.
 subroutine calculate_density_derivs_2d_Roquet_rho(this, T, S, pressure, &
     drho_dT, drho_dS, dom)
@@ -752,6 +821,79 @@ subroutine calculate_density_derivs_2d_Roquet_rho(this, T, S, pressure, &
         pressure(i,j), drho_dT(i,j), drho_dS(i,j))
   enddo
 end subroutine calculate_density_derivs_2d_Roquet_rho
+
+!> Calculate the in-situ density derivatives for 3D array inputs and outputs.
+subroutine calculate_density_derivs_3d_Roquet_rho(this, T, S, pressure, &
+    drho_dT, drho_dS, dom)
+  class(Roquet_rho_EOS), intent(in) :: this
+    !< This EOS
+  real, intent(in)  :: T(:,:,:)
+    !< Conservative temperature [degC]
+  real, intent(in)  :: S(:,:,:)
+    !< Absolute salinity [g kg-1]
+  real, intent(in)  :: pressure(:,:,:)
+    !< Pressure [Pa]
+  real, intent(out) :: drho_dT(:,:,:)
+    !< Partial derivative of density with potential temperature [kg m-3 degC-1]
+  real, intent(out) :: drho_dS(:,:,:)
+    !< Partial derivative of density with salinity [kg m-3 ppt-1]
+  integer, intent(in) :: dom(3,2)
+    !< Index bounds of domain.  First index is rank, second is bounds
+
+  integer :: is, ie, js, je, ks, ke
+  integer :: i, j, k
+
+  is = dom(1,1) ; ie = dom(1,2)
+  js = dom(2,1) ; je = dom(2,2)
+  ks = dom(3,1) ; ke = dom(3,2)
+
+  ! The element subroutine is called via its free-function (_loc) form rather than
+  ! through the polymorphic "this" binding, which causes runtime errors in do concurrent
+  ! regions offloaded to the GPU with nvfortran.
+  do concurrent (k=ks:ke, j=js:je, i=is:ie)
+    call calculate_density_derivs_elem_Roquet_rho_loc(T(i,j,k), S(i,j,k), &
+        pressure(i,j,k), drho_dT(i,j,k), drho_dS(i,j,k))
+  enddo
+end subroutine calculate_density_derivs_3d_Roquet_rho
+
+!> Calculate the second derivatives of density for 2D array inputs and outputs.
+subroutine calculate_density_second_derivs_2d_Roquet_rho(this, T, S, pressure, &
+    drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, dom)
+  class(Roquet_rho_EOS), intent(in) :: this
+    !< This EOS
+  real, intent(in)    :: T(:,:)
+    !< Conservative temperature [degC]
+  real, intent(in)    :: S(:,:)
+    !< Absolute salinity [g kg-1]
+  real, intent(in)    :: pressure(:,:)
+    !< Pressure [Pa]
+  real, intent(inout) :: drho_dS_dS(:,:)
+    !< Partial derivative of beta with respect to S [kg m-3 ppt-2]
+  real, intent(inout) :: drho_dS_dT(:,:)
+    !< Partial derivative of beta with respect to T [kg m-3 ppt-1 degC-1]
+  real, intent(inout) :: drho_dT_dT(:,:)
+    !< Partial derivative of alpha with respect to T [kg m-3 degC-2]
+  real, intent(inout) :: drho_dS_dP(:,:)
+    !< Partial derivative of beta with respect to pressure [kg m-3 ppt-1 Pa-1]
+  real, intent(inout) :: drho_dT_dP(:,:)
+    !< Partial derivative of alpha with respect to pressure [kg m-3 degC-1 Pa-1]
+  integer, intent(in) :: dom(2,2)
+    !< Index bounds of domain.  First index is rank, second is bounds
+
+  integer :: is, ie, js, je
+  integer :: i, j
+
+  is = dom(1,1) ; ie = dom(1,2)
+  js = dom(2,1) ; je = dom(2,2)
+
+  ! The element subroutine is called via its free-function (_loc) form rather than
+  ! through the polymorphic "this" binding, which causes runtime errors in do concurrent
+  ! regions offloaded to the GPU with nvfortran.
+  do concurrent (j=js:je, i=is:ie)
+    call calculate_density_second_derivs_elem_Roquet_rho_loc(T(i,j), S(i,j), pressure(i,j), &
+        drho_dS_dS(i,j), drho_dS_dT(i,j), drho_dT_dT(i,j), drho_dS_dP(i,j), drho_dT_dP(i,j))
+  enddo
+end subroutine calculate_density_second_derivs_2d_Roquet_rho
 
 !> Calculate the in-situ specific volume for 1D array inputs and outputs.
 subroutine calculate_spec_vol_array_Roquet_rho(this, T, S, pressure, specvol, start, npts, spv_ref)

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -71,10 +71,14 @@ contains
   procedure :: calculate_density_array => calculate_density_array_buggy_Wright
   !> Local implementation of generic calculate_density_array_2d for efficiency
   procedure :: calculate_density_array_2d => calculate_density_array_2d_buggy_Wright
+  !> Local implementation of generic calculate_density_array_3d for efficiency
+  procedure :: calculate_density_array_3d => calculate_density_array_3d_buggy_Wright
   !> Local implementation of generic calculate_spec_vol_array for efficiency
   procedure :: calculate_spec_vol_array => calculate_spec_vol_array_buggy_Wright
   !> Local implementation of generic calculate_density_derivs_2d for efficiency
   procedure :: calculate_density_derivs_2d => calculate_density_derivs_2d_buggy_Wright
+  !> Local implementation of generic calculate_density_derivs_3d for efficiency
+  procedure :: calculate_density_derivs_3d => calculate_density_derivs_3d_buggy_Wright
 
 end type buggy_Wright_EOS
 
@@ -1016,6 +1020,46 @@ subroutine calculate_density_array_2d_buggy_Wright(this, T, S, pressure, rho, &
   endif
 end subroutine calculate_density_array_2d_buggy_Wright
 
+!> Calculate the in-situ density for 3D array inputs and outputs.
+subroutine calculate_density_array_3d_buggy_Wright(this, T, S, pressure, rho, &
+    dom, rho_ref)
+  class(buggy_Wright_EOS), intent(in) :: this
+    !< This EOS
+  real, intent(in) :: T(:,:,:)
+    !< Potential temperature relative to the surface [degC]
+  real, intent(in) :: S(:,:,:)
+    !< Salinity [PSU]
+  real, intent(in) :: pressure(:,:,:)
+    !< Pressure [Pa]
+  real, intent(out) :: rho(:,:,:)
+    !< In situ density [kg m-3]
+  integer, intent(in) :: dom(3,2)
+    !< Index bounds of domain.  First index is rank, second is bounds
+  real, optional, intent(in) :: rho_ref
+    !< A reference density [kg m-3]
+
+  integer :: is, ie, js, je, ks, ke
+  integer :: i, j, k
+
+  is = dom(1,1) ; ie = dom(1,2)
+  js = dom(2,1) ; je = dom(2,2)
+  ks = dom(3,1) ; ke = dom(3,2)
+
+  ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
+  !   Possibly because Nvidia cannot associate `this` with `EOS%type`.
+
+  if (present(rho_ref)) then
+    do concurrent (k=ks:ke, j=js:je, i=is:ie)
+      rho(i,j,k) = density_anomaly_elem_buggy_Wright(this, T(i,j,k), S(i,j,k), &
+          pressure(i,j,k), rho_ref)
+    enddo
+  else
+    do concurrent (k=ks:ke, j=js:je, i=is:ie)
+      rho(i,j,k) = density_elem_buggy_Wright_loc( T(i,j,k), S(i,j,k), pressure(i,j,k))
+    enddo
+  endif
+end subroutine calculate_density_array_3d_buggy_Wright
+
 !> Calculate the in-situ specific volume for 1D array inputs and outputs.
 subroutine calculate_spec_vol_array_buggy_Wright(this, T, S, pressure, specvol, start, npts, spv_ref)
   class(buggy_Wright_EOS),  intent(in) :: this !< This EOS
@@ -1074,6 +1118,39 @@ subroutine calculate_density_derivs_2d_buggy_Wright(this, T, S, pressure, &
         pressure(i,j), drho_dT(i,j), drho_dS(i,j))
   enddo
 end subroutine calculate_density_derivs_2d_buggy_Wright
+
+!> Calculate the in-situ density derivatives for 3D array inputs and outputs.
+subroutine calculate_density_derivs_3d_buggy_Wright(this, T, S, pressure, &
+    drho_dT, drho_dS, dom)
+  class(buggy_Wright_EOS), intent(in) :: this
+    !< This EOS
+  real, intent(in) :: T(:,:,:)
+    !< Potential temperature relative to the surface [degC]
+  real, intent(in) :: S(:,:,:)
+    !< Salinity [PSU]
+  real, intent(in) :: pressure(:,:,:)
+    !< Pressure [Pa]
+  real, intent(out) :: drho_dT(:,:,:)
+    !< Partial derivative of density with potential temperature [kg m-3 degC-1]
+  real, intent(out) :: drho_dS(:,:,:)
+    !< Partial derivative of density with salinity [kg m-3 PSU-1]
+  integer, intent(in) :: dom(3,2)
+    !< Index bounds of domain.  First index is rank, second is bounds
+
+  integer :: is, ie, js, je, ks, ke
+  integer :: i, j, k
+
+  is = dom(1,1) ; ie = dom(1,2)
+  js = dom(2,1) ; je = dom(2,2)
+  ks = dom(3,1) ; ke = dom(3,2)
+
+  ! NOTE: There is an implicit copy of `this` which cannot yet be prevented.
+
+  do concurrent (k=ks:ke, j=js:je, i=is:ie)
+    call calculate_density_derivs_elem_buggy_Wright_loc( T(i,j,k), S(i,j,k), &
+        pressure(i,j,k), drho_dT(i,j,k), drho_dS(i,j,k))
+  enddo
+end subroutine calculate_density_derivs_3d_buggy_Wright
 
 !> Set coefficients that can correct bugs un the buggy Wright equation of state.
 subroutine set_params_buggy_Wright(this, use_Wright_2nd_deriv_bug)

--- a/src/equation_of_state/MOM_EOS_base_type.F90
+++ b/src/equation_of_state/MOM_EOS_base_type.F90
@@ -46,6 +46,8 @@ contains
   procedure :: calculate_density_array => a_calculate_density_array
   !> Calculates the in-situ density or density anomaly for 2d array inputs [m3 kg-1]
   procedure :: calculate_density_array_2d => a_calculate_density_array_2d
+  !> Calculates the in-situ density or density anomaly for 3d array inputs [m3 kg-1]
+  procedure :: calculate_density_array_3d => a_calculate_density_array_3d
   !> Calculates the in-situ specific volume or specific volume anomaly for scalar inputs [m3 kg-1]
   procedure :: calculate_spec_vol_scalar => a_calculate_spec_vol_scalar
   !> Calculates the in-situ specific volume or specific volume anomaly for array inputs [m3 kg-1]
@@ -56,10 +58,14 @@ contains
   procedure :: calculate_density_derivs_array => a_calculate_density_derivs_array
   !> Calculates the derivatives of density for array inputs
   procedure :: calculate_density_derivs_2d => a_calculate_density_derivs_2d
+  !> Calculates the derivatives of density for 3d array inputs
+  procedure :: calculate_density_derivs_3d => a_calculate_density_derivs_3d
   !> Calculates the second derivatives of density for scalar inputs
   procedure :: calculate_density_second_derivs_scalar => a_calculate_density_second_derivs_scalar
   !> Calculates the second derivatives of density for array inputs
   procedure :: calculate_density_second_derivs_array => a_calculate_density_second_derivs_array
+  !> Calculates the second derivatives of density for 2d array inputs
+  procedure :: calculate_density_second_derivs_2d => a_calculate_density_second_derivs_2d
   !> Calculates the derivatives of specific volume for array inputs
   procedure :: calculate_specvol_derivs_array => a_calculate_specvol_derivs_array
   !> Calculates the compressibility for array inputs
@@ -288,6 +294,37 @@ contains
     endif
   end subroutine a_calculate_density_array_2d
 
+  !> Calculate the in-situ density for 3D array inputs and outputs.
+  subroutine a_calculate_density_array_3d(this, T, S, pressure, rho, dom, rho_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real, intent(in) :: T(:,:,:)
+      !< Potential temperature relative to the surface [degC]
+    real, intent(in) :: S(:,:,:)
+      !< Salinity [PSU]
+    real, intent(in) :: pressure(:,:,:)
+      !< Pressure [Pa]
+    real, intent(out) :: rho(:,:,:)
+      !< In situ density [kg m-3]
+    integer, intent(in) :: dom(3,2)
+      !< Index bounds of domain.  First index is rank, second is bounds
+    real, optional, intent(in) :: rho_ref
+      !< A reference density [kg m-3]
+
+    integer :: is, ie, js, je, ks, ke
+
+    is = dom(1,1) ; ie = dom(1,2)
+    js = dom(2,1) ; je = dom(2,2)
+    ks = dom(3,1) ; ke = dom(3,2)
+
+    if (present(rho_ref)) then
+      rho(is:ie, js:je, ks:ke) = this%density_anomaly_elem(T(is:ie, js:je, ks:ke), &
+          S(is:ie, js:je, ks:ke), pressure(is:ie, js:je, ks:ke), rho_ref)
+    else
+      rho(is:ie, js:je, ks:ke) = this%density_elem(T(is:ie, js:je, ks:ke), &
+          S(is:ie, js:je, ks:ke), pressure(is:ie, js:je, ks:ke))
+    endif
+  end subroutine a_calculate_density_array_3d
+
   !> In situ specific volume [m3 kg-1]
   real function a_spec_vol_fn(this, T, S, pressure, spv_ref)
     class(EOS_base), intent(in) :: this     !< This EOS
@@ -414,6 +451,35 @@ contains
         pressure(is:ie, js:je), drho_dt(is:ie, js:je), drho_ds(is:ie, js:je))
   end subroutine a_calculate_density_derivs_2d
 
+  !> Calculate the derivatives of density with respect to temperature and salinity
+  !! for 3d array inputs
+  subroutine a_calculate_density_derivs_3d(this, T, S, pressure, drho_dT, drho_dS, dom)
+    class(EOS_base), intent(in) :: this
+      !< This EOS
+    real, intent(in) :: T(:,:,:)
+      !< Potential temperature relative to the surface [degC]
+    real, intent(in)  :: S(:,:,:)
+      !< Salinity [PSU]
+    real, intent(in)  :: pressure(:,:,:)
+      !< Pressure [Pa]
+    real, intent(out) :: drho_dT(:,:,:)
+      !< The partial derivative of density with potential temperature
+      !! [kg m-3 degC-1]
+    real, intent(out) :: drho_dS(:,:,:)
+      !< The partial derivative of density with salinity, in [kg m-3 PSU-1]
+    integer, intent(in) :: dom(3,2)
+      !< Index bounds of domain.  First index is rank, second is bounds
+
+    integer :: is, ie, js, je, ks, ke
+
+    is = dom(1,1) ; ie = dom(1,2)
+    js = dom(2,1) ; je = dom(2,2)
+    ks = dom(3,1) ; ke = dom(3,2)
+
+    call this%calculate_density_derivs_elem(T(is:ie, js:je, ks:ke), S(is:ie, js:je, ks:ke), &
+        pressure(is:ie, js:je, ks:ke), drho_dt(is:ie, js:je, ks:ke), drho_ds(is:ie, js:je, ks:ke))
+  end subroutine a_calculate_density_derivs_3d
+
   !> Calculate the second derivatives of density with respect to temperature, salinity and pressure
   !! for scalar inputs
   subroutine a_calculate_density_second_derivs_scalar(this, T, S, pressure, &
@@ -470,6 +536,32 @@ contains
                               drho_ds_dp(js:je), drho_dt_dp(js:je))
 
   end subroutine a_calculate_density_second_derivs_array
+
+  !> Default implementation: calculate second derivatives of density for 2d array inputs.
+  !! Delegates to the elemental calculate_density_second_derivs_elem via array sections.
+  subroutine a_calculate_density_second_derivs_2d(this, T, S, pressure, &
+                     drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp, dom)
+    class(EOS_base), intent(in)    :: this       !< This EOS
+    real,            intent(in)    :: T(:,:)     !< Potential temperature [degC]
+    real,            intent(in)    :: S(:,:)     !< Salinity [PSU]
+    real,            intent(in)    :: pressure(:,:) !< Pressure [Pa]
+    real,            intent(inout) :: drho_ds_ds(:,:) !< Partial derivative of beta w.r.t. S [kg m-3 PSU-2]
+    real,            intent(inout) :: drho_ds_dt(:,:) !< Partial derivative of beta w.r.t. T [kg m-3 PSU-1 degC-1]
+    real,            intent(inout) :: drho_dt_dt(:,:) !< Partial derivative of alpha w.r.t. T [kg m-3 degC-2]
+    real,            intent(inout) :: drho_ds_dp(:,:) !< Partial derivative of beta w.r.t. p [kg m-3 PSU-1 Pa-1]
+    real,            intent(inout) :: drho_dt_dp(:,:) !< Partial derivative of alpha w.r.t. p [kg m-3 degC-1 Pa-1]
+    integer,         intent(in)    :: dom(2,2)   !< Index bounds; first index is rank, second is bounds
+
+    integer :: is, ie, js, je
+
+    is = dom(1,1) ; ie = dom(1,2)
+    js = dom(2,1) ; je = dom(2,2)
+
+    call this%calculate_density_second_derivs_elem( &
+        T(is:ie, js:je), S(is:ie, js:je), pressure(is:ie, js:je), &
+        drho_ds_ds(is:ie, js:je), drho_ds_dt(is:ie, js:je), drho_dt_dt(is:ie, js:je), &
+        drho_ds_dp(is:ie, js:je), drho_dt_dp(is:ie, js:je))
+  end subroutine a_calculate_density_second_derivs_2d
 
   !> Calculate the partial derivatives of specific volume with temperature and salinity
   !! for array inputs


### PR DESCRIPTION
The following have been added to Roquet and Wright equations of state:

    module procedure calculate_density_3d
    module procedure calculate_stanley_density_2d
    module procedure calculate_density_derivs_3d
    module procedure calculate_density_second_derivs_2d

These were extracted from a larger pull request supporting pressure density integrals (#156) and was needed by other outstanding PRs.

Submitted on behalf of @edoyango 