### PR TITLE
MOM_coms: GPU port of reproducible_sum (from dev/gfdl)

### DIFF
--- a/config_src/drivers/unit_tests/test_reproducing_sum.F90
+++ b/config_src/drivers/unit_tests/test_reproducing_sum.F90
@@ -5,7 +5,7 @@
 program test_reproducing_sum
 
 use MOM_coms, only : PE_here, root_PE, num_PEs, reproducing_sum
-use MOM_coms, only : sum_across_PEs, max_across_PEs, max_count_prec
+use MOM_coms, only : sum_across_PEs, max_across_PEs
 use MOM_domains, only : MOM_domain_type, create_MOM_domain, MOM_infra_init, MOM_infra_end
 use MOM_domains, only : MOM_define_layout
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, MOM_set_verbosity
@@ -95,13 +95,9 @@ use MOM_hor_index, only : hor_index_type, hor_index_init
   endif
   ! tot_fastR and tot_R should be identical unless too many values are summed
   if (abs(tot_fastR - tot_R) > 0.) then
-    if (n < max_count_prec) then
-      write(mesg,'("Mismatch between reproducing and fast reproducing sums.",4ES13.5)') &
-         tot_fastR, tot_R, tot_fastR - tot_R, ( tot_fastR - tot_R ) / tot_R
-      tests_failed = tests_failed .or. .true.
-    else
-      write(mesg,'("Too many values were summed for the fast reproducing sum to work.")')
-    endif
+    write(mesg,'("Mismatch between reproducing and fast reproducing sums.",4ES13.5)') &
+      tot_fastR, tot_R, tot_fastR - tot_R, ( tot_fastR - tot_R ) / tot_R
+    tests_failed = tests_failed .or. .true.
     call MOM_mesg(mesg)
   endif
 

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -27,36 +27,55 @@ public :: reproducing_sum, reproducing_sum_EFP, EFP_sum_across_PEs, EFP_list_sum
 public :: EFP_plus, EFP_minus, EFP_to_real, real_to_EFP, EFP_real_diff
 public :: operator(+), operator(-), assignment(=)
 public :: query_EFP_overflow_error, reset_EFP_overflow_error
-public :: max_count_prec
 
-! This module provides interfaces to the non-domain-oriented communication subroutines.
+integer, parameter :: accum_width = digits(1_int64)
+  !< Accumulator width; total available bits for summation (excluding sign bit)
+integer, parameter :: prec_width = 46
+  !< Precision width; total bits for computed results
+integer, parameter :: guard_width = accum_width - prec_width
+  !< Number of guard bits reserved for carry overflow
 
-integer(kind=int64), parameter :: prec = (2_int64)**46 !< The precision of each integer.
-real, parameter :: r_prec=2.0**46  !< A real version of prec [nondim].
-real, parameter :: I_prec=1.0/(2.0**46) !< The inverse of prec [nondim].
-integer, parameter :: max_count_prec=2**(63-46)-1
-                              !< The number of values that can be added together
-                              !! with the current value of prec before there will
-                              !! be roundoff problems.
+! A sum of N points does N - 1 additions, which at most adds N - 1 carry bits.
+! For G guard bits, the maximum value is 2**G - 1.  A summation of N values
+! therefore requires that N - 1 <= 2**G - 1, or simply N <= 2**G.
 
-integer, parameter :: ni=6    !< The number of long integers to use to represent
-                              !< a real number.
-real, parameter, dimension(ni) :: &
-  pr = (/ r_prec**2, r_prec, 1.0, 1.0/r_prec, 1.0/r_prec**2, 1.0/r_prec**3 /)
-    !< An array of the real precision of each of the integers in arbitrary units [a]
-real, parameter, dimension(ni) :: &
-  I_pr = (/ 1.0/r_prec**2, 1.0/r_prec, 1.0, r_prec, r_prec**2, r_prec**3 /)
-    !< An array of the inverse of the real precision of each of the integers in arbitrary units [a-1]
-real, parameter :: max_efp_float = pr(1) * (2.**63 - 1.)
-                              !< The largest float with an EFP representation in arbitrary units [a].
-                              !! NOTE: Only the first bin can exceed precision,
-                              !! but is bounded by the largest signed integer.
+integer, parameter :: max_summands = 2**guard_width
+  !< Maximum number of summable points that can guarantee no carry overflow.
+  !! Assumes that guard_bits is less than number of bits in a default integer.
 
-logical :: overflow_error = .false. !< This becomes true if an overflow is encountered.
-logical :: NaN_error = .false.      !< This becomes true if a NaN is encountered.
-logical :: debug = .false.          !< Making this true enables debugging output.
+integer(kind=int64), parameter :: prec = (2_int64)**prec_width
+  !< EPF upper bound (exclusive).  For each EPF bin e(i), 0 <= e(i) < prec.
+
+real, parameter :: r_prec = 2.**prec_width
+  !< Real-value of prec [nondim]
+real, parameter :: I_prec = 2.**(-prec_width)
+  !< Inverse real-value of prec [nondim]
+
+integer, parameter :: efp_digits = 6
+  !< The number of base `prec` digits used to represent an EFP value.
+real, parameter, dimension(efp_digits) :: &
+    pr = [r_prec**2, r_prec, 1., r_prec**(-1), r_prec**(-2), r_prec**(-3)]
+  !< An array of the real precision of each of the integers in arbitrary
+  !! units [a]
+real, parameter, dimension(efp_digits) :: &
+    I_pr = [r_prec**(-2), r_prec**(-1), 1., r_prec, r_prec**2, r_prec**3]
+  !< An array of the inverse of the real precision of each of the integers in
+  !! arbitrary units [a-1]
+real, parameter :: max_efp_float = pr(1) * real(huge(1_int64))
+  !< The largest float with an EFP representation in arbitrary units [a].
+  !! NOTE: Only the first bin can exceed precision, but is bounded by the
+  !! largest signed integer.
 
 !$omp declare target(pr, I_pr)
+
+logical :: overflow_error = .false.
+  !< This becomes true if an overflow is encountered.
+logical :: NaN_error = .false.
+  !< This becomes true if a NaN is encountered.
+logical :: debug = .false.
+  !< Making this true enables debugging output.
+
+! This module provides interfaces to the non-domain-oriented communication subroutines.
 
 !> Find an accurate and order-invariant sum of a distributed 2d or 3d field, in some cases after
 !! undoing the scaling of the input array and restoring that scaling in the returned value
@@ -82,7 +101,7 @@ end interface EFP_sum_across_PEs
 !!   Hallberg, R. & A. Adcroft, 2014: An Order-invariant Real-to-Integer Conversion Sum.
 !!   Parallel Computing, 40(5-6), doi:10.1016/j.parco.2014.04.007.
 type, public :: EFP_type ; private
-  integer(kind=int64), dimension(ni) :: v !< The value in this type
+  integer(kind=int64), dimension(efp_digits) :: v !< The value in this type
 end type EFP_type
 
 !> Add two extended-fixed-point numbers
@@ -127,7 +146,7 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
   ! of real numbers to give order-invariant sums that will reproduce
   ! across PE count.  This idea comes from R. Hallberg and A. Adcroft.
 
-  integer(kind=int64), dimension(ni)  :: ints_sum
+  integer(kind=int64), dimension(efp_digits)  :: ints_sum
   integer(kind=int64) :: ival, prec_error
   real    :: rs ! The remaining value to add, in arbitrary units [a]
   real    :: max_mag_term ! A running maximum magnitude of the values in arbitrary units [a]
@@ -136,11 +155,11 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
   character(len=256) :: mesg
   integer :: i, j, n, is, ie, js, je, sgn
 
-  if (num_PEs() > max_count_prec) call MOM_error(FATAL, &
+  if (num_PEs() > max_summands) call MOM_error(FATAL, &
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
+  prec_error = huge(1_int64) / num_PEs()
 
   is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2)
   if (present(isr)) then
@@ -166,29 +185,16 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
   descale = 1.0 ; if (do_unscale) descale = unscale
 
   overflow_error = .false. ; NaN_error = .false. ; max_mag_term = 0.0
+
   ints_sum(:) = 0
   if (over_check) then
-    if ((je+1-js)*(ie+1-is) < max_count_prec) then
-      ! Common case: window is small enough that all carrying happens at the tail.
-      call increment_ints_2d(array, is, ie, js, je, descale, ints_sum, max_mag_term)
-      call carry_overflow(ints_sum, prec_error)
-    elseif ((ie+1-is) < max_count_prec) then
-      do j=js,je
-        do i=is,ie
-          call increment_ints_faster(ints_sum, descale*array(i,j), max_mag_term)
-        enddo
-        call carry_overflow(ints_sum, prec_error)
-      enddo
-    else
-      do j=js,je ; do i=is,ie
-        call increment_ints(ints_sum, real_to_ints(descale*array(i,j), prec_error), prec_error)
-      enddo ; enddo
-    endif
+    call increment_block_ints(array, is, ie, js, je, descale, ints_sum, &
+        max_mag_term, prec_error)
   else
     do j=js,je ; do i=is,ie
       sgn = 1 ; if (array(i,j)<0.0) sgn = -1
       rs = abs(descale*array(i,j))
-      do n=1,ni
+      do n=1,efp_digits
         ival = int(rs*I_pr(n), kind=int64)
         rs = rs - ival*pr(n)
         ints_sum(n) = ints_sum(n) + sgn*ival
@@ -203,7 +209,7 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
       err = err+2
     if (NaN_error) &
       err = err+4
-    if (err > 0) then ; do n=1,ni ; ints_sum(n) = 0 ; enddo ; endif
+    if (err > 0) then ; do n=1,efp_digits ; ints_sum(n) = 0 ; enddo ; endif
   else
     if (NaN_error) then
       call MOM_error(FATAL, "NaN in input field of reproducing_EFP_sum(_2d).")
@@ -217,7 +223,7 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
     endif
   endif
 
-  if (do_sum_across_PEs) call sum_across_PEs(ints_sum, ni)
+  if (do_sum_across_PEs) call sum_across_PEs(ints_sum, efp_digits)
 
   call regularize_ints(ints_sum)
 
@@ -260,7 +266,7 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
                                                    !! arbitrary units as array [a] or [A ~> a]
 
   ! Local variables
-  integer(kind=int64), dimension(ni)  :: ints_sum
+  integer(kind=int64), dimension(efp_digits)  :: ints_sum
   integer(kind=int64) :: prec_error
   real    :: rsum(1)    ! The running sum, in arbitrary units [a]
   real    :: descale    ! A local copy of unscale if it is present [a A-1 ~> 1] or 1
@@ -270,11 +276,11 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
   type(EFP_type) :: EFP_val ! An extended fixed point version of the sum
   integer :: i, j, is, ie, js, je
 
-  if (num_PEs() > max_count_prec) call MOM_error(FATAL, &
+  if (num_PEs() > max_summands) call MOM_error(FATAL, &
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
+  prec_error = huge(1_int64) / num_PEs()
 
   is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2)
   if (present(isr)) then
@@ -334,7 +340,7 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
   endif
 
   if (debug) then
-    write(mesg,'("2d RS: ", ES24.16, 6 Z17.16)') sum*descale, ints_sum(1:ni)
+    write(mesg,'("2d RS: ", ES24.16, 6 Z17.16)') sum*descale, ints_sum(1:efp_digits)
     call MOM_mesg(mesg, 3)
   endif
 
@@ -376,18 +382,18 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
   real    :: max_mag_term ! A running maximum magnitude of the val's in arbitrary units [a]
   real    :: descale    ! A local copy of unscale if it is present [a A-1 ~> 1] or 1
   real    :: I_unscale  ! The Adcroft reciprocal of unscale [A a-1 ~> 1]
-  integer(kind=int64), dimension(ni)  :: ints_sum
-  integer(kind=int64), dimension(ni,size(array,3))  :: ints_sums
+  integer(kind=int64), dimension(efp_digits)  :: ints_sum
+  integer(kind=int64), dimension(efp_digits,size(array,3))  :: ints_sums
   integer(kind=int64) :: prec_error
   character(len=256) :: mesg
   logical :: do_sum_across_PEs, do_unscale
   integer :: i, j, k, is, ie, js, je, ke, isz, jsz, n
 
-  if (num_PEs() > max_count_prec) call MOM_error(FATAL, &
+  if (num_PEs() > max_summands) call MOM_error(FATAL, &
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
+  prec_error = huge(1_int64) / num_PEs()
   max_mag_term = 0.0
 
   is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2) ; ke = size(array,3)
@@ -420,32 +426,21 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
     if (present(EFP_lay_sums)) then ; if (size(EFP_lay_sums) < ke) then
       call MOM_error(FATAL, "Sums is smaller than the vertical extent of array in reproducing_sum(_3d).")
     endif ; endif
-    ints_sums(:,:) = 0
+
     overflow_error = .false. ; NaN_error = .false. ; max_mag_term = 0.0
-    if (jsz*isz < max_count_prec) then
-      do k=1,ke
-        call increment_ints_2d(array(:,:,k), is, ie, js, je, descale, ints_sums(:,k), max_mag_term)
-        call carry_overflow(ints_sums(:,k), prec_error)
-      enddo
-    elseif (isz < max_count_prec) then
-      do k=1,ke ; do j=js,je
-        do i=is,ie
-          call increment_ints_faster(ints_sums(:,k), descale*array(i,j,k), max_mag_term)
-        enddo
-        call carry_overflow(ints_sums(:,k), prec_error)
-      enddo ; enddo
-    else
-      do k=1,ke ; do j=js,je ; do i=is,ie
-        call increment_ints(ints_sums(:,k), &
-                            real_to_ints(descale*array(i,j,k), prec_error), prec_error)
-      enddo ; enddo ; enddo
-    endif
+
+    ints_sums(:,:) = 0
+    do k=1,ke
+      call increment_block_ints(array(:,:,k), is, ie, js, je, descale, &
+          ints_sums(:,k), max_mag_term, prec_error)
+    enddo
+
     if (present(err)) then
       err = 0
       if (abs(max_mag_term) >= prec_error*pr(1)) err = err+1
       if (overflow_error) err = err+2
       if (NaN_error) err = err+2
-      if (err > 0) then ; do k=1,ke ; do n=1,ni ; ints_sums(n,k) = 0 ; enddo ; enddo ; endif
+      if (err > 0) then ; do k=1,ke ; do n=1,efp_digits ; ints_sums(n,k) = 0 ; enddo ; enddo ; endif
     else
       if (NaN_error) call MOM_error(FATAL, "NaN in input field of reproducing_sum(_3d).")
       if (abs(max_mag_term) >= prec_error*pr(1)) then
@@ -455,7 +450,7 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
       if (overflow_error) call MOM_error(FATAL, "Overflow in reproducing_sum(_3d).")
     endif
 
-    if (do_sum_across_PEs) call sum_across_PEs(ints_sums(:,1:ke), ni*ke)
+    if (do_sum_across_PEs) call sum_across_PEs(ints_sums(:,1:ke), efp_digits*ke)
 
     sum = 0.0
     do k=1,ke
@@ -474,38 +469,26 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
     endif
 
     if (debug) then
-      do n=1,ni ; ints_sum(n) = 0 ; enddo
-      do k=1,ke ; do n=1,ni ; ints_sum(n) = ints_sum(n) + ints_sums(n,k) ; enddo ; enddo
-      write(mesg,'("3D RS: ", ES24.16, 6 Z17.16)') sum, ints_sum(1:ni)
+      do n=1,efp_digits ; ints_sum(n) = 0 ; enddo
+      do k=1,ke ; do n=1,efp_digits ; ints_sum(n) = ints_sum(n) + ints_sums(n,k) ; enddo ; enddo
+      write(mesg,'("3D RS: ", ES24.16, 6 Z17.16)') sum, ints_sum(1:efp_digits)
       call MOM_mesg(mesg, 3)
     endif
   else
-    ints_sum(:) = 0
     overflow_error = .false. ; NaN_error = .false. ; max_mag_term = 0.0
-    if (jsz*isz < max_count_prec) then
-      do k=1,ke
-        call increment_ints_2d(array(:,:,k), is, ie, js, je, descale, ints_sum, max_mag_term)
-        call carry_overflow(ints_sum, prec_error)
-      enddo
-    elseif (isz < max_count_prec) then
-      do k=1,ke ; do j=js,je
-        do i=is,ie
-          call increment_ints_faster(ints_sum, descale*array(i,j,k), max_mag_term)
-        enddo
-        call carry_overflow(ints_sum, prec_error)
-      enddo ; enddo
-    else
-      do k=1,ke ; do j=js,je ; do i=is,ie
-        call increment_ints(ints_sum, real_to_ints(descale*array(i,j,k), prec_error), &
-                            prec_error)
-      enddo ; enddo ; enddo
-    endif
+
+    ints_sum(:) = 0
+    do k=1,ke
+      call increment_block_ints(array(:,:,k), is, ie, js, je, descale, &
+          ints_sum, max_mag_term, prec_error)
+    enddo
+
     if (present(err)) then
       err = 0
       if (abs(max_mag_term) >= prec_error*pr(1)) err = err+1
       if (overflow_error) err = err+2
       if (NaN_error) err = err+2
-      if (err > 0) then ; do n=1,ni ; ints_sum(n) = 0 ; enddo ; endif
+      if (err > 0) then ; do n=1,efp_digits ; ints_sum(n) = 0 ; enddo ; endif
     else
       if (NaN_error) call MOM_error(FATAL, "NaN in input field of reproducing_sum(_3d).")
       if (abs(max_mag_term) >= prec_error*pr(1)) then
@@ -515,7 +498,7 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
       if (overflow_error) call MOM_error(FATAL, "Overflow in reproducing_sum(_3d).")
     endif
 
-    if (do_sum_across_PEs) call sum_across_PEs(ints_sum, ni)
+    if (do_sum_across_PEs) call sum_across_PEs(ints_sum, efp_digits)
 
     call regularize_ints(ints_sum)
     sum = ints_to_real(ints_sum)
@@ -523,7 +506,7 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
     if (present(EFP_sum)) EFP_sum%v(:) = ints_sum(:)
 
     if (debug) then
-      write(mesg,'("3d RS: ", ES24.16, 6 Z17.16)') sum, ints_sum(1:ni)
+      write(mesg,'("3d RS: ", ES24.16, 6 Z17.16)') sum, ints_sum(1:efp_digits)
       call MOM_mesg(mesg, 3)
     endif
   endif
@@ -548,7 +531,7 @@ function real_to_ints(r, prec_error, overflow) result(ints)
                                               !! precision parameter, and is used to detect overflows.
   logical,         optional, intent(inout) :: overflow !< Returns true if the conversion is being
                                               !! done on a value that is too large to be represented
-  integer(kind=int64), dimension(ni)  :: ints
+  integer(kind=int64), dimension(efp_digits)  :: ints
 
   !   This subroutine converts a real number to an equivalent representation
   ! using several long integers.
@@ -574,7 +557,7 @@ function real_to_ints(r, prec_error, overflow) result(ints)
     call MOM_error(FATAL,"Overflow in real_to_ints conversion of "//trim(mesg))
   endif
 
-  do i=1,ni
+  do i=1,efp_digits
     ival = int(rs*I_pr(i), kind=int64)
     rs = rs - ival*pr(i)
     ints(i) = sgn*ival
@@ -585,21 +568,21 @@ end function real_to_ints
 !> Convert the array of integers that constitute an extended-fixed-point
 !! representation into a real number
 function ints_to_real(ints) result(r)
-  integer(kind=int64), dimension(ni), intent(in) :: ints !< The array of EFP integers
+  integer(kind=int64), dimension(efp_digits), intent(in) :: ints !< The array of EFP integers
   real :: r  ! The real number that is extracted in arbitrary units [a]
   ! This subroutine reverses the conversion in real_to_ints.
 
   integer :: i
 
   r = 0.0
-  do i=1,ni ; r = r + pr(i)*ints(i) ; enddo
+  do i=1,efp_digits ; r = r + pr(i)*ints(i) ; enddo
 end function ints_to_real
 
 !> Increment an array of integers that constitutes an extended-fixed-point
 !! representation with a another EFP number
 subroutine increment_ints(int_sum, int2, prec_error)
-  integer(kind=int64), dimension(ni), intent(inout) :: int_sum !< The array of EFP integers being incremented
-  integer(kind=int64), dimension(ni), intent(in)    :: int2    !< The array of EFP integers being added
+  integer(kind=int64), dimension(efp_digits), intent(inout) :: int_sum !< The array of EFP integers being incremented
+  integer(kind=int64), dimension(efp_digits), intent(in)    :: int2    !< The array of EFP integers being added
   integer(kind=int64), optional,      intent(in)    :: prec_error !< The PE-count dependent precision of the
                                               !! integers that is safe from overflows during global
                                               !! sums.  This will be larger than the compile-time
@@ -609,7 +592,7 @@ subroutine increment_ints(int_sum, int2, prec_error)
   ! representation in real_to_ints.
   integer :: i
 
-  do i=ni,2,-1
+  do i=efp_digits,2,-1
     int_sum(i) = int_sum(i) + int2(i)
     ! Carry the local overflow.
     if (int_sum(i) > prec) then
@@ -630,45 +613,12 @@ subroutine increment_ints(int_sum, int2, prec_error)
 end subroutine increment_ints
 
 
-!> Increment an EFP number with a real number without doing any carrying of
-!! of overflows and using only minimal error checking.
-subroutine increment_ints_faster(int_sum, r, max_mag_term)
-  integer(kind=int64), intent(inout) :: int_sum(ni)
-    !< The array of EFP integers being incremented
-  real, intent(in) :: r
-    !< The real number being added in arbitrary units [a]
-  real, intent(inout) :: max_mag_term
-    !< A running maximum magnitude of the r's in arbitrary units [a]
-
-  ! This subroutine increments a number with another, both using the integer
-  ! representation in real_to_ints, but without doing any carrying of overflow.
-  ! The per-element decomposition is shared with the GPU kernel via efp_decompose.
-  integer(kind=int64) :: e(ni)
-  real    :: rmag
-  integer :: is_nan, is_ovf
-
-  call efp_decompose(r, e, rmag, is_nan, is_ovf)
-
-  if (is_nan /= 0) then ; NaN_error = .true. ; return ; endif
-  if (rmag > abs(max_mag_term)) max_mag_term = r
-
-  ! Abort if the number has no EFP representation
-  if (is_ovf /= 0) then ; overflow_error = .true. ; return ; endif
-
-  int_sum(:) = int_sum(:) + e(:)
-
-end subroutine increment_ints_faster
-
-
-!> Increment an EFP number with a real number over a 2d array without doing any
-!! carrying of overflows and using only minimal error checking.
-!! modulo: max_mag_term is updated with the magnitude (>=0) rather than the
-!! signed last-winner. Only consumer of max_mag_term is abs() in the overflow
-!! guard, so values are unchanged; only the sign in one FATAL message can
-!! differ.
-subroutine increment_ints_2d(array, is, ie, js, je, descale, ints_sum, max_mag_term)
+!> Sum the elements of an array in EFP form and append the result to an
+!! existing EFP array.
+subroutine increment_block_ints(array, is, ie, js, je, descale, ints_sum, &
+    max_mag_term, prec_error)
   real, intent(in) :: array(:,:)
-    !< The field being added, in arbitrary units [a]
+    !< The field being added, in arbitrary units [A ~> a]
   integer, intent(in) :: is
     !< Start i-index of the summed domain
   integer, intent(in) :: ie
@@ -678,54 +628,158 @@ subroutine increment_ints_2d(array, is, ie, js, je, descale, ints_sum, max_mag_t
   integer, intent(in) :: je
     !< End j-index of the summed domain
   real, intent(in) :: descale
-    !< unscale factor or 1.0 [a A-1 ~> 1]
-  integer(kind=int64), intent(inout) :: ints_sum(ni)
+    !< Factor to descale array to physical value [a A-1 ~> 1]
+  integer(kind=int64), intent(inout) :: ints_sum(efp_digits)
     !< The array of EFP integers being incremented
   real, intent(inout) :: max_mag_term
     !< A running maximum magnitude of the r's, in arbitrary units [a]
+  integer(kind=int64), intent(in) :: prec_error
+    !< The maximum resolvable value for a given number of PEs
 
-  integer :: i, j
-  integer(kind=int64) :: e(ni)
-  real :: r, rmag, mmag
+  integer :: i, j, ib, jb, ibs, ibe, jbs, jbe
+    ! Loop indices
+  integer :: b
+    ! Block counter
+  integer :: ni, nj
+    ! Array summation domain size along each axis
+  integer :: isize_max
+    ! Largest block size in i.  Typically equal to ni
+  integer :: jsize
+    ! Number of j-rows per block.
+  integer :: nblocks, niblocks, njblocks
+    ! Number of total blocks, and number of blocks in i and j
+  integer(kind=int64) :: e(efp_digits)
+    ! The EPF representation of each array element
+  integer(kind=int64) :: block_sum(efp_digits), array_sum(efp_digits)
+    ! The cumulant per-block and total array EFP sums
+  real :: r, rmag
+    ! Local array element value and its magnitude [a]
+  real :: max_pos, max_neg, block_max_pos, block_max_neg
+    ! Largest positive and negative values (whole array and per-block) used to
+    ! find the largest maximum magnitude of array in a thread-safe manner [a]
   integer :: inan, iovf, lnan, lovf
+    ! Thread-safe tracking of NaN and overflow state
+  integer :: max_sum_count
+    ! The total number of local sum operations that ensures no carry overflow
 
-  mmag = abs(max_mag_term)
+  max_pos = max(0., max_mag_term)
+  max_neg = max(0., -max_mag_term)
   inan = 0 ; iovf = 0
 
-  ! This subroutine increments a number with another, both using the integer
-  ! representation in real_to_ints, but without doing any carrying of overflow.
-  do concurrent (j=js:je, i=is:ie) &
-      DO_LOCALITY(local(r, e, rmag, lnan, lovf)) &
-      DO_LOCALITY(reduce(+: ints_sum) reduce(max: mmag, inan, iovf))
+  ! Reduce the maximum number of summations to account for the cumulant
+  ! summations of array_sum and ints_sum.
+  max_sum_count = max_summands - 2
 
-    r = descale*array(i,j)
+  ! Get the compute domain size
+  ni = ie - is + 1
+  nj = je - js + 1
 
-    call efp_decompose(r, e, rmag, lnan, lovf)
+  ! Partition in i so that the widest i-slice fits within max_sum_count.
+  niblocks = (ni + max_sum_count - 1) / max_sum_count
+         ! = ⌈ni / max_sum_count⌉
 
-    inan = max(inan, lnan)
-    iovf = max(iovf, lovf)
+  ! NOTE: niblocks is typically one, since default max_sum_count is ~130k.
 
-    if (rmag > mmag) mmag = rmag
+  ! For a balanced i-partition, the number of i-points per block is either
+  !   ⌊ni / niblocks⌋ or ⌈ni / niblocks⌉.  Use the upper bound to find jsize.
 
-    ints_sum(:) = ints_sum(:) + e(:)
+  isize_max = (ni + niblocks - 1) / niblocks
+          ! = ⌈ni / niblocks⌉
+
+  ! Set jsize so that the widest i-slice times the number of j-rows does not
+  !   exceed max_sum_count.
+  jsize = max_sum_count / isize_max
+      ! = ⌊max_sum_count / isize_max⌋
+
+  ! Choose enough j-blocks so that no j-block has more than jsize rows.
+  njblocks = (nj + jsize - 1) / jsize
+         ! = ⌈nj / jsize⌉
+
+  nblocks = niblocks * njblocks
+
+  ! Abort if the number of blocks also exceeds the carry-bit summation limit.
+  ! For default settings, this would be over 17 billion points per PE.
+  if (nblocks > max_sum_count) call MOM_error(FATAL, &
+      "reproducing sum: Number of blocks exceeds summmation carry limit." &
+  )
+
+  array_sum(:) = 0
+
+  do jb=1,njblocks ; do ib=1,niblocks
+    ! Use evenly distributed blocks, either ⌊n / nblocks⌋ or ⌈n / nblocks⌉.
+    jbs = js + ((jb - 1) * nj) / njblocks
+    jbe = js + (jb * nj) / njblocks - 1
+
+    ibs = is + ((ib - 1) * ni) / niblocks
+    ibe = is + (ib * ni) / niblocks - 1
+
+    block_sum(:) = 0
+    block_max_pos = 0.
+    block_max_neg = 0.
+
+    ! Compute the sum of each block
+    do concurrent (j=jbs:jbe, i=ibs:ibe) &
+        DO_LOCALITY(local(r, e, rmag, lnan, lovf)) &
+        DO_LOCALITY(reduce(+: block_sum)) &
+        DO_LOCALITY(reduce(max: block_max_pos, block_max_neg, inan, iovf))
+
+      ! Convert array(i,j) to EFP form
+      r = descale * array(i,j)
+      call efp_decompose(r, e, rmag, lnan, lovf)
+
+      ! Verify that the conversion was completed
+      inan = max(inan, lnan)
+      iovf = max(iovf, lovf)
+
+      if (r >= 0.) then
+        if (rmag > block_max_pos) block_max_pos = rmag
+      else
+        if (rmag > block_max_neg) block_max_neg = rmag
+      endif
+
+      ! Add the EFP result (including potential carry bits)
+      block_sum(:) = block_sum(:) + e(:)
+    enddo ; enddo
+
+    array_sum(:) = array_sum(:) + block_sum(:)
+
+    ! Redistribute carry bits across bins
+    ! For the final pass (or single pass) this is handled by ints_sum.
+    b = (jb - 1) * niblocks + ib
+    if (b < nblocks) call carry_overflow(array_sum, prec_error)
+
+    ! Update maximum magnitudes
+    max_pos = max(max_pos, block_max_pos)
+    max_neg = max(max_neg, block_max_neg)
   enddo
 
-  max_mag_term = mmag
+  ! Finally, apply the cumulant result
+  ints_sum(:) = ints_sum(:) + array_sum(:)
 
+  ! Redistribute carry bits to normalize the final result.
+  call carry_overflow(ints_sum, prec_error)
+
+  ! Extract the maximum value while preserving sign (NOTE: ties to positive)
+  if (max_pos >= max_neg) then
+    max_mag_term = max_pos
+  else
+    max_mag_term = -max_neg
+  endif
+
+  ! Transfer error/warning signals to module flags
   if (inan /= 0) NaN_error = .true.
   if (iovf /= 0) overflow_error = .true.
-end subroutine increment_ints_2d
+end subroutine increment_block_ints
 
 
-!> Decompose one real into its 6 signed EFP bin contributions.  The function is
-!! used for both CPU and GPU kernels.  NaNs and overflows are reported by
-!! flags, rather than the module-level error logicals, so that the routine is
-!! free of side effects.
+!> Decompose one real into its 6 signed EFP bin contributions.  NaNs and
+!! overflows are reported by flags, rather than the module-level error
+!! logicals, so that the routine is free of side effects.
 pure subroutine efp_decompose(r, e, rmag, is_nan, is_ovf)
   !$omp declare target
   real, intent(in)  :: r
     !< The real number being decomposed [a]
-  integer(kind=int64), intent(out) :: e(ni)
+  integer(kind=int64), intent(out) :: e(efp_digits)
     !< Signed contribution to EFP bins
   real, intent(out) :: rmag
     !< Equals abs(r), or 0 if r is NaN/Inf [a]
@@ -759,7 +813,7 @@ pure subroutine efp_decompose(r, e, rmag, is_nan, is_ovf)
     return
   endif
 
-  do n=1,ni
+  do n=1,efp_digits
     ival = int(rs * I_pr(n), kind=int64)
     rs = rs - ival * pr(n)
     e(n) = sgn * ival
@@ -769,7 +823,7 @@ end subroutine efp_decompose
 
 !> This subroutine handles carrying of the overflow.
 subroutine carry_overflow(int_sum, prec_error)
-  integer(kind=int64), dimension(ni), intent(inout) :: int_sum  !< The array of EFP integers being
+  integer(kind=int64), dimension(efp_digits), intent(inout) :: int_sum  !< The array of EFP integers being
                                               !! modified by carries, but without changing value.
   integer(kind=int64),                intent(in)    :: prec_error  !< The PE-count dependent precision of the
                                               !! integers that is safe from overflows during global
@@ -779,7 +833,7 @@ subroutine carry_overflow(int_sum, prec_error)
   ! This subroutine handles carrying of the overflow.
   integer :: i, num_carry
 
-  do i=ni,2,-1 ; if (abs(int_sum(i)) >= prec) then
+  do i=efp_digits,2,-1 ; if (abs(int_sum(i)) >= prec) then
     num_carry = int(int_sum(i) * I_prec)
     int_sum(i) = int_sum(i) - num_carry*prec
     int_sum(i-1) = int_sum(i-1) + num_carry
@@ -793,7 +847,7 @@ end subroutine carry_overflow
 !> This subroutine carries the overflow, and then makes sure that
 !! all integers are of the same sign as the overall value.
 subroutine regularize_ints(int_sum)
-  integer(kind=int64), dimension(ni), &
+  integer(kind=int64), dimension(efp_digits), &
     intent(inout) :: int_sum !< The array of integers being modified to take a
                              !! regular form with all integers of the same sign,
                              !! but without changing value.
@@ -803,7 +857,7 @@ subroutine regularize_ints(int_sum)
   logical :: positive
   integer :: i, num_carry
 
-  do i=ni,2,-1 ; if (abs(int_sum(i)) >= prec) then
+  do i=efp_digits,2,-1 ; if (abs(int_sum(i)) >= prec) then
     num_carry = int(int_sum(i) * I_prec)
     int_sum(i) = int_sum(i) - num_carry*prec
     int_sum(i-1) = int_sum(i-1) + num_carry
@@ -811,7 +865,7 @@ subroutine regularize_ints(int_sum)
 
   ! Determine the sign of the final number.
   positive = .true.
-  do i=1,ni
+  do i=1,efp_digits
     if (abs(int_sum(i)) > 0) then
       if (int_sum(i) < 0) positive = .false.
       exit
@@ -819,12 +873,12 @@ subroutine regularize_ints(int_sum)
   enddo
 
   if (positive) then
-    do i=ni,2,-1 ; if (int_sum(i) < 0) then
+    do i=efp_digits,2,-1 ; if (int_sum(i) < 0) then
       int_sum(i) = int_sum(i) + prec
       int_sum(i-1) = int_sum(i-1) - 1
     endif ; enddo
   else
-    do i=ni,2,-1 ; if (int_sum(i) > 0) then
+    do i=efp_digits,2,-1 ; if (int_sum(i) > 0) then
       int_sum(i) = int_sum(i) - prec
       int_sum(i-1) = int_sum(i-1) + 1
     endif ; enddo
@@ -862,7 +916,7 @@ function EFP_minus(EFP1, EFP2)
                         !! subtracted from the first extended fixed point number
   integer :: i
 
-  do i=1,ni ; EFP_minus%v(i) = -1*EFP2%v(i) ; enddo
+  do i=1,efp_digits ; EFP_minus%v(i) = -1*EFP2%v(i) ; enddo
 
   call increment_ints(EFP_minus%v(:), EFP1%v(:))
 end function EFP_minus
@@ -876,7 +930,7 @@ subroutine EFP_assign(EFP1, EFP2)
   ! variable on the RHS (EFP2) to the components of the variable on the LHS
   ! (EFP1).
 
-  do i=1,ni ; EFP1%v(i) = EFP2%v(i) ; enddo
+  do i=1,efp_digits ; EFP1%v(i) = EFP2%v(i) ; enddo
 end subroutine EFP_assign
 
 !> Return the real number that an extended-fixed-point number corresponds with
@@ -939,29 +993,30 @@ subroutine EFP_list_sum_across_PEs(EFPs, nval, errors)
   !   This subroutine does a sum across PEs of a list of EFP variables,
   ! returning the sums in place, with all overflows carried.
 
-  integer(kind=int64), dimension(ni,nval) :: ints
+  integer(kind=int64), dimension(efp_digits,nval) :: ints
   integer(kind=int64) :: prec_error
   logical :: error_found
   character(len=256) :: mesg
   integer :: i, n
 
-  if (num_PEs() > max_count_prec) call MOM_error(FATAL, &
+  if (num_PEs() > max_summands) call MOM_error(FATAL, &
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
+  prec_error = huge(1_int64) / num_PEs()
+
   ! overflow_error is an overflow error flag for the whole module.
   overflow_error = .false. ; error_found = .false.
 
-  do i=1,nval ; do n=1,ni ; ints(n,i) = EFPs(i)%v(n) ; enddo ; enddo
+  do i=1,nval ; do n=1,efp_digits ; ints(n,i) = EFPs(i)%v(n) ; enddo ; enddo
 
-  call sum_across_PEs(ints(:,:), ni*nval)
+  call sum_across_PEs(ints(:,:), efp_digits*nval)
 
   if (present(errors)) errors(:) = .false.
   do i=1,nval
     overflow_error = .false.
     call carry_overflow(ints(:,i), prec_error)
-    do n=1,ni ; EFPs(i)%v(n) = ints(n,i) ; enddo
+    do n=1,efp_digits ; EFPs(i)%v(n) = ints(n,i) ; enddo
     if (present(errors)) errors(i) = overflow_error
     if (overflow_error) then
       write (mesg,'("EFP_list_sum_across_PEs error at ",i0," val was ",ES12.6, ", prec_error = ",ES12.6)') &
@@ -986,29 +1041,30 @@ subroutine EFP_val_sum_across_PEs(EFP, error)
   !   This subroutine does a sum across PEs of a list of EFP variables,
   ! returning the sums in place, with all overflows carried.
 
-  integer(kind=int64), dimension(ni) :: ints
+  integer(kind=int64), dimension(efp_digits) :: ints
   integer(kind=int64) :: prec_error
   logical :: error_found
   character(len=256) :: mesg
   integer :: n
 
-  if (num_PEs() > max_count_prec) call MOM_error(FATAL, &
+  if (num_PEs() > max_summands) call MOM_error(FATAL, &
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
+  prec_error = huge(1_int64) / num_PEs()
+
   ! overflow_error is an overflow error flag for the whole module.
   overflow_error = .false. ; error_found = .false.
 
-  do n=1,ni ; ints(n) = EFP%v(n) ; enddo
+  do n=1,efp_digits ; ints(n) = EFP%v(n) ; enddo
 
-  call sum_across_PEs(ints(:), ni)
+  call sum_across_PEs(ints(:), efp_digits)
 
   if (present(error)) error = .false.
 
   overflow_error = .false.
   call carry_overflow(ints(:), prec_error)
-  do n=1,ni ; EFP%v(n) = ints(n) ; enddo
+  do n=1,efp_digits ; EFP%v(n) = ints(n) ; enddo
   if (present(error)) error = overflow_error
   if (overflow_error) then
     write (mesg,'("EFP_val_sum_across_PEs error val was ",ES12.6, ", prec_error = ",ES12.6)') &


### PR DESCRIPTION
Backport of the reproducing sum changes after dev/gfdl merge.

* Restores the do-concurrent block and omp directives
* Block-based implementation to support larger domains.
* Refactor based on Fortran bitfield intrinsics
* unit test update to include larger domains (and remove one public module parameter)